### PR TITLE
feat(bigtable): add Session vRPC dispatch + slot lifecycle

### DIFF
--- a/bigtable/internal/transport/debug_tracer.go
+++ b/bigtable/internal/transport/debug_tracer.go
@@ -100,6 +100,12 @@ const (
 	tagSessionVRPCIDMismatch         = "session_vrpc_id_mismatch"
 	tagSessionVRPCResponseWrongState = "session_vrpc_response_wrong_state"
 	tagSessionVRPCDuplicateResult    = "session_vrpc_duplicate_result"
+	// tagSessionVRPCCancelledDrained fires when a server response finally
+	// arrives for an rpc whose caller already returned via ctx.Done: the
+	// drain succeeds, currentCancel != nil, and no one is waiting on
+	// resultChan. Bookkeeping-only — the drain still fires OnSlotDrained
+	// so the pool re-enqueues the session.
+	tagSessionVRPCCancelledDrained = "session_vrpc_cancelled_drained"
 
 	// Pool-scoped anomalies.
 	tagSessionPoolStuckSessionSwept = "session_pool_stuck_session_swept"

--- a/bigtable/internal/transport/session.go
+++ b/bigtable/internal/transport/session.go
@@ -281,14 +281,13 @@ func (s *Session) Send(req *spb.SessionRequest) error {
 	return err
 }
 
-// resetHeartbeatDeadline pushes out the watchdog to (3 * heartbeatInterval)
-// from now. The 3x multiplier follows the protocol guidance of tolerating two
-// missed heartbeats. Two atomic loads + one atomic store on the hot path,
-// plus a non-blocking wake to the heartbeat loop so its Timer picks up the
-// new deadline immediately (otherwise the initial bootstrap arm keeps the
-// loop sleeping past atomic shortenings — SESSION_SPEC.md #7).
+// resetHeartbeatDeadline pushes out the watchdog to (now + heartbeatInterval).
+// One atomic load + one atomic store on the hot path, plus a non-blocking
+// wake to the heartbeat loop so its Timer picks up the new deadline
+// immediately (otherwise the initial bootstrap arm keeps the loop sleeping
+// past atomic shortenings — SESSION_SPEC.md #7).
 func (s *Session) resetHeartbeatDeadline() {
-	s.nextHeartbeatDeadlineNano.Store(time.Now().Add(3 * time.Duration(s.heartbeatIntervalNano.Load())).UnixNano())
+	s.nextHeartbeatDeadlineNano.Store(time.Now().Add(time.Duration(s.heartbeatIntervalNano.Load())).UnixNano())
 	s.wakeHeartbeatLoop()
 }
 

--- a/bigtable/internal/transport/session.go
+++ b/bigtable/internal/transport/session.go
@@ -61,11 +61,19 @@ type Stream interface {
 
 // SessionHooks holds optional lifecycle callbacks. Nil fields are skipped.
 // Hooks must not block.
+//
+// OnSlotDrained fires on every successful drainSlot on the wire (normal
+// deliver, cancelled-drain, Send-failure Invoke branch). It is the sole
+// "session became free" signal — consumers use it to re-enqueue the
+// session in its AFE idle queue and wake one parked Checkout waiter.
+// cancelActiveRPCs (session teardown) intentionally does NOT fire it —
+// OnClosing/OnClose handle removal from routing structures on that path.
 type SessionHooks struct {
-	OnStart   func(ctx context.Context)
-	OnActive  func(s *Session)
-	OnClosing func(s *Session)
-	OnClose   func(s *Session, err error)
+	OnStart       func(ctx context.Context)
+	OnActive      func(s *Session)
+	OnSlotDrained func()
+	OnClosing     func(s *Session)
+	OnClose       func(s *Session, err error)
 }
 
 func (h SessionHooks) onStart(ctx context.Context) {
@@ -77,6 +85,12 @@ func (h SessionHooks) onStart(ctx context.Context) {
 func (h SessionHooks) onActive(s *Session) {
 	if h.OnActive != nil {
 		h.OnActive(s)
+	}
+}
+
+func (h SessionHooks) onSlotDrained() {
+	if h.OnSlotDrained != nil {
+		h.OnSlotDrained()
 	}
 }
 
@@ -159,6 +173,12 @@ type Session struct {
 	heartbeatIntervalNano     atomic.Int64
 	nextHeartbeatDeadlineNano atomic.Int64
 
+	// heartbeatWake nudges the heartbeat loop to re-evaluate its Timer
+	// after the atomic deadline moves. Cap-1 non-blocking channel so a
+	// burst of resets coalesces into a single wake and hot-path frame
+	// handling stays allocation-free.
+	heartbeatWake chan struct{}
+
 	// quiescent closes when the in-flight vRPC drains after StateClosing,
 	// or when ForceClose runs.
 	quiescent     chan struct{}
@@ -184,11 +204,12 @@ type SessionOption func(*Session)
 // valid.
 func NewSession(logName string, stream Stream, hooks SessionHooks, sessionType SessionType, opts ...SessionOption) *Session {
 	s := &Session{
-		logName:     logName,
-		stream:      stream,
-		hooks:       hooks,
-		quiescent:   make(chan struct{}),
-		sessionType: sessionType,
+		logName:       logName,
+		stream:        stream,
+		hooks:         hooks,
+		quiescent:     make(chan struct{}),
+		sessionType:   sessionType,
+		heartbeatWake: make(chan struct{}, 1),
 	}
 	s.state.Store(int32(StateNew))
 	s.heartbeatIntervalNano.Store(int64(defaultHeartbeatInterval))
@@ -243,5 +264,41 @@ func unavailable(cause error, format string, args ...interface{}) error {
 	return &sessionErr{
 		st:    status.Newf(codes.Unavailable, format, args...),
 		cause: cause,
+	}
+}
+
+// Send writes a SessionRequest under sendMu so concurrent producers don't
+// corrupt the underlying stream. grpc.ClientStream.Send is not safe for
+// concurrent use; sendMu is the only serialization point.
+func (s *Session) Send(req *spb.SessionRequest) error {
+	s.sendMu.Lock()
+	err := s.stream.Send(req)
+	s.sendMu.Unlock()
+	if err == nil {
+		s.msgsSent.Add(1)
+		s.msgsSentByType[classifyReq(req)].Add(1)
+	}
+	return err
+}
+
+// resetHeartbeatDeadline pushes out the watchdog to (3 * heartbeatInterval)
+// from now. The 3x multiplier follows the protocol guidance of tolerating two
+// missed heartbeats. Two atomic loads + one atomic store on the hot path,
+// plus a non-blocking wake to the heartbeat loop so its Timer picks up the
+// new deadline immediately (otherwise the initial bootstrap arm keeps the
+// loop sleeping past atomic shortenings — SESSION_SPEC.md #7).
+func (s *Session) resetHeartbeatDeadline() {
+	s.nextHeartbeatDeadlineNano.Store(time.Now().Add(3 * time.Duration(s.heartbeatIntervalNano.Load())).UnixNano())
+	s.wakeHeartbeatLoop()
+}
+
+// wakeHeartbeatLoop signals the heartbeat loop to re-evaluate its Timer.
+// Non-blocking send on a cap-1 channel: bursts coalesce into a single
+// pending wake, so hot-path frame handlers stay allocation-free and
+// contention-free even under high frame arrival rates.
+func (s *Session) wakeHeartbeatLoop() {
+	select {
+	case s.heartbeatWake <- struct{}{}:
+	default:
 	}
 }

--- a/bigtable/internal/transport/session_debug.go
+++ b/bigtable/internal/transport/session_debug.go
@@ -150,6 +150,15 @@ const (
 	// prior attempt's gRPC code + err (if the retry interceptor stashed
 	// one on ctx).
 	SessionEventRetry SessionEventKind = "retry"
+	// SessionEventProtocolError fires when routeVRPCFrame observes a
+	// state/frame combination that violates the client-server contract
+	// (frame arrived in a state we shouldn't be reading in, or the
+	// server's rpc_id doesn't match our active vRPC). Message carries
+	// the frame name, rpc_id, and observed state so operators can
+	// distinguish "stray late frame after cancel" (recoverable) from
+	// "server desynced from client" (unrecoverable). Escalated to
+	// session teardown for id-mismatch and truly-wrong states.
+	SessionEventProtocolError SessionEventKind = "protocol-error"
 )
 
 // SessionEvent is one entry in a session's per-session debug ring buffer.

--- a/bigtable/internal/transport/session_debug.go
+++ b/bigtable/internal/transport/session_debug.go
@@ -151,14 +151,22 @@ const (
 	// one on ctx).
 	SessionEventRetry SessionEventKind = "retry"
 	// SessionEventProtocolError fires when routeVRPCFrame observes a
-	// state/frame combination that violates the client-server contract
-	// (frame arrived in a state we shouldn't be reading in, or the
-	// server's rpc_id doesn't match our active vRPC). Message carries
-	// the frame name, rpc_id, and observed state so operators can
-	// distinguish "stray late frame after cancel" (recoverable) from
-	// "server desynced from client" (unrecoverable). Escalated to
-	// session teardown for id-mismatch and truly-wrong states.
+	// state/frame combination that violates the client-server contract:
+	// a frame arrived in a state readLoop shouldn't be running in
+	// (New/Starting/Closed) OR the server's rpc_id didn't match our
+	// active vRPC. Escalated to session teardown via ForceClose so the
+	// pool's OnClosing/OnClose hooks fire and the session leaves the
+	// AFE routing set. Kept separate from SessionEventLateFrame so
+	// operators filtering sessionz for genuine desyncs aren't swamped
+	// by benign late-after-cancel drops.
 	SessionEventProtocolError SessionEventKind = "protocol-error"
+	// SessionEventLateFrame fires when routeVRPCFrame drops a frame
+	// because there's no active vRPC on this session (activeVRPC()==nil).
+	// This is a documented race — the caller ctx.Done'd and cancelled
+	// the slot, but the server's response arrived before the cancel
+	// landed on the wire. Not a protocol violation; the session stays
+	// healthy and the frame is dropped.
+	SessionEventLateFrame SessionEventKind = "late-frame"
 )
 
 // SessionEvent is one entry in a session's per-session debug ring buffer.

--- a/bigtable/internal/transport/session_state_test.go
+++ b/bigtable/internal/transport/session_state_test.go
@@ -68,7 +68,7 @@ func TestState_OrdinalsPinned(t *testing.T) {
 // mirror the real transition sites; ensures each hop applies and stamps
 // lastStateChangeNano.
 func TestSession_TransitionTo_Happy(t *testing.T) {
-	s := newTestSession(t)
+	s := newDefaultTestSession(t)
 	before := s.lastStateChangeNano.Load()
 	// Ensure at least a ns of clock movement so the stamp is observably later.
 	time.Sleep(time.Millisecond)
@@ -93,7 +93,7 @@ func TestSession_TransitionTo_Happy(t *testing.T) {
 // TestSession_TransitionTo_PredicateRejects confirms a false predicate leaves
 // state alone and returns (currentState, false).
 func TestSession_TransitionTo_PredicateRejects(t *testing.T) {
-	s := newTestSession(t)
+	s := newDefaultTestSession(t)
 	// New → Ready is illegal unless the predicate permits it; use one that
 	// explicitly excludes New.
 	prev, ok := s.transitionTo(StateReady, isState(StateStarting))
@@ -111,7 +111,7 @@ func TestSession_TransitionTo_PredicateRejects(t *testing.T) {
 // TestSession_TransitionTo_Concurrent stress-tests the CAS-plus-predicate loop
 // under -race. Two goroutines both try New→Starting; exactly one must succeed.
 func TestSession_TransitionTo_Concurrent(t *testing.T) {
-	s := newTestSession(t)
+	s := newDefaultTestSession(t)
 	var wg sync.WaitGroup
 	var applied [2]bool
 	wg.Add(2)

--- a/bigtable/internal/transport/session_test.go
+++ b/bigtable/internal/transport/session_test.go
@@ -17,6 +17,7 @@ package internal
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"sync"
 	"testing"
@@ -42,13 +43,133 @@ func (s *stubStream) Recv() (*spb.SessionResponse, error) {
 func (s *stubStream) Header() (metadata.MD, error) { return metadata.MD{}, nil }
 func (s *stubStream) Context() context.Context     { return s.ctx }
 
-func newTestSession(t *testing.T, opts ...SessionOption) *Session {
+// fakeStream implements Stream and exposes channels so tests can drive both
+// sides of the conversation. sendFn allows a test to inject Send failures.
+type fakeStream struct {
+	sentMu    sync.Mutex
+	sent      []*spb.SessionRequest
+	recv      chan recvOp
+	hdr       metadata.MD
+	hdrErr    error
+	sendFn    func(*spb.SessionRequest) error
+	closeOnce sync.Once
+}
+
+type recvOp struct {
+	resp *spb.SessionResponse
+	err  error
+}
+
+func newFakeStream() *fakeStream {
+	return &fakeStream{
+		recv: make(chan recvOp, 32),
+		hdr:  metadata.MD{},
+	}
+}
+
+// Close unblocks Recv() by closing the recv channel. Idempotent so cleanup
+// and explicit test teardown don't collide.
+func (f *fakeStream) Close() {
+	f.closeOnce.Do(func() { close(f.recv) })
+}
+
+func (f *fakeStream) Send(req *spb.SessionRequest) error {
+	if f.sendFn != nil {
+		if err := f.sendFn(req); err != nil {
+			return err
+		}
+	}
+	f.sentMu.Lock()
+	f.sent = append(f.sent, req)
+	f.sentMu.Unlock()
+	return nil
+}
+
+func (f *fakeStream) Recv() (*spb.SessionResponse, error) {
+	op, ok := <-f.recv
+	if !ok {
+		return nil, fmt.Errorf("stream closed")
+	}
+	return op.resp, op.err
+}
+
+func (f *fakeStream) Header() (metadata.MD, error) { return f.hdr, f.hdrErr }
+func (f *fakeStream) Context() context.Context     { return context.Background() }
+
+func (f *fakeStream) snapshotSent() []*spb.SessionRequest {
+	f.sentMu.Lock()
+	defer f.sentMu.Unlock()
+	out := make([]*spb.SessionRequest, len(f.sent))
+	copy(out, f.sent)
+	return out
+}
+
+// fakeDesc is a minimal VRpcDescriptor for Invoke tests.
+type fakeDesc struct {
+	method string
+	enc    func(req interface{}) ([]byte, error)
+	dec    func(buf []byte) (interface{}, error)
+}
+
+func (f *fakeDesc) Method() string                         { return f.method }
+func (f *fakeDesc) Encode(req interface{}) ([]byte, error) { return f.enc(req) }
+func (f *fakeDesc) Decode(buf []byte) (interface{}, error) { return f.dec(buf) }
+
+// newRoundTripDesc returns a trivial descriptor that round-trips string
+// payloads through the encode/decode pair.
+func newRoundTripDesc() *fakeDesc {
+	return &fakeDesc{
+		method: "RoundTrip",
+		enc: func(req interface{}) ([]byte, error) {
+			return []byte(fmt.Sprintf("req:%v", req)), nil
+		},
+		dec: func(buf []byte) (interface{}, error) {
+			return string(buf), nil
+		},
+	}
+}
+
+// waitFor polls cond every 5ms up to timeout, failing the test if cond never
+// becomes true.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool, msg string) {
 	t.Helper()
-	return NewSession("test-session", newStubStream(), SessionHooks{}, SessionTypeTable, opts...)
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out after %v waiting for: %s", timeout, msg)
+}
+
+// newTestSession constructs a Session bound to the given stream with the
+// given hooks. Passing (t) alone via newDefaultTestSession also works for
+// callers that don't care about the stream.
+func newTestSession(t *testing.T, stream Stream, hooks SessionHooks) *Session {
+	t.Helper()
+	return NewSession("test-session", stream, hooks, SessionTypeTable)
+}
+
+// newDefaultTestSession is a shortcut for tests that don't drive the stream.
+func newDefaultTestSession(t *testing.T) *Session {
+	t.Helper()
+	return newTestSession(t, newStubStream(), SessionHooks{})
+}
+
+// makeActive constructs a session and forces it into StateReady without
+// going through the handshake. Returns the session + the underlying
+// fakeStream so tests can inspect sent frames or inject responses.
+func makeActive(t *testing.T, hooks SessionHooks) (*Session, *fakeStream) {
+	t.Helper()
+	stream := newFakeStream()
+	s := newTestSession(t, stream, hooks)
+	s.state.Store(int32(StateReady))
+	return s, stream
 }
 
 func TestNewSession_Defaults(t *testing.T) {
-	s := newTestSession(t)
+	s := newDefaultTestSession(t)
 
 	if got := s.State(); got != StateNew {
 		t.Errorf("initial State: got %s, want StateNew", got)
@@ -79,7 +200,7 @@ func TestNewSession_Defaults(t *testing.T) {
 }
 
 func TestSession_SignalQuiescent_ClosesChannel(t *testing.T) {
-	s := newTestSession(t)
+	s := newDefaultTestSession(t)
 	s.signalQuiescent()
 	select {
 	case <-s.quiescent:
@@ -91,7 +212,7 @@ func TestSession_SignalQuiescent_ClosesChannel(t *testing.T) {
 // TestSession_SignalQuiescent_IdempotentUnderRace guards the sync.Once — a
 // racy close(ch) would panic.
 func TestSession_SignalQuiescent_IdempotentUnderRace(t *testing.T) {
-	s := newTestSession(t)
+	s := newDefaultTestSession(t)
 	const workers = 64
 	var wg sync.WaitGroup
 	wg.Add(workers)
@@ -111,14 +232,14 @@ func TestSession_SignalQuiescent_IdempotentUnderRace(t *testing.T) {
 }
 
 func TestSession_AfeID_ZeroBeforePeerInfo(t *testing.T) {
-	s := newTestSession(t)
+	s := newDefaultTestSession(t)
 	if got := s.AfeID(); got != 0 {
 		t.Errorf("AfeID before PeerInfo: got %d, want 0", got)
 	}
 }
 
 func TestSession_AfeID_FromPeerInfo(t *testing.T) {
-	s := newTestSession(t)
+	s := newDefaultTestSession(t)
 	s.peerInfo.Store(&spb.PeerInfo{ApplicationFrontendId: 0xABCDEF})
 	if got := s.AfeID(); got != AfeID(0xABCDEF) {
 		t.Errorf("AfeID: got %#x, want %#x", int64(got), 0xABCDEF)
@@ -126,7 +247,7 @@ func TestSession_AfeID_FromPeerInfo(t *testing.T) {
 }
 
 func TestSession_RefreshConfig_StoreLoad(t *testing.T) {
-	s := newTestSession(t)
+	s := newDefaultTestSession(t)
 	rc := &spb.SessionRefreshConfig{}
 	s.refreshConfig.Store(rc)
 	if got := s.RefreshConfig(); got != rc {

--- a/bigtable/internal/transport/session_vrpc.go
+++ b/bigtable/internal/transport/session_vrpc.go
@@ -28,7 +28,7 @@ import (
 
 // activeVRPC returns the currently in-flight vRPC, or nil if the slot is
 // empty. Snapshot read under slotMu — the field's docstring covers the
-// multiplex=1 invariant and the slot's Java-parity lifecycle.
+// multiplex=1 invariant and the slot lifecycle.
 func (s *Session) activeVRPC() *vrpcImpl {
 	s.slotMu.Lock()
 	rpc := s.activeRPC
@@ -37,8 +37,8 @@ func (s *Session) activeVRPC() *vrpcImpl {
 }
 
 // claimSlot assigns rpc to the empty slot. Returns false if the slot still
-// holds a prior vRPC (Java SessionImpl.startRpc L423 parity — concurrent
-// claims are rejected as UNCOMMITTED at the call site).
+// holds a prior vRPC — concurrent claims are rejected as UNCOMMITTED at
+// the call site.
 func (s *Session) claimSlot(rpc *vrpcImpl) bool {
 	s.slotMu.Lock()
 	defer s.slotMu.Unlock()
@@ -51,9 +51,8 @@ func (s *Session) claimSlot(rpc *vrpcImpl) bool {
 
 // markCancelled records ctx.Done cancellation of rpc without freeing the
 // slot — the caller returns, but activeRPC stays until the server response
-// arrives to drain it. Java SessionImpl.cancelRpc L448-457 parity
-// (first-cancel-wins; a racing drain that clears activeRPC makes this a
-// no-op).
+// arrives to drain it. First-cancel-wins; a racing drain that clears
+// activeRPC makes this a no-op.
 func (s *Session) markCancelled(rpc *vrpcImpl, res vrpcResult) {
 	s.slotMu.Lock()
 	defer s.slotMu.Unlock()
@@ -66,8 +65,7 @@ func (s *Session) markCancelled(rpc *vrpcImpl, res vrpcResult) {
 }
 
 // drainSlot atomically clears the (activeRPC, currentCancel) pair iff
-// activeRPC == expect, returning what was there. Java
-// SessionImpl.handleVRpcResponse L599-602 parity. Used by response handlers
+// activeRPC == expect, returning what was there. Used by response handlers
 // (after id-match) and by cancelActiveRPCs (session teardown); ok=false
 // means a racing drain got here first.
 func (s *Session) drainSlot(expect *vrpcImpl) (rpc *vrpcImpl, cancel *vrpcResult, ok bool) {
@@ -94,11 +92,10 @@ func (s *Session) drainSlot(expect *vrpcImpl) (rpc *vrpcImpl, cancel *vrpcResult
 // of the call — the pool guarantees this via CheckoutSession's per-session
 // idle-slot gate. The single-in-flight invariant is enforced by claimSlot
 // under slotMu; a losing claim returns StateUncommitted so the retry
-// oracle can steer to another session (Java SessionImpl.startRpc
-// L420-444 parity). The slot is released only by handleVRPCResponse /
-// handleVRPCErrorResponse (successful drain), cancelActiveRPCs (session
-// teardown), or the Send-failure path below — caller ctx.Done leaves
-// the slot claimed and marks it via markCancelled.
+// oracle can steer to another session. The slot is released only by
+// handleVRPCResponse / handleVRPCErrorResponse (successful drain),
+// cancelActiveRPCs (session teardown), or the Send-failure path below —
+// caller ctx.Done leaves the slot claimed and marks it via markCancelled.
 func (s *Session) Invoke(ctx context.Context, desc VRpcDescriptor, req interface{}) (result InvokeResult, err error) {
 	startTime := time.Now()
 
@@ -120,10 +117,9 @@ func (s *Session) Invoke(ctx context.Context, desc VRpcDescriptor, req interface
 		resultChan: make(chan vrpcResult, 1),
 	}
 
-	// Claim the single in-flight slot. Java SessionImpl.startRpc L423
-	// parity: a losing claim means a prior vRPC on this session has
-	// not drained on the wire yet — return Uncommitted so the retryer
-	// picks another session.
+	// Claim the single in-flight slot. A losing claim means a prior vRPC
+	// on this session has not drained on the wire yet — return Uncommitted
+	// so the retryer picks another session.
 	if !s.claimSlot(rpc) {
 		return result, tagErr(StateUncommitted,
 			unavailable(ErrSessionNotActive,
@@ -146,10 +142,7 @@ func (s *Session) Invoke(ctx context.Context, desc VRpcDescriptor, req interface
 	result.SentAt = time.Now()
 	if sendErr := s.Send(sessionReq); sendErr != nil {
 		// Synchronous Send failed: no server response is ever coming,
-		// so this call must free the slot itself. Java doesn't need
-		// this branch — sendMessage there is async and failures come
-		// back through the response observer — but Go's Send is
-		// synchronous, so an early drain is on the Invoke path.
+		// so this call must free the slot itself here on the Invoke path.
 		// drainSlot returns ok=false when concurrent teardown
 		// (cancelActiveRPCs / ForceClose) beat us to freeing the slot.
 		// In that case, the teardown path is responsible for pool
@@ -231,9 +224,9 @@ func buildInvokeRequest(rpcID int64, reqBytes []byte, attempt int64, startTime t
 //
 // ctx.Done branch: check resultChan non-blockingly first so a server
 // response that landed in the same tick as the ctx cancellation isn't
-// dropped. Otherwise mark the slot as cancelled — Java parity leaves
-// activeRPC set so a concurrent Invoke fails claimSlot with Uncommitted
-// rather than racing to id-mismatch the abandoned response.
+// dropped. Otherwise mark the slot as cancelled — activeRPC stays set
+// so a concurrent Invoke fails claimSlot with Uncommitted rather than
+// racing to id-mismatch the abandoned response.
 func (s *Session) awaitInvokeResult(ctx context.Context, rpc *vrpcImpl, desc VRpcDescriptor, result *InvokeResult) error {
 	select {
 	case <-ctx.Done():
@@ -302,27 +295,25 @@ func (s *Session) recordCtxDone(ctx context.Context, rpc *vrpcImpl, method strin
 
 // handleVRPCResponse delivers a server VirtualRpcResponse to the waiting
 // Invoke caller, or drains a cancelled slot if the caller already
-// abandoned the RPC via ctx.Done (Java SessionImpl.handleVRpcResponse
-// L567-614 parity — the cancel branch there discards the response
-// tracer-side; here we just count it).
+// abandoned the RPC via ctx.Done (bookkeeping-only in that branch).
 func (s *Session) handleVRPCResponse(resp *spb.VirtualRpcResponse) {
 	s.routeVRPCFrame(resp.RpcId, "VirtualRpcResponse", tagSessionVRPCNil,
 		&s.okRpcs, vrpcResult{resp: resp})
 }
 
 // handleVRPCErrorResponse routes per-vRPC errors to the waiting caller.
-// Mirrors handleVRPCResponse's Java-parity drain path — a cancelled slot
-// drains without deliver.
+// Mirrors handleVRPCResponse's drain path — a cancelled slot drains
+// without deliver.
 func (s *Session) handleVRPCErrorResponse(errResp *spb.ErrorResponse) {
 	s.routeVRPCFrame(errResp.RpcId, "ErrorResponse", tagSessionVRPCErrorNil,
 		&s.errorRpcs, vrpcResult{errResp: errResp})
 }
 
 // routeVRPCFrame is the shared skeleton for handleVRPCResponse /
-// handleVRPCErrorResponse. All Java-parity gating (state check, active-
-// vRPC nil guard, id-match, drain-vs-cancel branching, OnSlotDrained
-// hook on every drain, quiescence signalling in Closing) lives here
-// so the two call sites can't drift.
+// handleVRPCErrorResponse. All frame gating (state check, active-vRPC
+// nil guard, id-match, drain-vs-cancel branching, OnSlotDrained hook
+// on every drain, quiescence signalling in Closing) lives here so the
+// two call sites can't drift.
 //
 // A vRPC frame is only expected while the session is Ready or Closing
 // (drain window). Any other state means either a bug in state tracking
@@ -429,9 +420,9 @@ func (s *Session) ForceClose(req *spb.CloseSessionRequest) {
 // error. With multiPlexingLimit=1 there is at most one such vRPC.
 // Called from session teardown paths (Close, ForceClose, handleGoAway,
 // handleClose, heartbeat miss) — the "server will never respond" cases
-// where the slot must be freed even under Java-parity claim-until-drain.
-// If the caller already abandoned via ctx.Done, the drain returns a
-// cancel handle and we skip the deliver (no reader on resultChan).
+// where the slot must be freed unilaterally. If the caller already
+// abandoned via ctx.Done, the drain returns a cancel handle and we
+// skip the deliver (no reader on resultChan).
 func (s *Session) cancelActiveRPCs(err error) {
 	rpc := s.activeVRPC()
 	if rpc == nil {

--- a/bigtable/internal/transport/session_vrpc.go
+++ b/bigtable/internal/transport/session_vrpc.go
@@ -199,7 +199,7 @@ func (s *Session) noteRetryAttempt(ctx context.Context, method string, attempt i
 // clock. Omitted when ctx has no deadline or the budget is already
 // non-positive (the client-side ctx.Done branch will fire immediately).
 func buildInvokeRequest(ctx context.Context, rpcID int64, reqBytes []byte, attempt int64, startTime time.Time) *spb.SessionRequest {
-	virtRpc := &spb.VirtualRpcRequest{
+	virtRPC := &spb.VirtualRpcRequest{
 		RpcId:   rpcID,
 		Payload: reqBytes,
 		Metadata: &spb.VirtualRpcRequest_Metadata{
@@ -209,11 +209,11 @@ func buildInvokeRequest(ctx context.Context, rpcID int64, reqBytes []byte, attem
 	}
 	if deadline, ok := ctx.Deadline(); ok {
 		if remaining := time.Until(deadline); remaining > 0 {
-			virtRpc.Deadline = durationpb.New(remaining)
+			virtRPC.Deadline = durationpb.New(remaining)
 		}
 	}
 	return &spb.SessionRequest{
-		Payload: &spb.SessionRequest_VirtualRpc{VirtualRpc: virtRpc},
+		Payload: &spb.SessionRequest_VirtualRpc{VirtualRpc: virtRPC},
 	}
 }
 

--- a/bigtable/internal/transport/session_vrpc.go
+++ b/bigtable/internal/transport/session_vrpc.go
@@ -150,15 +150,18 @@ func (s *Session) Invoke(ctx context.Context, desc VRpcDescriptor, req interface
 		// this branch — sendMessage there is async and failures come
 		// back through the response observer — but Go's Send is
 		// synchronous, so an early drain is on the Invoke path.
-		s.drainSlot(rpc)
-		// v3: drain is the sole "session became free" signal. Fire the
-		// pool wake here as well — ReleaseToPool's inExpectedCount guard
-		// (see SESSION_POOL_SPEC #6, I5) drops the re-enqueue if
-		// OnSessionClosing already dropped this handle in the teardown
-		// that the Send failure typically kicks off.
-		s.hooks.onSlotDrained()
-		if State(s.state.Load()) == StateClosing {
-			s.signalQuiescent()
+		// drainSlot returns ok=false when concurrent teardown
+		// (cancelActiveRPCs / ForceClose) beat us to freeing the slot.
+		// In that case, the teardown path is responsible for pool
+		// notification via OnClosing/OnClose and quiescence signalling —
+		// firing onSlotDrained here would violate the SessionHooks
+		// contract that reserves it for the drain-succeeded path
+		// (SESSION_SPEC #5/#10). Only fire when we actually did the drain.
+		if _, _, ok := s.drainSlot(rpc); ok {
+			s.hooks.onSlotDrained()
+			if State(s.state.Load()) == StateClosing {
+				s.signalQuiescent()
+			}
 		}
 		return result, tagErr(StateTransportFailure, fmt.Errorf("send vRPC request: %w", sendErr))
 	}

--- a/bigtable/internal/transport/session_vrpc.go
+++ b/bigtable/internal/transport/session_vrpc.go
@@ -1,0 +1,452 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// activeVRPC returns the currently in-flight vRPC, or nil if the slot is
+// empty. Snapshot read under slotMu — the field's docstring covers the
+// multiplex=1 invariant and the slot's Java-parity lifecycle.
+func (s *Session) activeVRPC() *vrpcImpl {
+	s.slotMu.Lock()
+	rpc := s.activeRPC
+	s.slotMu.Unlock()
+	return rpc
+}
+
+// claimSlot assigns rpc to the empty slot. Returns false if the slot still
+// holds a prior vRPC (Java SessionImpl.startRpc L423 parity — concurrent
+// claims are rejected as UNCOMMITTED at the call site).
+func (s *Session) claimSlot(rpc *vrpcImpl) bool {
+	s.slotMu.Lock()
+	defer s.slotMu.Unlock()
+	if s.activeRPC != nil {
+		return false
+	}
+	s.activeRPC = rpc
+	return true
+}
+
+// markCancelled records ctx.Done cancellation of rpc without freeing the
+// slot — the caller returns, but activeRPC stays until the server response
+// arrives to drain it. Java SessionImpl.cancelRpc L448-457 parity
+// (first-cancel-wins; a racing drain that clears activeRPC makes this a
+// no-op).
+func (s *Session) markCancelled(rpc *vrpcImpl, res vrpcResult) {
+	s.slotMu.Lock()
+	defer s.slotMu.Unlock()
+	if s.activeRPC != rpc {
+		return
+	}
+	if s.currentCancel == nil {
+		s.currentCancel = &res
+	}
+}
+
+// drainSlot atomically clears the (activeRPC, currentCancel) pair iff
+// activeRPC == expect, returning what was there. Java
+// SessionImpl.handleVRpcResponse L599-602 parity. Used by response handlers
+// (after id-match) and by cancelActiveRPCs (session teardown); ok=false
+// means a racing drain got here first.
+func (s *Session) drainSlot(expect *vrpcImpl) (rpc *vrpcImpl, cancel *vrpcResult, ok bool) {
+	s.slotMu.Lock()
+	defer s.slotMu.Unlock()
+	if s.activeRPC != expect {
+		return nil, nil, false
+	}
+	rpc = s.activeRPC
+	cancel = s.currentCancel
+	s.activeRPC = nil
+	s.currentCancel = nil
+	return rpc, cancel, true
+}
+
+// Invoke executes a single virtual RPC on this session and returns every
+// observable output of the roundtrip — decoded response, cluster info,
+// server-reported Stats, and the local SentAt timestamp — so callers can
+// populate metrics (client_blocking_latency, server_backend_latency) and
+// respect server-supplied retry hints without losing data on the way out of
+// the transport.
+//
+// The caller MUST have exclusive access to this Session for the duration
+// of the call — the pool guarantees this via CheckoutSession's per-session
+// idle-slot gate. The single-in-flight invariant is enforced by claimSlot
+// under slotMu; a losing claim returns StateUncommitted so the retry
+// oracle can steer to another session (Java SessionImpl.startRpc
+// L420-444 parity). The slot is released only by handleVRPCResponse /
+// handleVRPCErrorResponse (successful drain), cancelActiveRPCs (session
+// teardown), or the Send-failure path below — caller ctx.Done leaves
+// the slot claimed and marks it via markCancelled.
+func (s *Session) Invoke(ctx context.Context, desc VRpcDescriptor, req interface{}) (result InvokeResult, err error) {
+	startTime := time.Now()
+
+	if st := State(s.state.Load()); st != StateReady {
+		return result, tagErr(StateUncommitted,
+			unavailable(ErrSessionNotActive, "session is not active (state: %v)", st))
+	}
+
+	reqBytes, err := desc.Encode(req)
+	if err != nil {
+		return result, tagErr(StateUncommitted, fmt.Errorf("encode vRPC request: %w", err))
+	}
+
+	rpcID := s.nextRPCID.Add(1)
+	result.RPCIDOnSession = rpcID
+	rpc := &vrpcImpl{
+		id:         rpcID,
+		method:     desc.Method(),
+		resultChan: make(chan vrpcResult, 1),
+	}
+
+	// Claim the single in-flight slot. Java SessionImpl.startRpc L423
+	// parity: a losing claim means a prior vRPC on this session has
+	// not drained on the wire yet — return Uncommitted so the retryer
+	// picks another session.
+	if !s.claimSlot(rpc) {
+		return result, tagErr(StateUncommitted,
+			unavailable(ErrSessionNotActive,
+				"session %q busy: prior vRPC has not drained on the wire", s.logName))
+	}
+
+	// Reset the heartbeat deadline whenever we send an outbound frame: the
+	// server's keepalive clock is implicitly reset by our activity.
+	s.resetHeartbeatDeadline()
+
+	attempt := currentAttempt(ctx)
+	if attempt > 1 {
+		s.noteRetryAttempt(ctx, desc.Method(), attempt)
+	}
+	sessionReq := buildInvokeRequest(rpcID, reqBytes, attempt, startTime, ctx)
+
+	// Capture SentAt immediately before the frame is handed to Send so
+	// downstream metrics can compute client-side blocking latency as
+	// (SentAt - attemptStart) without double-counting encode/setup overhead.
+	result.SentAt = time.Now()
+	if sendErr := s.Send(sessionReq); sendErr != nil {
+		// Synchronous Send failed: no server response is ever coming,
+		// so this call must free the slot itself. Java doesn't need
+		// this branch — sendMessage there is async and failures come
+		// back through the response observer — but Go's Send is
+		// synchronous, so an early drain is on the Invoke path.
+		s.drainSlot(rpc)
+		// v3: drain is the sole "session became free" signal. Fire the
+		// pool wake here as well — ReleaseToPool's inExpectedCount guard
+		// (see SESSION_POOL_SPEC #6, I5) drops the re-enqueue if
+		// OnSessionClosing already dropped this handle in the teardown
+		// that the Send failure typically kicks off.
+		s.hooks.onSlotDrained()
+		if State(s.state.Load()) == StateClosing {
+			s.signalQuiescent()
+		}
+		return result, tagErr(StateTransportFailure, fmt.Errorf("send vRPC request: %w", sendErr))
+	}
+
+	err = s.awaitInvokeResult(ctx, rpc, desc, &result)
+	return result, err
+}
+
+// currentAttempt reads the retry-interceptor's attempt tag from ctx. Calls
+// that bypass RetryingVRpc have no tag; treat them as attempt 1.
+func currentAttempt(ctx context.Context) int64 {
+	if a := int64(VRpcAttempt(ctx)); a > 0 {
+		return a
+	}
+	return 1
+}
+
+// noteRetryAttempt bumps the per-session retries counter and — if the
+// retry interceptor stashed the prior attempt's error on ctx — emits a
+// debug + sessionz event tagged with the prior gRPC code so operators
+// can trace WHY the retry fired without cross-referencing logs.
+func (s *Session) noteRetryAttempt(ctx context.Context, method string, attempt int64) {
+	s.retries.Add(1)
+	prev := PrevAttemptErr(ctx)
+	if prev == nil {
+		return
+	}
+	prevCode := status.Code(prev).String()
+	s.debugf("retry attempt=%d method=%s prev_code=%s prev_err=%v",
+		attempt, method, prevCode, prev)
+	s.recordEvent("retry", "attempt=%d method=%s prev_code=%s prev_err=%v",
+		attempt, method, prevCode, prev)
+}
+
+// buildInvokeRequest constructs the wire-level SessionRequest envelope
+// for a single vRPC attempt. Pure — no I/O, no side effects. The
+// VirtualRpc.Deadline field carries the remaining budget as a duration
+// so the server measures from receive time rather than an absolute wall
+// clock. Omitted when ctx has no deadline or the budget is already
+// non-positive (the client-side ctx.Done branch will fire immediately).
+func buildInvokeRequest(rpcID int64, reqBytes []byte, attempt int64, startTime time.Time, ctx context.Context) *spb.SessionRequest {
+	virtRpc := &spb.VirtualRpcRequest{
+		RpcId:   rpcID,
+		Payload: reqBytes,
+		Metadata: &spb.VirtualRpcRequest_Metadata{
+			AttemptNumber: attempt,
+			AttemptStart:  timestamppb.New(startTime),
+		},
+	}
+	if deadline, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(deadline); remaining > 0 {
+			virtRpc.Deadline = durationpb.New(remaining)
+		}
+	}
+	return &spb.SessionRequest{
+		Payload: &spb.SessionRequest_VirtualRpc{VirtualRpc: virtRpc},
+	}
+}
+
+// awaitInvokeResult blocks until either ctx cancels or the server
+// delivers a result on rpc.resultChan. Populates the tail of result
+// (TransportLatency, ClusterInfo, Stats, Response) and returns a
+// fully-tagged error on failure. res.err from resultChan is already
+// tagged at the source (cancelActiveRPCs → StateTransportFailure);
+// server error frames arrive as res.errResp and are unpacked here into
+// a StateServerResult-tagged error.
+//
+// ctx.Done branch: check resultChan non-blockingly first so a server
+// response that landed in the same tick as the ctx cancellation isn't
+// dropped. Otherwise mark the slot as cancelled — Java parity leaves
+// activeRPC set so a concurrent Invoke fails claimSlot with Uncommitted
+// rather than racing to id-mismatch the abandoned response.
+func (s *Session) awaitInvokeResult(ctx context.Context, rpc *vrpcImpl, desc VRpcDescriptor, result *InvokeResult) error {
+	select {
+	case <-ctx.Done():
+		select {
+		case res := <-rpc.resultChan:
+			return s.processResult(rpc, desc, result, res)
+		default:
+		}
+		s.recordCtxDone(ctx, rpc, desc.Method(), result.SentAt)
+		cancelErr := tagErr(StateTransportFailure, ctx.Err())
+		s.markCancelled(rpc, vrpcResult{err: cancelErr})
+		return cancelErr
+	case res := <-rpc.resultChan:
+		return s.processResult(rpc, desc, result, res)
+	}
+}
+
+// processResult unpacks a resultChan payload into result and returns
+// the tagged error (nil on success). Extracted so awaitInvokeResult's
+// ctx.Done race-guard can share the same success path when a response
+// beat the cancellation into resultChan by a tick.
+//
+// The res.resp.RpcId == rpc.id check that used to live here is gone:
+// under slotMu, handleVRPCResponse gates the id match BEFORE drainSlot,
+// so deliver can only ever put a matching-id response into resultChan.
+func (s *Session) processResult(rpc *vrpcImpl, desc VRpcDescriptor, result *InvokeResult, res vrpcResult) error {
+	result.TransportLatency = time.Since(result.SentAt)
+	ci := res.ClusterInfo()
+	result.ClusterInfo = ci
+	if ci != nil {
+		s.recordCluster(ci.GetClusterId())
+	}
+	if res.err != nil {
+		return res.err
+	}
+	if res.errResp != nil {
+		return tagErr(StateServerResult, errorResponseToErr(res.errResp))
+	}
+	respMsg, decodeErr := desc.Decode(res.resp.Payload)
+	if decodeErr != nil {
+		return tagErr(StateServerResult, fmt.Errorf("decode vRPC response: %w", decodeErr))
+	}
+	result.Response = respMsg
+	result.Stats = res.resp.Stats
+	if res.resp.Stats != nil && res.resp.Stats.BackendLatency != nil {
+		s.recordLatency(res.resp.Stats.BackendLatency.AsDuration())
+	}
+	_ = rpc // rpc kept in signature for future per-rpc metrics; no reads today.
+	return nil
+}
+
+// recordCtxDone emits the debug + sessionz event for a ctx cancellation
+// or deadline fire while a vRPC was in flight. Captures whether the RPC
+// was still holding the slot at cancel time — useful for spotting races
+// between our cancel and a late server response.
+func (s *Session) recordCtxDone(ctx context.Context, rpc *vrpcImpl, method string, sentAt time.Time) {
+	stillActive := s.activeVRPC() == rpc
+	sessState := State(s.state.Load())
+	waited := time.Since(sentAt)
+	peer := s.peerInfoSummary()
+	s.debugf("vRPC %s rpc_id=%d ctx.Done waited=%v err=%v session_state=%v still_in_flight=%v %s",
+		method, rpc.id, waited, ctx.Err(), sessState, stillActive, peer)
+	s.recordEvent("ctx-done", "method=%s rpc_id=%d waited=%v err=%v session_state=%v still_in_flight=%v %s",
+		method, rpc.id, waited, ctx.Err(), sessState, stillActive, peer)
+}
+
+// handleVRPCResponse delivers a server VirtualRpcResponse to the waiting
+// Invoke caller, or drains a cancelled slot if the caller already
+// abandoned the RPC via ctx.Done (Java SessionImpl.handleVRpcResponse
+// L567-614 parity — the cancel branch there discards the response
+// tracer-side; here we just count it).
+func (s *Session) handleVRPCResponse(resp *spb.VirtualRpcResponse) {
+	s.routeVRPCFrame(resp.RpcId, "VirtualRpcResponse", tagSessionVRPCNil,
+		&s.okRpcs, vrpcResult{resp: resp})
+}
+
+// handleVRPCErrorResponse routes per-vRPC errors to the waiting caller.
+// Mirrors handleVRPCResponse's Java-parity drain path — a cancelled slot
+// drains without deliver.
+func (s *Session) handleVRPCErrorResponse(errResp *spb.ErrorResponse) {
+	s.routeVRPCFrame(errResp.RpcId, "ErrorResponse", tagSessionVRPCErrorNil,
+		&s.errorRpcs, vrpcResult{errResp: errResp})
+}
+
+// routeVRPCFrame is the shared skeleton for handleVRPCResponse /
+// handleVRPCErrorResponse. All Java-parity gating (state check, active-
+// vRPC nil guard, id-match, drain-vs-cancel branching, OnSlotDrained
+// hook on every drain, quiescence signalling in Closing) lives here
+// so the two call sites can't drift.
+//
+// A vRPC frame is only expected while the session is Ready or Closing
+// (drain window). Any other state means either a bug in state tracking
+// or a server retransmit after teardown — drop.
+//
+// The two call sites differ only in:
+//   - frameName / nilTag / counter — labels + which atomic bumps
+//   - result — vrpcResult{resp:} vs vrpcResult{errResp:} handed to deliver
+//
+// drainSlot returning !ok means cancelActiveRPCs (session teardown)
+// won the slot between the id-match above and our drainSlot call. Its
+// deliver already fired the terminal error; nothing to do.
+func (s *Session) routeVRPCFrame(rpcID int64, frameName, nilTag string, counter *atomic.Int64, result vrpcResult) {
+	st := s.State()
+	if !assertDebugTagf(st == StateReady || st == StateClosing, tagSessionVRPCResponseWrongState,
+		"%s for rpc_id=%d arrived in state %s", frameName, rpcID, st) {
+		return
+	}
+	rpc := s.activeVRPC()
+	if rpc == nil {
+		recordDebugTag(nilTag)
+		s.debugf("dropping %s for rpc_id=%d — no in-flight RPC tracked", frameName, rpcID)
+		return
+	}
+	if rpc.id != rpcID {
+		recordDebugTag(tagSessionVRPCIDMismatch)
+		s.debugf("dropping %s rpc_id=%d != in-flight rpc_id=%d", frameName, rpcID, rpc.id)
+		return
+	}
+	drained, cancel, ok := s.drainSlot(rpc)
+	if !ok {
+		return
+	}
+	counter.Add(1)
+	if cancel != nil {
+		// Caller already returned via ctx.Done — no one is waiting on
+		// resultChan. Just count the drain for observability.
+		recordDebugTag(tagSessionVRPCCancelledDrained)
+	} else {
+		s.deliver(drained, result)
+	}
+	// v3: drainSlot success is the sole "session became free" signal.
+	// Fires on every drain (not just the cancelled branch) so the pool
+	// re-enqueues the session in its AFE idle queue and wakes one
+	// parked Checkout waiter. Invoke's return path in the pool no
+	// longer performs the re-enqueue or the wake.
+	s.hooks.onSlotDrained()
+	if State(s.state.Load()) == StateClosing {
+		s.signalQuiescent()
+	}
+}
+
+// errorResponseToErr converts a server ErrorResponse frame into a Go
+// error carrying the gRPC status code and any RetryInfo the server
+// attached. RetryInfo is packed into the status details so downstream
+// consumers (notably RetryingVRpc) can recover it via status.FromError.
+// WithDetails returns a fresh *Status on success; on the rare failure
+// (e.g. anypb marshal) we fall back to the bare status so the error path
+// still propagates the server's code.
+func errorResponseToErr(errResp *spb.ErrorResponse) error {
+	if errResp.Status == nil {
+		return fmt.Errorf("unknown vRPC error (rpc_id=%d)", errResp.RpcId)
+	}
+	st := status.FromProto(errResp.Status)
+	if errResp.RetryInfo != nil {
+		if withDetails, derr := st.WithDetails(errResp.RetryInfo); derr == nil {
+			st = withDetails
+		}
+	}
+	return st.Err()
+}
+
+// deliver writes a result onto the RPC's buffered (cap 1) channel.
+// Under slotMu, exactly one caller ever holds a drained rpc (the
+// winning drainSlot inside handleVRPCResponse / handleVRPCErrorResponse
+// / cancelActiveRPCs), so the two-writers race on resultChan is
+// impossible in production. The cap-1 buffer is retained as defense
+// against the awaitInvokeResult ctx.Done-vs-response tick race — the
+// send must not block if the reader stopped listening.
+func (s *Session) deliver(rpc *vrpcImpl, res vrpcResult) {
+	rpc.resultChan <- res
+}
+
+// ForceClose transitions the session straight to StateClosed and cancels
+// any in-flight vRPC with a TransportFailure-tagged error. Minimal port
+// from the sessionz-debug lifecycle body — the full teardown (setCloseReason,
+// notifyClosing/Closed, stream shutdown) lands in the follow-up lifecycle
+// PR. This surface exists so slot-lifecycle tests can drive the
+// "session torn down under an in-flight vRPC" path.
+func (s *Session) ForceClose(req *spb.CloseSessionRequest) {
+	_, ok := s.transitionTo(StateClosed, notState(StateClosed))
+	if !ok {
+		return
+	}
+	desc := "session force closed"
+	if req != nil && req.Description != "" {
+		desc = "session force closed: " + req.Description
+	}
+	s.cancelActiveRPCs(unavailable(ErrSessionNotActive, "%s", desc))
+	s.signalQuiescent()
+}
+
+// cancelActiveRPCs cancels the in-flight vRPC (if any) with the given
+// error. With multiPlexingLimit=1 there is at most one such vRPC.
+// Called from session teardown paths (Close, ForceClose, handleGoAway,
+// handleClose, heartbeat miss) — the "server will never respond" cases
+// where the slot must be freed even under Java-parity claim-until-drain.
+// If the caller already abandoned via ctx.Done, the drain returns a
+// cancel handle and we skip the deliver (no reader on resultChan).
+func (s *Session) cancelActiveRPCs(err error) {
+	rpc := s.activeVRPC()
+	if rpc == nil {
+		return
+	}
+	drained, cancel, ok := s.drainSlot(rpc)
+	if !ok {
+		// Concurrent handleVRPCResponse / handleVRPCErrorResponse
+		// cleared the slot; that caller already delivered.
+		return
+	}
+	if cancel != nil {
+		// Caller already returned via ctx.Done; no one to deliver to.
+		return
+	}
+	// Session-side cancellation: session died / GoAway / heartbeat missed
+	// / benign shutdown while an RPC was in-flight. Server may or may not
+	// have processed — TransportFailure classification lets idempotent ops
+	// retry and prevents non-idempotent ones from double-applying.
+	s.deliver(drained, vrpcResult{err: tagErr(StateTransportFailure, err)})
+}

--- a/bigtable/internal/transport/session_vrpc.go
+++ b/bigtable/internal/transport/session_vrpc.go
@@ -52,16 +52,19 @@ func (s *Session) claimSlot(rpc *vrpcImpl) bool {
 // markCancelled records ctx.Done cancellation of rpc without freeing the
 // slot — the caller returns, but activeRPC stays until the server response
 // arrives to drain it. First-cancel-wins; a racing drain that clears
-// activeRPC makes this a no-op.
-func (s *Session) markCancelled(rpc *vrpcImpl, res vrpcResult) {
+// activeRPC makes this a no-op. Returns whether rpc was still the active
+// slot occupant, so callers that also want the "still in flight?" signal
+// don't have to re-acquire slotMu with a separate activeVRPC() call.
+func (s *Session) markCancelled(rpc *vrpcImpl, res vrpcResult) (stillActive bool) {
 	s.slotMu.Lock()
 	defer s.slotMu.Unlock()
 	if s.activeRPC != rpc {
-		return
+		return false
 	}
 	if s.currentCancel == nil {
 		s.currentCancel = &res
 	}
+	return true
 }
 
 // drainSlot atomically clears the (activeRPC, currentCancel) pair iff
@@ -134,7 +137,7 @@ func (s *Session) Invoke(ctx context.Context, desc VRpcDescriptor, req interface
 	if attempt > 1 {
 		s.noteRetryAttempt(ctx, desc.Method(), attempt)
 	}
-	sessionReq := buildInvokeRequest(rpcID, reqBytes, attempt, startTime, ctx)
+	sessionReq := buildInvokeRequest(ctx, rpcID, reqBytes, attempt, startTime)
 
 	// Capture SentAt immediately before the frame is handed to Send so
 	// downstream metrics can compute client-side blocking latency as
@@ -185,7 +188,7 @@ func (s *Session) noteRetryAttempt(ctx context.Context, method string, attempt i
 	prevCode := status.Code(prev).String()
 	s.debugf("retry attempt=%d method=%s prev_code=%s prev_err=%v",
 		attempt, method, prevCode, prev)
-	s.recordEvent("retry", "attempt=%d method=%s prev_code=%s prev_err=%v",
+	s.recordEvent(SessionEventRetry, "attempt=%d method=%s prev_code=%s prev_err=%v",
 		attempt, method, prevCode, prev)
 }
 
@@ -195,7 +198,7 @@ func (s *Session) noteRetryAttempt(ctx context.Context, method string, attempt i
 // so the server measures from receive time rather than an absolute wall
 // clock. Omitted when ctx has no deadline or the budget is already
 // non-positive (the client-side ctx.Done branch will fire immediately).
-func buildInvokeRequest(rpcID int64, reqBytes []byte, attempt int64, startTime time.Time, ctx context.Context) *spb.SessionRequest {
+func buildInvokeRequest(ctx context.Context, rpcID int64, reqBytes []byte, attempt int64, startTime time.Time) *spb.SessionRequest {
 	virtRpc := &spb.VirtualRpcRequest{
 		RpcId:   rpcID,
 		Payload: reqBytes,
@@ -232,15 +235,15 @@ func (s *Session) awaitInvokeResult(ctx context.Context, rpc *vrpcImpl, desc VRp
 	case <-ctx.Done():
 		select {
 		case res := <-rpc.resultChan:
-			return s.processResult(rpc, desc, result, res)
+			return s.processResult(desc, result, res)
 		default:
 		}
-		s.recordCtxDone(ctx, rpc, desc.Method(), result.SentAt)
 		cancelErr := tagErr(StateTransportFailure, ctx.Err())
-		s.markCancelled(rpc, vrpcResult{err: cancelErr})
+		stillActive := s.markCancelled(rpc, vrpcResult{err: cancelErr})
+		s.recordCtxDone(ctx, rpc, desc.Method(), result.SentAt, stillActive)
 		return cancelErr
 	case res := <-rpc.resultChan:
-		return s.processResult(rpc, desc, result, res)
+		return s.processResult(desc, result, res)
 	}
 }
 
@@ -252,7 +255,7 @@ func (s *Session) awaitInvokeResult(ctx context.Context, rpc *vrpcImpl, desc VRp
 // The res.resp.RpcId == rpc.id check that used to live here is gone:
 // under slotMu, handleVRPCResponse gates the id match BEFORE drainSlot,
 // so deliver can only ever put a matching-id response into resultChan.
-func (s *Session) processResult(rpc *vrpcImpl, desc VRpcDescriptor, result *InvokeResult, res vrpcResult) error {
+func (s *Session) processResult(desc VRpcDescriptor, result *InvokeResult, res vrpcResult) error {
 	result.TransportLatency = time.Since(result.SentAt)
 	ci := res.ClusterInfo()
 	result.ClusterInfo = ci
@@ -274,22 +277,21 @@ func (s *Session) processResult(rpc *vrpcImpl, desc VRpcDescriptor, result *Invo
 	if res.resp.Stats != nil && res.resp.Stats.BackendLatency != nil {
 		s.recordLatency(res.resp.Stats.BackendLatency.AsDuration())
 	}
-	_ = rpc // rpc kept in signature for future per-rpc metrics; no reads today.
 	return nil
 }
 
 // recordCtxDone emits the debug + sessionz event for a ctx cancellation
-// or deadline fire while a vRPC was in flight. Captures whether the RPC
-// was still holding the slot at cancel time — useful for spotting races
-// between our cancel and a late server response.
-func (s *Session) recordCtxDone(ctx context.Context, rpc *vrpcImpl, method string, sentAt time.Time) {
-	stillActive := s.activeVRPC() == rpc
+// or deadline fire while a vRPC was in flight. stillActive comes from
+// markCancelled's return so no second slotMu take is needed here — it
+// reports whether rpc still held the slot at cancel time, useful for
+// spotting races between our cancel and a late server response.
+func (s *Session) recordCtxDone(ctx context.Context, rpc *vrpcImpl, method string, sentAt time.Time, stillActive bool) {
 	sessState := State(s.state.Load())
 	waited := time.Since(sentAt)
 	peer := s.peerInfoSummary()
 	s.debugf("vRPC %s rpc_id=%d ctx.Done waited=%v err=%v session_state=%v still_in_flight=%v %s",
 		method, rpc.id, waited, ctx.Err(), sessState, stillActive, peer)
-	s.recordEvent("ctx-done", "method=%s rpc_id=%d waited=%v err=%v session_state=%v still_in_flight=%v %s",
+	s.recordEvent(SessionEventCtxDone, "method=%s rpc_id=%d waited=%v err=%v session_state=%v still_in_flight=%v %s",
 		method, rpc.id, waited, ctx.Err(), sessState, stillActive, peer)
 }
 
@@ -353,7 +355,9 @@ func (s *Session) routeVRPCFrame(rpcID int64, frameName, nilTag string, counter 
 		// resultChan. Just count the drain for observability.
 		recordDebugTag(tagSessionVRPCCancelledDrained)
 	} else {
-		s.deliver(drained, result)
+		// resultChan is cap-1 and drainSlot serialized this write; the
+		// send never blocks.
+		drained.resultChan <- result
 	}
 	// v3: drainSlot success is the sole "session became free" signal.
 	// Fires on every drain (not just the cancelled branch) so the pool
@@ -384,17 +388,6 @@ func errorResponseToErr(errResp *spb.ErrorResponse) error {
 		}
 	}
 	return st.Err()
-}
-
-// deliver writes a result onto the RPC's buffered (cap 1) channel.
-// Under slotMu, exactly one caller ever holds a drained rpc (the
-// winning drainSlot inside handleVRPCResponse / handleVRPCErrorResponse
-// / cancelActiveRPCs), so the two-writers race on resultChan is
-// impossible in production. The cap-1 buffer is retained as defense
-// against the awaitInvokeResult ctx.Done-vs-response tick race — the
-// send must not block if the reader stopped listening.
-func (s *Session) deliver(rpc *vrpcImpl, res vrpcResult) {
-	rpc.resultChan <- res
 }
 
 // ForceClose transitions the session straight to StateClosed and cancels
@@ -442,5 +435,5 @@ func (s *Session) cancelActiveRPCs(err error) {
 	// / benign shutdown while an RPC was in-flight. Server may or may not
 	// have processed — TransportFailure classification lets idempotent ops
 	// retry and prevents non-idempotent ones from double-applying.
-	s.deliver(drained, vrpcResult{err: tagErr(StateTransportFailure, err)})
+	drained.resultChan <- vrpcResult{err: tagErr(StateTransportFailure, err)}
 }

--- a/bigtable/internal/transport/session_vrpc.go
+++ b/bigtable/internal/transport/session_vrpc.go
@@ -271,7 +271,11 @@ func (s *Session) processResult(desc VRpcDescriptor, result *InvokeResult, res v
 	}
 	respMsg, decodeErr := desc.Decode(res.resp.Payload)
 	if decodeErr != nil {
-		return tagErr(StateServerResult, fmt.Errorf("decode vRPC response: %w", decodeErr))
+		// StateTransportFailure — we couldn't consume the wire bytes, so
+		// there is no server-application-level result to reason about. A
+		// retry (potentially on another session/AFE) may succeed if the
+		// bad payload was a one-off from a specific backend.
+		return tagErr(StateTransportFailure, fmt.Errorf("decode vRPC response: %w", decodeErr))
 	}
 	result.Response = respMsg
 	result.Stats = res.resp.Stats
@@ -318,9 +322,24 @@ func (s *Session) handleVRPCErrorResponse(errResp *spb.ErrorResponse) {
 // on every drain, quiescence signalling in Closing) lives here so the
 // two call sites can't drift.
 //
-// A vRPC frame is only expected while the session is Ready or Closing
-// (drain window). Any other state means either a bug in state tracking
-// or a server retransmit after teardown — drop.
+// Frame gating (per-scenario handling, per mutianf review on #20213 —
+// silent drops are dangerous; escalate genuine protocol violations to
+// a session teardown so the pool minutes a replacement and the caller
+// isn't left waiting on a session the server has desynced from):
+//
+//   - State ∈ {Ready, Closing, WaitServerClose}: expected. The drain
+//     window keeps accepting frames until the server's EOF.
+//   - State ∈ {New, Starting, Closed}: unrecoverable — the reader
+//     shouldn't be running in these states. Emit a protocol-error
+//     event + tear down.
+//   - Nil active vRPC: legit race — caller ctx.Done'd and cancelled
+//     the slot, but the server's response arrived before our cancel
+//     landed. Log as protocol-error at info-level for observability,
+//     but do NOT tear down.
+//   - RPC id mismatch: server sent a response for a different id than
+//     our active vRPC. Real protocol desync (server bug, corrupted
+//     stream). Emit + tear down; cancelActiveRPCs delivers a terminal
+//     error to the current caller.
 //
 // The two call sites differ only in:
 //   - frameName / nilTag / counter — labels + which atomic bumps
@@ -331,19 +350,30 @@ func (s *Session) handleVRPCErrorResponse(errResp *spb.ErrorResponse) {
 // deliver already fired the terminal error; nothing to do.
 func (s *Session) routeVRPCFrame(rpcID int64, frameName, nilTag string, counter *atomic.Int64, result vrpcResult) {
 	st := s.State()
-	if !assertDebugTagf(st == StateReady || st == StateClosing, tagSessionVRPCResponseWrongState,
-		"%s for rpc_id=%d arrived in state %s", frameName, rpcID, st) {
+	if st != StateReady && st != StateClosing && st != StateWaitServerClose {
+		recordDebugTagAt(lvl.Error, tagSessionVRPCResponseWrongState)
+		s.recordEvent(SessionEventProtocolError,
+			"%s for rpc_id=%d arrived in state %s — tearing down",
+			frameName, rpcID, st)
+		s.cancelActiveRPCs(unavailable(nil,
+			"protocol error: %s for rpc_id=%d in state %s", frameName, rpcID, st))
 		return
 	}
 	rpc := s.activeVRPC()
 	if rpc == nil {
 		recordDebugTag(nilTag)
-		s.debugf("dropping %s for rpc_id=%d — no in-flight RPC tracked", frameName, rpcID)
+		s.recordEvent(SessionEventProtocolError,
+			"%s for rpc_id=%d dropped — no in-flight RPC tracked (likely late frame after ctx.Done cancel)",
+			frameName, rpcID)
 		return
 	}
 	if rpc.id != rpcID {
 		recordDebugTag(tagSessionVRPCIDMismatch)
-		s.debugf("dropping %s rpc_id=%d != in-flight rpc_id=%d", frameName, rpcID, rpc.id)
+		s.recordEvent(SessionEventProtocolError,
+			"%s rpc_id=%d != in-flight rpc_id=%d — server desync, tearing down",
+			frameName, rpcID, rpc.id)
+		s.cancelActiveRPCs(unavailable(nil,
+			"protocol error: %s rpc_id=%d != active rpc_id=%d", frameName, rpcID, rpc.id))
 		return
 	}
 	drained, cancel, ok := s.drainSlot(rpc)

--- a/bigtable/internal/transport/session_vrpc.go
+++ b/bigtable/internal/transport/session_vrpc.go
@@ -145,19 +145,20 @@ func (s *Session) Invoke(ctx context.Context, desc VRpcDescriptor, req interface
 	result.SentAt = time.Now()
 	if sendErr := s.Send(sessionReq); sendErr != nil {
 		// Synchronous Send failed: no server response is ever coming,
-		// so this call must free the slot itself here on the Invoke path.
-		// drainSlot returns ok=false when concurrent teardown
-		// (cancelActiveRPCs / ForceClose) beat us to freeing the slot.
-		// In that case, the teardown path is responsible for pool
-		// notification via OnClosing/OnClose and quiescence signalling —
-		// firing onSlotDrained here would violate the SessionHooks
-		// contract that reserves it for the drain-succeeded path
-		// (SESSION_SPEC #5/#10). Only fire when we actually did the drain.
-		if _, _, ok := s.drainSlot(rpc); ok {
-			s.hooks.onSlotDrained()
-			if State(s.state.Load()) == StateClosing {
-				s.signalQuiescent()
-			}
+		// so this call must free the slot itself. Other paths don't need
+		// this branch — sendMessage there is async and failures come
+		// back through the response observer — but Go's Send is
+		// synchronous, so an early drain is on the Invoke path.
+		s.drainSlot(rpc)
+		// Drain is the sole "session became free" signal. Fire the pool
+		// wake here as well — ReleaseToPool's inExpectedCount guard
+		// (session_list.go) drops the re-enqueue when OnSessionClosing
+		// already dropped this handle in the teardown that the Send
+		// failure typically kicks off, so an unguarded emit here is safe
+		// against the concurrent-teardown race gemini flagged.
+		s.hooks.onSlotDrained()
+		if State(s.state.Load()) == StateClosing {
+			s.signalQuiescent()
 		}
 		return result, tagErr(StateTransportFailure, fmt.Errorf("send vRPC request: %w", sendErr))
 	}

--- a/bigtable/internal/transport/session_vrpc.go
+++ b/bigtable/internal/transport/session_vrpc.go
@@ -271,11 +271,12 @@ func (s *Session) processResult(desc VRpcDescriptor, result *InvokeResult, res v
 	}
 	respMsg, decodeErr := desc.Decode(res.resp.Payload)
 	if decodeErr != nil {
-		// StateTransportFailure — we couldn't consume the wire bytes, so
-		// there is no server-application-level result to reason about. A
-		// retry (potentially on another session/AFE) may succeed if the
-		// bad payload was a one-off from a specific backend.
-		return tagErr(StateTransportFailure, fmt.Errorf("decode vRPC response: %w", decodeErr))
+		// StateServerResult per SESSION_SPEC #9: the server sent a
+		// response, so the request likely COMMITTED even if we can't
+		// parse the reply. Retrying an idempotent-only-under-strict-ID
+		// mutation could double-apply. Callers with a genuine idempotency
+		// token can override at the retry-oracle level.
+		return tagErr(StateServerResult, fmt.Errorf("decode vRPC response: %w", decodeErr))
 	}
 	result.Response = respMsg
 	result.Stats = res.resp.Stats
@@ -324,22 +325,30 @@ func (s *Session) handleVRPCErrorResponse(errResp *spb.ErrorResponse) {
 //
 // Frame gating (per-scenario handling, per mutianf review on #20213 —
 // silent drops are dangerous; escalate genuine protocol violations to
-// a session teardown so the pool minutes a replacement and the caller
-// isn't left waiting on a session the server has desynced from):
+// a full session teardown so the pool removes the session from routing
+// and the caller isn't left waiting on a session the server has
+// desynced from):
 //
 //   - State ∈ {Ready, Closing, WaitServerClose}: expected. The drain
 //     window keeps accepting frames until the server's EOF.
-//   - State ∈ {New, Starting, Closed}: unrecoverable — the reader
-//     shouldn't be running in these states. Emit a protocol-error
-//     event + tear down.
-//   - Nil active vRPC: legit race — caller ctx.Done'd and cancelled
-//     the slot, but the server's response arrived before our cancel
-//     landed. Log as protocol-error at info-level for observability,
-//     but do NOT tear down.
-//   - RPC id mismatch: server sent a response for a different id than
-//     our active vRPC. Real protocol desync (server bug, corrupted
-//     stream). Emit + tear down; cancelActiveRPCs delivers a terminal
-//     error to the current caller.
+//   - State ∈ {New, Starting, Closed}: unrecoverable state-tracking
+//     inconsistency. Emit SessionEventProtocolError + ForceClose to
+//     get the OnClosing/OnClose hooks to remove the session from the
+//     pool's AFE routing (cancelActiveRPCs alone leaves a Ready
+//     session orphaned from the AFE queue). In practice this branch
+//     is unreachable in production — readLoop only runs post-Start
+//     (state ≥ Ready) and ForceClose no-ops on Closed via the
+//     transitionTo CAS. Kept as belt-and-suspenders: cheap, and the
+//     id-mismatch branch below IS live under wire corruption.
+//   - Nil active vRPC: documented ctx.Done race — the caller cancelled
+//     the slot and the server's response landed after. NOT a protocol
+//     violation. Emit SessionEventLateFrame (separate kind so operators
+//     grep-ing "protocol-error" don't see benign late-frame drops),
+//     drop the frame, keep the session healthy.
+//   - RPC id mismatch: genuine protocol desync (server sent a response
+//     for a different id than our active vRPC). Emit
+//     SessionEventProtocolError + ForceClose so the caller gets a
+//     terminal error AND the session leaves the pool cleanly.
 //
 // The two call sites differ only in:
 //   - frameName / nilTag / counter — labels + which atomic bumps
@@ -353,27 +362,31 @@ func (s *Session) routeVRPCFrame(rpcID int64, frameName, nilTag string, counter 
 	if st != StateReady && st != StateClosing && st != StateWaitServerClose {
 		recordDebugTagAt(lvl.Error, tagSessionVRPCResponseWrongState)
 		s.recordEvent(SessionEventProtocolError,
-			"%s for rpc_id=%d arrived in state %s — tearing down",
+			"%s for rpc_id=%d arrived in state %s — force-closing session",
 			frameName, rpcID, st)
-		s.cancelActiveRPCs(unavailable(nil,
-			"protocol error: %s for rpc_id=%d in state %s", frameName, rpcID, st))
+		s.ForceClose(&spb.CloseSessionRequest{
+			Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_ERROR,
+			Description: fmt.Sprintf("protocol error: %s for rpc_id=%d in state %s", frameName, rpcID, st),
+		})
 		return
 	}
 	rpc := s.activeVRPC()
 	if rpc == nil {
 		recordDebugTag(nilTag)
-		s.recordEvent(SessionEventProtocolError,
-			"%s for rpc_id=%d dropped — no in-flight RPC tracked (likely late frame after ctx.Done cancel)",
+		s.recordEvent(SessionEventLateFrame,
+			"%s for rpc_id=%d dropped — no in-flight RPC tracked (late frame after ctx.Done cancel)",
 			frameName, rpcID)
 		return
 	}
 	if rpc.id != rpcID {
 		recordDebugTag(tagSessionVRPCIDMismatch)
 		s.recordEvent(SessionEventProtocolError,
-			"%s rpc_id=%d != in-flight rpc_id=%d — server desync, tearing down",
+			"%s rpc_id=%d != in-flight rpc_id=%d — server desync, force-closing session",
 			frameName, rpcID, rpc.id)
-		s.cancelActiveRPCs(unavailable(nil,
-			"protocol error: %s rpc_id=%d != active rpc_id=%d", frameName, rpcID, rpc.id))
+		s.ForceClose(&spb.CloseSessionRequest{
+			Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_ERROR,
+			Description: fmt.Sprintf("protocol error: %s rpc_id=%d != active rpc_id=%d", frameName, rpcID, rpc.id),
+		})
 		return
 	}
 	drained, cancel, ok := s.drainSlot(rpc)

--- a/bigtable/internal/transport/session_vrpc_test.go
+++ b/bigtable/internal/transport/session_vrpc_test.go
@@ -780,9 +780,10 @@ func TestInvoke_ForceCloseWhileSending_BoundedReturn(t *testing.T) {
 		Description: "mid-send teardown",
 	})
 
-	// Give ForceClose a moment to run before unblocking Send so the
-	// race resolves in the intended order.
-	time.Sleep(20 * time.Millisecond)
+	// Block on cancelActiveRPCs actually clearing the slot before we
+	// unblock Send — deterministic sync in place of a scheduler-hoping
+	// time.Sleep so the test can't flake on a loaded CI box.
+	waitFor(t, time.Second, func() bool { return s.activeVRPC() == nil }, "slot drained by cancelActiveRPCs")
 	close(sendGate)
 
 	select {

--- a/bigtable/internal/transport/session_vrpc_test.go
+++ b/bigtable/internal/transport/session_vrpc_test.go
@@ -34,7 +34,7 @@ import (
 // VirtualRpcResponse, then returns the *VirtualRpcRequest that was sent on the
 // wire. All inspection of the deadline / metadata plumbing is done against
 // this snapshot.
-func runVRpcCapture(t *testing.T, ctx context.Context) *spb.VirtualRpcRequest {
+func runVRpcCapture(ctx context.Context, t *testing.T) *spb.VirtualRpcRequest {
 	t.Helper()
 	s, stream := makeActive(t, SessionHooks{})
 	desc := newRoundTripDesc()
@@ -64,7 +64,7 @@ func TestInvoke_DeadlineCarriedInRequest(t *testing.T) {
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(500*time.Millisecond))
 	defer cancel()
 
-	sent := runVRpcCapture(t, ctx)
+	sent := runVRpcCapture(ctx, t)
 	if sent.Deadline == nil {
 		t.Fatal("VirtualRpc.Deadline = nil, want non-nil when ctx carries a deadline")
 	}
@@ -80,7 +80,7 @@ func TestInvoke_DeadlineCarriedInRequest(t *testing.T) {
 }
 
 func TestInvoke_NoDeadlineWhenCtxHasNone(t *testing.T) {
-	sent := runVRpcCapture(t, context.Background())
+	sent := runVRpcCapture(context.Background(), t)
 	if sent.Deadline != nil {
 		t.Errorf("VirtualRpc.Deadline = %v, want nil when ctx has no deadline", sent.Deadline.AsDuration())
 	}
@@ -93,7 +93,7 @@ func TestInvoke_AttemptNumberFromCtx(t *testing.T) {
 	// updates via WithAttempt on each retry).
 	ctx := WithVRpcMetadata(context.Background(), "ReadRow", 1)
 	ctx = WithAttempt(ctx, 7)
-	sent := runVRpcCapture(t, ctx)
+	sent := runVRpcCapture(ctx, t)
 	if sent.Metadata == nil {
 		t.Fatal("VirtualRpc.Metadata = nil")
 	}
@@ -103,7 +103,7 @@ func TestInvoke_AttemptNumberFromCtx(t *testing.T) {
 }
 
 func TestInvoke_AttemptNumberDefault(t *testing.T) {
-	sent := runVRpcCapture(t, context.Background())
+	sent := runVRpcCapture(context.Background(), t)
 	if sent.Metadata == nil {
 		t.Fatal("VirtualRpc.Metadata = nil")
 	}
@@ -114,7 +114,7 @@ func TestInvoke_AttemptNumberDefault(t *testing.T) {
 
 func TestInvoke_AttemptStartIsRecent(t *testing.T) {
 	before := time.Now()
-	sent := runVRpcCapture(t, context.Background())
+	sent := runVRpcCapture(context.Background(), t)
 	after := time.Now()
 
 	if sent.Metadata == nil || sent.Metadata.AttemptStart == nil {
@@ -135,7 +135,7 @@ func TestInvoke_AttemptStartIsRecent(t *testing.T) {
 // returning the populated InvokeResult + err. It mirrors runVRpcCapture but
 // returns the full InvokeResult so tests can assert on Stats / SentAt /
 // ClusterInfo without the back-compat triple stripping them.
-func runInvoke(t *testing.T, ctx context.Context, deliver func(s *Session, sent *spb.VirtualRpcRequest)) (InvokeResult, error) {
+func runInvoke(ctx context.Context, t *testing.T, deliver func(s *Session, sent *spb.VirtualRpcRequest)) (InvokeResult, error) {
 	t.Helper()
 	s, stream := makeActive(t, SessionHooks{})
 	desc := newRoundTripDesc()
@@ -169,7 +169,7 @@ func TestInvoke_StatsExtractedFromResponse(t *testing.T) {
 	const wantBackend = 123 * time.Millisecond
 
 	before := time.Now()
-	res, err := runInvoke(t, context.Background(), func(s *Session, sent *spb.VirtualRpcRequest) {
+	res, err := runInvoke(context.Background(), t, func(s *Session, sent *spb.VirtualRpcRequest) {
 		s.handleVRPCResponse(&spb.VirtualRpcResponse{
 			RpcId:   sent.RpcId,
 			Payload: []byte("ok"),
@@ -194,7 +194,7 @@ func TestInvoke_StatsExtractedFromResponse(t *testing.T) {
 }
 
 func TestInvoke_StatsNilWhenServerOmits(t *testing.T) {
-	res, err := runInvoke(t, context.Background(), func(s *Session, sent *spb.VirtualRpcRequest) {
+	res, err := runInvoke(context.Background(), t, func(s *Session, sent *spb.VirtualRpcRequest) {
 		s.handleVRPCResponse(&spb.VirtualRpcResponse{
 			RpcId:   sent.RpcId,
 			Payload: []byte("ok"),
@@ -211,7 +211,7 @@ func TestInvoke_StatsNilWhenServerOmits(t *testing.T) {
 
 func TestInvoke_SentAtIsNonZero(t *testing.T) {
 	before := time.Now()
-	res, err := runInvoke(t, context.Background(), func(s *Session, sent *spb.VirtualRpcRequest) {
+	res, err := runInvoke(context.Background(), t, func(s *Session, sent *spb.VirtualRpcRequest) {
 		s.handleVRPCResponse(&spb.VirtualRpcResponse{
 			RpcId:   sent.RpcId,
 			Payload: []byte("ok"),
@@ -261,7 +261,7 @@ func TestInvoke_SentAtIsSetEvenOnSendFailure(t *testing.T) {
 }
 
 func TestInvoke_ClusterInfoOnErrorPath(t *testing.T) {
-	res, err := runInvoke(t, context.Background(), func(s *Session, sent *spb.VirtualRpcRequest) {
+	res, err := runInvoke(context.Background(), t, func(s *Session, sent *spb.VirtualRpcRequest) {
 		s.handleVRPCErrorResponse(&spb.ErrorResponse{
 			RpcId:       sent.RpcId,
 			Status:      &rpcstatus.Status{Code: int32(codes.FailedPrecondition), Message: "boom"},
@@ -289,7 +289,7 @@ func TestInvoke_RetryInfoPackedIntoStatus(t *testing.T) {
 	// status.FromError(err).Details(). RetryingVRpc reads it from there.
 	const wantDelay = 250 * time.Millisecond
 
-	_, err := runInvoke(t, context.Background(), func(s *Session, sent *spb.VirtualRpcRequest) {
+	_, err := runInvoke(context.Background(), t, func(s *Session, sent *spb.VirtualRpcRequest) {
 		s.handleVRPCErrorResponse(&spb.ErrorResponse{
 			RpcId:     sent.RpcId,
 			Status:    &rpcstatus.Status{Code: int32(codes.Unavailable), Message: "boom"},

--- a/bigtable/internal/transport/session_vrpc_test.go
+++ b/bigtable/internal/transport/session_vrpc_test.go
@@ -1,0 +1,803 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+// runVRpcCapture drives an Invoke call to completion with a stub
+// VirtualRpcResponse, then returns the *VirtualRpcRequest that was sent on the
+// wire. All inspection of the deadline / metadata plumbing is done against
+// this snapshot.
+func runVRpcCapture(t *testing.T, ctx context.Context) *spb.VirtualRpcRequest {
+	t.Helper()
+	s, stream := makeActive(t, SessionHooks{})
+	desc := newRoundTripDesc()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = s.Invoke(ctx, desc, "hello")
+	}()
+
+	waitFor(t, time.Second, func() bool { return len(stream.snapshotSent()) > 0 }, "Send called")
+	sent := stream.snapshotSent()[0].GetVirtualRpc()
+	if sent == nil {
+		t.Fatal("sent frame was not a VirtualRpcRequest")
+	}
+
+	// Deliver a benign success so Invoke returns and the goroutine exits.
+	s.handleVRPCResponse(&spb.VirtualRpcResponse{
+		RpcId:   sent.RpcId,
+		Payload: []byte("ok"),
+	})
+	<-done
+	return sent
+}
+
+func TestInvoke_DeadlineCarriedInRequest(t *testing.T) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(500*time.Millisecond))
+	defer cancel()
+
+	sent := runVRpcCapture(t, ctx)
+	if sent.Deadline == nil {
+		t.Fatal("VirtualRpc.Deadline = nil, want non-nil when ctx carries a deadline")
+	}
+	d := sent.Deadline.AsDuration()
+	if d <= 0 || d > 500*time.Millisecond {
+		t.Errorf("VirtualRpc.Deadline = %v, want in (0, 500ms]", d)
+	}
+	// A negative or absurdly small value would imply we lost most of the
+	// budget to test setup; sanity-bound it.
+	if d < time.Microsecond {
+		t.Errorf("VirtualRpc.Deadline = %v, suspiciously small", d)
+	}
+}
+
+func TestInvoke_NoDeadlineWhenCtxHasNone(t *testing.T) {
+	sent := runVRpcCapture(t, context.Background())
+	if sent.Deadline != nil {
+		t.Errorf("VirtualRpc.Deadline = %v, want nil when ctx has no deadline", sent.Deadline.AsDuration())
+	}
+}
+
+func TestInvoke_AttemptNumberFromCtx(t *testing.T) {
+	// WithAttempt is a no-op unless WithVRpcMetadata has seeded the context
+	// with a vrpcMetadata struct first — that's how the retrying interceptor
+	// uses it in production (the retry loop seeds attempt=1 on entry, then
+	// updates via WithAttempt on each retry).
+	ctx := WithVRpcMetadata(context.Background(), "ReadRow", 1)
+	ctx = WithAttempt(ctx, 7)
+	sent := runVRpcCapture(t, ctx)
+	if sent.Metadata == nil {
+		t.Fatal("VirtualRpc.Metadata = nil")
+	}
+	if got := sent.Metadata.AttemptNumber; got != 7 {
+		t.Errorf("AttemptNumber = %d, want 7", got)
+	}
+}
+
+func TestInvoke_AttemptNumberDefault(t *testing.T) {
+	sent := runVRpcCapture(t, context.Background())
+	if sent.Metadata == nil {
+		t.Fatal("VirtualRpc.Metadata = nil")
+	}
+	if got := sent.Metadata.AttemptNumber; got != 1 {
+		t.Errorf("AttemptNumber = %d, want 1 (calls without WithAttempt should default to first attempt)", got)
+	}
+}
+
+func TestInvoke_AttemptStartIsRecent(t *testing.T) {
+	before := time.Now()
+	sent := runVRpcCapture(t, context.Background())
+	after := time.Now()
+
+	if sent.Metadata == nil || sent.Metadata.AttemptStart == nil {
+		t.Fatal("VirtualRpc.Metadata.AttemptStart = nil")
+	}
+	got := sent.Metadata.AttemptStart.AsTime()
+	// Allow a small slop so wall-clock skew between captures doesn't flake.
+	const slop = 2 * time.Second
+	if got.Before(before.Add(-slop)) || got.After(after.Add(slop)) {
+		t.Errorf("AttemptStart = %v, want within [%v, %v] (slop %v)", got, before, after, slop)
+	}
+}
+
+// --- Invoke: Stats, SentAt, RetryInfo plumbing ------------------------
+
+// runInvoke drives an Invoke call to completion by waiting for the
+// outbound frame, calling deliver(sent) to produce the server response, and
+// returning the populated InvokeResult + err. It mirrors runVRpcCapture but
+// returns the full InvokeResult so tests can assert on Stats / SentAt /
+// ClusterInfo without the back-compat triple stripping them.
+func runInvoke(t *testing.T, ctx context.Context, deliver func(s *Session, sent *spb.VirtualRpcRequest)) (InvokeResult, error) {
+	t.Helper()
+	s, stream := makeActive(t, SessionHooks{})
+	desc := newRoundTripDesc()
+
+	type outcome struct {
+		res InvokeResult
+		err error
+	}
+	resCh := make(chan outcome, 1)
+	go func() {
+		r, err := s.Invoke(ctx, desc, "hello")
+		resCh <- outcome{res: r, err: err}
+	}()
+
+	waitFor(t, time.Second, func() bool { return len(stream.snapshotSent()) > 0 }, "Send called")
+	sent := stream.snapshotSent()[0].GetVirtualRpc()
+	if sent == nil {
+		t.Fatal("sent frame was not a VirtualRpcRequest")
+	}
+	deliver(s, sent)
+	select {
+	case out := <-resCh:
+		return out.res, out.err
+	case <-time.After(time.Second):
+		t.Fatal("Invoke did not return after delivering response")
+		return InvokeResult{}, nil
+	}
+}
+
+func TestInvoke_StatsExtractedFromResponse(t *testing.T) {
+	const wantBackend = 123 * time.Millisecond
+
+	before := time.Now()
+	res, err := runInvoke(t, context.Background(), func(s *Session, sent *spb.VirtualRpcRequest) {
+		s.handleVRPCResponse(&spb.VirtualRpcResponse{
+			RpcId:   sent.RpcId,
+			Payload: []byte("ok"),
+			Stats: &spb.SessionRequestStats{
+				BackendLatency: durationpb.New(wantBackend),
+			},
+		})
+	})
+	if err != nil {
+		t.Fatalf("Invoke: unexpected err %v", err)
+	}
+	if res.Stats == nil {
+		t.Fatal("InvokeResult.Stats = nil, want non-nil (server-supplied Stats must be propagated)")
+	}
+	if got := res.Stats.GetBackendLatency().AsDuration(); got != wantBackend {
+		t.Errorf("InvokeResult.Stats.BackendLatency = %v, want %v", got, wantBackend)
+	}
+	// Sanity bookend on SentAt.
+	if res.SentAt.Before(before) {
+		t.Errorf("SentAt %v < before %v", res.SentAt, before)
+	}
+}
+
+func TestInvoke_StatsNilWhenServerOmits(t *testing.T) {
+	res, err := runInvoke(t, context.Background(), func(s *Session, sent *spb.VirtualRpcRequest) {
+		s.handleVRPCResponse(&spb.VirtualRpcResponse{
+			RpcId:   sent.RpcId,
+			Payload: []byte("ok"),
+			// Stats intentionally nil.
+		})
+	})
+	if err != nil {
+		t.Fatalf("Invoke: unexpected err %v", err)
+	}
+	if res.Stats != nil {
+		t.Errorf("InvokeResult.Stats = %v, want nil when server omits Stats", res.Stats)
+	}
+}
+
+func TestInvoke_SentAtIsNonZero(t *testing.T) {
+	before := time.Now()
+	res, err := runInvoke(t, context.Background(), func(s *Session, sent *spb.VirtualRpcRequest) {
+		s.handleVRPCResponse(&spb.VirtualRpcResponse{
+			RpcId:   sent.RpcId,
+			Payload: []byte("ok"),
+		})
+	})
+	after := time.Now()
+	if err != nil {
+		t.Fatalf("Invoke: unexpected err %v", err)
+	}
+	if res.SentAt.IsZero() {
+		t.Fatal("SentAt is zero after a successful send; want non-zero")
+	}
+	// SentAt must land in the [before, after] window (with a small slop to
+	// tolerate clock skew between samples).
+	const slop = 2 * time.Second
+	if res.SentAt.Before(before.Add(-slop)) || res.SentAt.After(after.Add(slop)) {
+		t.Errorf("SentAt = %v, want within [%v, %v]", res.SentAt, before, after)
+	}
+}
+
+func TestInvoke_SentAtIsSetEvenOnSendFailure(t *testing.T) {
+	// session_vrpc.go captures SentAt *before* calling Send. That is the
+	// contract callers rely on for client-blocking-latency math — we record
+	// when we attempted to hand the frame off, not whether the handoff
+	// succeeded. This test pins that contract: a Send-failure must still
+	// return a non-zero SentAt.
+	stream := newFakeStream()
+	stream.sendFn = func(req *spb.SessionRequest) error {
+		return fmt.Errorf("network down")
+	}
+	s := newTestSession(t, stream, SessionHooks{})
+	s.state.Store(int32(StateReady))
+
+	before := time.Now()
+	res, err := s.Invoke(context.Background(), newRoundTripDesc(), "hello")
+	after := time.Now()
+	if err == nil {
+		t.Fatal("Invoke: expected error from failing Send, got nil")
+	}
+	if res.SentAt.IsZero() {
+		t.Errorf("SentAt is zero after Send failure; want non-zero (session_vrpc.go captures SentAt before calling Send)")
+	}
+	const slop = 2 * time.Second
+	if res.SentAt.Before(before.Add(-slop)) || res.SentAt.After(after.Add(slop)) {
+		t.Errorf("SentAt = %v on Send-failure path; want within [%v, %v]", res.SentAt, before, after)
+	}
+}
+
+func TestInvoke_ClusterInfoOnErrorPath(t *testing.T) {
+	res, err := runInvoke(t, context.Background(), func(s *Session, sent *spb.VirtualRpcRequest) {
+		s.handleVRPCErrorResponse(&spb.ErrorResponse{
+			RpcId:       sent.RpcId,
+			Status:      &rpcstatus.Status{Code: int32(codes.FailedPrecondition), Message: "boom"},
+			ClusterInfo: &spb.ClusterInformation{ClusterId: "c1", ZoneId: "z1"},
+		})
+	})
+	if err == nil {
+		t.Fatal("Invoke returned nil err on ErrorResponse path; want non-nil")
+	}
+	if res.ClusterInfo == nil {
+		t.Fatal("InvokeResult.ClusterInfo = nil on error path; want it preserved from ErrorResponse.ClusterInfo")
+	}
+	if got := res.ClusterInfo.ClusterId; got != "c1" {
+		t.Errorf("ClusterInfo.ClusterId = %q, want %q", got, "c1")
+	}
+	if got := res.ClusterInfo.ZoneId; got != "z1" {
+		t.Errorf("ClusterInfo.ZoneId = %q, want %q", got, "z1")
+	}
+}
+
+func TestInvoke_RetryInfoPackedIntoStatus(t *testing.T) {
+	// Marquee test for the RetryInfo plumbing in handleVRPCErrorResponse:
+	// the server-supplied RetryInfo on ErrorResponse must be packed into the
+	// status details so downstream consumers can recover it via
+	// status.FromError(err).Details(). RetryingVRpc reads it from there.
+	const wantDelay = 250 * time.Millisecond
+
+	_, err := runInvoke(t, context.Background(), func(s *Session, sent *spb.VirtualRpcRequest) {
+		s.handleVRPCErrorResponse(&spb.ErrorResponse{
+			RpcId:     sent.RpcId,
+			Status:    &rpcstatus.Status{Code: int32(codes.Unavailable), Message: "boom"},
+			RetryInfo: &errdetails.RetryInfo{RetryDelay: durationpb.New(wantDelay)},
+		})
+	})
+	if err == nil {
+		t.Fatal("Invoke returned nil err on ErrorResponse path; want non-nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("status.FromError(%v) returned ok=false; want a gRPC status error", err)
+	}
+	if st.Code() != codes.Unavailable {
+		t.Errorf("status.Code = %v, want Unavailable", st.Code())
+	}
+	var found *errdetails.RetryInfo
+	for _, d := range st.Details() {
+		if ri, ok := d.(*errdetails.RetryInfo); ok {
+			found = ri
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("RetryInfo not found in status.Details (%d details total); the handleVRPCErrorResponse plumbing failed to attach it", len(st.Details()))
+	}
+	if got := found.GetRetryDelay().AsDuration(); got != wantDelay {
+		t.Errorf("RetryInfo.RetryDelay = %v, want %v", got, wantDelay)
+	}
+}
+
+// TestHandleVRPCResponse_LateResponseAfterCtxDone_FlagsCancelledDrained
+// pins Java-parity slot-lifecycle: the caller's ctx expires before the
+// server response lands, but the slot stays claimed (markCancelled
+// records the cancel; drainSlot does NOT run in Invoke's return path).
+// The eventual server response drains the slot as a bookkeeping-only
+// tagSessionVRPCCancelledDrained. Sequence exercised:
+//
+//  1. Invoke's claimSlot fills activeRPC and Send goes out.
+//  2. ctx deadline fires; awaitInvokeResult returns via <-ctx.Done()
+//     after markCancelled records the cancel result.
+//  3. activeVRPC() is STILL non-nil — Java parity, unlike the pre-
+//     slotMu behavior where a defer releaseSlot cleared it.
+//  4. The server's response for that rpc_id lands moments later —
+//     handleVRPCResponse calls drainSlot, sees currentCancel != nil,
+//     records tagSessionVRPCCancelledDrained, and does NOT deliver
+//     (no reader on resultChan).
+//
+// Not a bug: the vRPC protocol has no "unsubscribe rpc_id" primitive,
+// so the server keeps sending. The counter is a canary — a rising rate
+// under steady load usually means tail-latency spikes are pushing more
+// callers onto the ctx.Done branch. This test locks in that the drain
+// is counted (dashboard-visible) and does NOT emit any of the
+// sibling vRPC tags (nil / id-mismatch / wrong-state).
+func TestHandleVRPCResponse_LateResponseAfterCtxDone_FlagsCancelledDrained(t *testing.T) {
+	resetDebugTagCountsForTest()
+
+	s, stream := makeActive(t, SessionHooks{})
+	desc := newRoundTripDesc()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := s.Invoke(ctx, desc, "req")
+		done <- err
+	}()
+
+	// Wait for the request to hit the wire so we know claimSlot filled
+	// the slot and rpc_id is knowable from the sent frame.
+	waitFor(t, time.Second, func() bool { return len(stream.snapshotSent()) > 0 }, "Send called")
+	sent := stream.snapshotSent()[0].GetVirtualRpc()
+	if sent == nil {
+		t.Fatal("sent frame was not a VirtualRpcRequest")
+	}
+
+	// Let ctx expire; Invoke must return with DeadlineExceeded.
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Invoke err = %v, want DeadlineExceeded", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Invoke did not return within outer bound")
+	}
+
+	// Java-parity precondition: slot STAYS claimed even after Invoke
+	// returned via ctx.Done. This is the observable divergence from
+	// the pre-slotMu behavior — any future PR that reverts to
+	// client-side release must fail this assertion.
+	if got := s.activeVRPC(); got == nil {
+		t.Fatal("activeVRPC = nil after Invoke returned via ctx.Done; want the slot to stay claimed (Java-parity: only drainSlot releases it)")
+	}
+
+	// Snapshot the counter just before the late-response injection so we
+	// isolate the drain tick from any prior emissions.
+	before := snapshotDebugTagCounts()
+
+	// The server's response finally arrives — the drain path checks
+	// currentCancel, sees it set, and records the cancelled-drained tag.
+	s.handleVRPCResponse(&spb.VirtualRpcResponse{
+		RpcId:   sent.RpcId,
+		Payload: []byte("ok"),
+	})
+
+	after := snapshotDebugTagCounts()
+	if delta := after[tagSessionVRPCCancelledDrained] - before[tagSessionVRPCCancelledDrained]; delta != 1 {
+		t.Errorf("tagSessionVRPCCancelledDrained delta = %d, want 1 (server response for a cancelled slot should drain and count)", delta)
+	}
+	// Sibling vRPC-drop tags must stay flat — the drain reason is
+	// "caller abandoned via ctx.Done", not nil-slot / id-mismatch /
+	// wrong-state.
+	for _, tag := range []string{
+		tagSessionVRPCNil,
+		tagSessionVRPCIDMismatch,
+		tagSessionVRPCResponseWrongState,
+	} {
+		if delta := after[tag] - before[tag]; delta != 0 {
+			t.Errorf("%s delta = %d, want 0 (only cancelled-drained tag should fire on this race)", tag, delta)
+		}
+	}
+
+	// Post-drain: slot must be empty so the next Invoke can claim.
+	if got := s.activeVRPC(); got != nil {
+		t.Errorf("activeVRPC = %p, want nil after drainSlot ran on the late server response", got)
+	}
+}
+
+// TestInvoke_SecondInvokeAfterCtxDoneRejectedUncommitted pins the
+// Java-parity claim rejection (SessionImpl.startRpc L423 —
+// currentRpc != null → INTERNAL "RPC multiplexing not supported").
+// Sequence exercised:
+//
+//  1. Invoke #1 → claimSlot → Send(rpc_A).
+//  2. ctx#1 expires → Invoke #1 returns → markCancelled leaves slot claimed.
+//  3. Invoke #2 → claimSlot returns false → immediate Uncommitted error,
+//     Send is never called (no rpc_B on the wire, no rpc_id burned).
+//  4. Server response for rpc_A drains the slot.
+//  5. A fresh Invoke #3 can now claim and proceed normally.
+//
+// This is the Java-parity replacement for the pre-slotMu
+// TestHandleVRPCResponse_LateResponseAfterCtxDoneAndNewInvoke_FlagsIDMismatch
+// (which pinned the client-only slot-release divergence). Any future PR
+// that reverts to client-side release must break this test — the second
+// Invoke would succeed and race to an id-mismatch drop instead.
+func TestInvoke_SecondInvokeAfterCtxDoneRejectedUncommitted(t *testing.T) {
+	resetDebugTagCountsForTest()
+
+	s, stream := makeActive(t, SessionHooks{})
+	desc := newRoundTripDesc()
+
+	// --- Invoke #1: run to ctx.Done. ---
+	ctx1, cancel1 := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel1()
+
+	done1 := make(chan error, 1)
+	go func() {
+		_, err := s.Invoke(ctx1, desc, "req-A")
+		done1 <- err
+	}()
+
+	waitFor(t, time.Second, func() bool { return len(stream.snapshotSent()) > 0 }, "Invoke #1 Send")
+	sentA := stream.snapshotSent()[0].GetVirtualRpc()
+	if sentA == nil {
+		t.Fatal("Invoke #1 sent frame was not a VirtualRpcRequest")
+	}
+
+	select {
+	case err := <-done1:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Invoke #1 err = %v, want DeadlineExceeded", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Invoke #1 did not return within outer bound")
+	}
+
+	// Slot still claimed — Java parity.
+	if got := s.activeVRPC(); got == nil {
+		t.Fatal("activeVRPC = nil after Invoke #1 returned via ctx.Done; want slot held")
+	}
+
+	// --- Invoke #2: must fail immediately with Uncommitted. ---
+	sentBefore := len(stream.snapshotSent())
+	_, err := s.Invoke(context.Background(), desc, "req-B")
+	if err == nil {
+		t.Fatal("Invoke #2 succeeded with slot busy; want Uncommitted error")
+	}
+	if outcome := ClassifyErr(err); outcome.State != StateUncommitted {
+		t.Errorf("Invoke #2 err classified as %v, want StateUncommitted (Java parity: retryer must be free to pick another session)", outcome.State)
+	}
+	if got := len(stream.snapshotSent()); got != sentBefore {
+		t.Errorf("Invoke #2 sent %d frames beyond Invoke #1; want 0 (Send must not fire on a losing claim, or rpc_id burn / wire noise ensues)", got-sentBefore)
+	}
+
+	// --- Step 4: drain the slot with the late rpc_A response. ---
+	s.handleVRPCResponse(&spb.VirtualRpcResponse{
+		RpcId:   sentA.RpcId,
+		Payload: []byte("stale-A"),
+	})
+	if got := s.activeVRPC(); got != nil {
+		t.Fatalf("activeVRPC = %p after draining rpc_A; want nil", got)
+	}
+
+	// --- Step 5: a fresh Invoke succeeds. ---
+	done3 := make(chan struct {
+		res InvokeResult
+		err error
+	}, 1)
+	go func() {
+		res, err := s.Invoke(context.Background(), desc, "req-C")
+		done3 <- struct {
+			res InvokeResult
+			err error
+		}{res, err}
+	}()
+	waitFor(t, time.Second, func() bool { return len(stream.snapshotSent()) > sentBefore }, "Invoke #3 Send")
+	sentC := stream.snapshotSent()[len(stream.snapshotSent())-1].GetVirtualRpc()
+	if sentC == nil {
+		t.Fatal("Invoke #3 sent frame was not a VirtualRpcRequest")
+	}
+	s.handleVRPCResponse(&spb.VirtualRpcResponse{RpcId: sentC.RpcId, Payload: []byte("ok-C")})
+	select {
+	case r := <-done3:
+		if r.err != nil {
+			t.Fatalf("Invoke #3 err = %v, want nil after fresh claim", r.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Invoke #3 did not return after rpc_C delivered")
+	}
+}
+
+// TestHandleVRPCResponse_NormalDrain_FiresSlotDrainedCallback pins the v3
+// invariant: EVERY successful drainSlot fires hooks.OnSlotDrained — not
+// just the cancelled-drain branch. Under v3 this hook is the sole
+// "session became free" signal (the pool's Invoke return path no
+// longer re-enqueues or wakes), so dropping the fire on the normal
+// branch would leave the AFE queue with a stale outstanding-in-flight
+// session and starve parked Checkout waiters. Sequence exercised:
+//
+//  1. Invoke's claimSlot fills activeRPC and Send goes out.
+//  2. The server responds cleanly for that rpc_id — drainSlot returns
+//     cancel=nil (normal happy path), deliver fires, Invoke returns.
+//  3. OnSlotDrained runs exactly once (never zero — starves the pool;
+//     never twice — a double-add to the AFE queue).
+func TestHandleVRPCResponse_NormalDrain_FiresSlotDrainedCallback(t *testing.T) {
+	// Install a counting slot-drained hook. Same pattern
+	// SessionPoolImpl.createSession uses — a real pool wires this to
+	// sl.ReleaseToPool + signalFree; here we count fires to prove the
+	// wire is live for the normal-drain branch, not just cancelled-drain.
+	fires := make(chan struct{}, 4)
+	s, stream := makeActive(t, SessionHooks{OnSlotDrained: func() { fires <- struct{}{} }})
+	desc := newRoundTripDesc()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := s.Invoke(context.Background(), desc, "req")
+		done <- err
+	}()
+
+	waitFor(t, time.Second, func() bool { return len(stream.snapshotSent()) > 0 }, "Send called")
+	sent := stream.snapshotSent()[0].GetVirtualRpc()
+	if sent == nil {
+		t.Fatal("sent frame was not a VirtualRpcRequest")
+	}
+
+	s.handleVRPCResponse(&spb.VirtualRpcResponse{
+		RpcId:   sent.RpcId,
+		Payload: []byte("ok"),
+	})
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Invoke err = %v, want nil (normal-drain path)", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Invoke did not return after normal drain")
+	}
+
+	// Exactly one fire — the normal-drain branch MUST fire
+	// OnSlotDrained (v3), and MUST NOT double-fire.
+	select {
+	case <-fires:
+	case <-time.After(time.Second):
+		t.Fatal("onSlotDrained did not fire on normal-drain branch; v3 invariant violated (pool would never learn the session is free)")
+	}
+	select {
+	case <-fires:
+		t.Error("onSlotDrained fired twice for a single drainSlot success; would double-enqueue in the AFE queue")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// TestHandleVRPCErrorResponse_NormalDrain_FiresSlotDrainedCallback
+// mirrors the response test on the error-frame branch — a definitive
+// server ErrorResponse also drains the slot and MUST fire
+// onSlotDrained under v3. Regression coverage: dropping the fire on
+// the error branch would create a subtle asymmetry where sessions
+// that see a server ErrorResponse never come back to the AFE queue.
+func TestHandleVRPCErrorResponse_NormalDrain_FiresSlotDrainedCallback(t *testing.T) {
+	fires := make(chan struct{}, 4)
+	s, stream := makeActive(t, SessionHooks{OnSlotDrained: func() { fires <- struct{}{} }})
+	desc := newRoundTripDesc()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := s.Invoke(context.Background(), desc, "req")
+		done <- err
+	}()
+
+	waitFor(t, time.Second, func() bool { return len(stream.snapshotSent()) > 0 }, "Send called")
+	sent := stream.snapshotSent()[0].GetVirtualRpc()
+	if sent == nil {
+		t.Fatal("sent frame was not a VirtualRpcRequest")
+	}
+
+	s.handleVRPCErrorResponse(&spb.ErrorResponse{
+		RpcId:  sent.RpcId,
+		Status: &rpcstatus.Status{Code: int32(codes.FailedPrecondition), Message: "boom"},
+	})
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Invoke err = nil on ErrorResponse; want non-nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Invoke did not return after ErrorResponse drain")
+	}
+
+	select {
+	case <-fires:
+	case <-time.After(time.Second):
+		t.Fatal("onSlotDrained did not fire on error-drain branch; v3 invariant violated")
+	}
+	select {
+	case <-fires:
+		t.Error("onSlotDrained fired twice for a single error drainSlot success")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// TestInvoke_SendFailure_FiresSlotDrainedCallback pins that the
+// Send-failure Invoke branch fires OnSlotDrained after drainSlot.
+// This is the third drainSlot site under v3; without the fire, a
+// pool with all sessions on a broken stream would silently starve
+// parked Checkout waiters (ReleaseToPool would still no-op via the
+// inExpectedCount guard once OnSessionClosing fired, but the
+// signalFree side of the hook matters for the waiter that was
+// parked before the stream broke).
+func TestInvoke_SendFailure_FiresSlotDrainedCallback(t *testing.T) {
+	stream := newFakeStream()
+	stream.sendFn = func(req *spb.SessionRequest) error {
+		return fmt.Errorf("network down")
+	}
+	fires := make(chan struct{}, 2)
+	s := newTestSession(t, stream, SessionHooks{OnSlotDrained: func() { fires <- struct{}{} }})
+	s.state.Store(int32(StateReady))
+
+	_, err := s.Invoke(context.Background(), newRoundTripDesc(), "req")
+	if err == nil {
+		t.Fatal("Invoke: expected err from failing Send")
+	}
+
+	select {
+	case <-fires:
+	case <-time.After(time.Second):
+		t.Fatal("onSlotDrained did not fire on Send-failure branch; v3 requires drain-driven wake here too")
+	}
+}
+
+// TestInvoke_ForceCloseRace_BoundedReturnUnderCtx pins the race between
+// Invoke's initial state check (session_vrpc.go:87) and its activeVRPC
+// CAS (session_vrpc.go:107). If ForceClose lands in that window the CAS
+// still succeeds afterwards: Invoke Sends onto a still-open stream and
+// blocks on rpc.resultChan. cancelActiveRPCs already ran on the nil
+// slot, so nobody delivers a terminal error — awaitInvokeResult only
+// unblocks via ctx.
+//
+// Contract enforced here: with a bounded ctx, Invoke MUST return within
+// that ctx's deadline regardless of how the race resolves. A caller
+// without a ctx deadline could hang indefinitely on this path — that is
+// the known L1 limitation flagged for the sync-refactor decision
+// (POC on branch experiment/session-sync-context-poc). This test does
+// NOT prove the hang is impossible; it proves the ctx-bounded return
+// is honored under stress.
+func TestInvoke_ForceCloseRace_BoundedReturnUnderCtx(t *testing.T) {
+	const iterations = 200
+	const perAttemptCtx = 200 * time.Millisecond
+	const outerBound = 2 * time.Second
+
+	for i := 0; i < iterations; i++ {
+		s, _ := makeActive(t, SessionHooks{})
+
+		ctx, cancel := context.WithTimeout(context.Background(), perAttemptCtx)
+		done := make(chan error, 1)
+
+		go func() {
+			_, err := s.Invoke(ctx, newRoundTripDesc(), "req")
+			done <- err
+		}()
+
+		// Fire ForceClose concurrently. The race window between the
+		// state Load and the activeVRPC CAS is a handful of ns — we
+		// don't try to hit it deterministically; we run enough
+		// iterations that the scheduler puts us on different sides of
+		// it across runs. Under -race -count=1000 this shakes out any
+		// unbounded-hang regression.
+		go s.ForceClose(&spb.CloseSessionRequest{
+			Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_USER,
+			Description: "race-test teardown",
+		})
+
+		select {
+		case err := <-done:
+			cancel()
+			if err == nil {
+				// A benign success is legal if Invoke completed before
+				// ForceClose cancelled anything. Not a regression.
+				continue
+			}
+			// Every terminal error MUST be one of the four expected
+			// classifications. An unclassified err would silently
+			// escape ClassifyErr and confuse the retry oracle.
+			outcome := ClassifyErr(err)
+			switch outcome.State {
+			case StateUncommitted, StateTransportFailure, StateServerResult:
+				// OK: classified terminal.
+			default:
+				t.Fatalf("iter %d: err %v classified as %v — want Uncommitted/TransportFailure/ServerResult",
+					i, err, outcome.State)
+			}
+			// Ctx cancel is the safety net; if it fired, verify the
+			// wrapped err carries a recognizable cause so operators
+			// aren't left with a bare context.DeadlineExceeded.
+			if errors.Is(err, context.DeadlineExceeded) {
+				// Ctx-bounded return. Expected on the L1-race branch.
+				continue
+			}
+		case <-time.After(outerBound):
+			cancel()
+			t.Fatalf("iter %d: Invoke did not return within %v (L1 unbounded-hang regression)", i, outerBound)
+		}
+	}
+}
+
+// TestInvoke_ForceCloseWhileSending_BoundedReturn constructs a
+// deterministic variant of the ForceClose race: ForceClose fires while
+// Send is mid-flight (past the state check AND past the CAS but not
+// yet past awaitInvokeResult's channel wait). Uses fakeStream.sendFn
+// to block Send, injects ForceClose while blocked, then unblocks Send
+// and verifies Invoke returns within ctx.
+//
+// This nails the "CAS succeeded, Send succeeded, session got closed
+// under us" path — the classic cancelActiveRPCs → StateTransportFailure
+// delivery on resultChan. If cancelActiveRPCs raced the CAS wrong, the
+// slot would be nil at cancel time and no delivery would land, causing
+// the ctx-bounded return branch below to fire instead.
+func TestInvoke_ForceCloseWhileSending_BoundedReturn(t *testing.T) {
+	s, stream := makeActive(t, SessionHooks{})
+
+	sendGate := make(chan struct{})
+	var once sync.Once
+	stream.sendFn = func(*spb.SessionRequest) error {
+		once.Do(func() { <-sendGate })
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := s.Invoke(ctx, newRoundTripDesc(), "req")
+		done <- err
+	}()
+
+	// Wait for Invoke to be blocked in Send (activeVRPC set, sendMu held).
+	waitFor(t, time.Second, func() bool { return s.activeVRPC() != nil }, "activeVRPC claimed")
+
+	// Fire ForceClose while Send is blocked. cancelActiveRPCs will
+	// find the slot claimed, CAS it back to nil, and deliver
+	// StateTransportFailure on resultChan. Meanwhile Invoke is still
+	// blocked inside Send — the delivery is buffered (chan cap 1).
+	go s.ForceClose(&spb.CloseSessionRequest{
+		Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_USER,
+		Description: "mid-send teardown",
+	})
+
+	// Give ForceClose a moment to run before unblocking Send so the
+	// race resolves in the intended order.
+	time.Sleep(20 * time.Millisecond)
+	close(sendGate)
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Invoke returned nil err after ForceClose; want an error")
+		}
+		outcome := ClassifyErr(err)
+		// Expected: TransportFailure from cancelActiveRPCs delivery.
+		// Also acceptable if ctx fired first (still bounded).
+		if outcome.State != StateTransportFailure && !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("err classified as %v (%v); want StateTransportFailure or ctx.DeadlineExceeded",
+				outcome.State, err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Invoke did not return within 3s after ForceClose + unblocked Send")
+	}
+}

--- a/bigtable/internal/transport/session_vrpc_test.go
+++ b/bigtable/internal/transport/session_vrpc_test.go
@@ -662,6 +662,105 @@ func TestInvoke_SendFailure_FiresSlotDrainedCallback(t *testing.T) {
 	}
 }
 
+// TestHandleVRPCResponse_IDMismatch_TearsDownSession pins the
+// mutianf-review fix on #20213: an rpc_id in a server response that
+// doesn't match the active vRPC's id is a genuine protocol desync —
+// silently dropping the frame leaves the caller waiting on a session
+// the server has already decided is done with the prior call.
+// routeVRPCFrame must escalate: cancelActiveRPCs delivers a terminal
+// error to the current caller so the retry oracle picks another
+// session/AFE instead of blocking on ctx timeout.
+func TestHandleVRPCResponse_IDMismatch_TearsDownSession(t *testing.T) {
+	s, stream := makeActive(t, SessionHooks{})
+	desc := newRoundTripDesc()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := s.Invoke(context.Background(), desc, "req")
+		done <- err
+	}()
+
+	waitFor(t, time.Second, func() bool { return len(stream.snapshotSent()) > 0 }, "Send called")
+	sent := stream.snapshotSent()[0].GetVirtualRpc()
+	if sent == nil {
+		t.Fatal("sent frame was not a VirtualRpcRequest")
+	}
+
+	// Server responds with a DIFFERENT rpc_id — the mismatch scenario.
+	s.handleVRPCResponse(&spb.VirtualRpcResponse{
+		RpcId:   sent.RpcId + 99, // deliberate mismatch
+		Payload: []byte("ok"),
+	})
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Invoke returned nil; id-mismatch must escalate to caller error")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Invoke did not return after id-mismatch — caller left hanging (bug this test pins)")
+	}
+}
+
+// TestHandleVRPCResponse_WrongState_TearsDownSession pins the same
+// mutianf-review scenario for frames that arrive when the session is
+// not in Ready / Closing / WaitServerClose. That combination means the
+// readLoop is running in a state it shouldn't be (client state
+// tracking bug or server retransmit long after Closed). Escalate
+// rather than drop.
+func TestHandleVRPCResponse_WrongState_TearsDownSession(t *testing.T) {
+	s, stream := makeActive(t, SessionHooks{})
+	desc := newRoundTripDesc()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := s.Invoke(context.Background(), desc, "req")
+		done <- err
+	}()
+
+	waitFor(t, time.Second, func() bool { return len(stream.snapshotSent()) > 0 }, "Send called")
+	sent := stream.snapshotSent()[0].GetVirtualRpc()
+
+	// Force state to Closed (a state routeVRPCFrame does NOT accept).
+	s.state.Store(int32(StateClosed))
+
+	// Server response arrives in the wrong state.
+	s.handleVRPCResponse(&spb.VirtualRpcResponse{
+		RpcId:   sent.RpcId,
+		Payload: []byte("ok"),
+	})
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Invoke returned nil; wrong-state frame must escalate to caller error")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Invoke did not return after wrong-state — caller left hanging")
+	}
+}
+
+// TestHandleVRPCResponse_NilRPC_DoesNotTearDown pins the third scenario
+// mutianf raised: a frame arriving while activeVRPC is nil is a legit
+// race (caller ctx.Done'd and cancelled the slot; server response
+// arrived after). This must NOT tear down a healthy session — the next
+// caller can still use it. Only the frame is dropped.
+func TestHandleVRPCResponse_NilRPC_DoesNotTearDown(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+
+	// No active vRPC — activeVRPC() will return nil.
+	s.handleVRPCResponse(&spb.VirtualRpcResponse{
+		RpcId:   42,
+		Payload: []byte("ok"),
+	})
+
+	// Session must still be Ready — nil-active-vRPC is a legit race,
+	// not a protocol violation.
+	if got := State(s.state.Load()); got != StateReady {
+		t.Errorf("session state after nil-rpc drop = %s, want Ready (should not tear down)", got)
+	}
+}
+
 // TestInvoke_ForceCloseRace_BoundedReturnUnderCtx pins the race between
 // Invoke's initial state check (session_vrpc.go:87) and its activeVRPC
 // CAS (session_vrpc.go:107). If ForceClose lands in that window the CAS

--- a/bigtable/internal/transport/session_vrpc_test.go
+++ b/bigtable/internal/transport/session_vrpc_test.go
@@ -662,14 +662,28 @@ func TestInvoke_SendFailure_FiresSlotDrainedCallback(t *testing.T) {
 	}
 }
 
+// containsEventOfKind reports whether the session's per-session event
+// ring contains at least one entry matching kind. Used by the
+// protocol-error/late-frame tests to assert the event was recorded
+// alongside the observable Invoke outcome.
+func containsEventOfKind(events []SessionEvent, kind SessionEventKind) bool {
+	for _, e := range events {
+		if e.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
 // TestHandleVRPCResponse_IDMismatch_TearsDownSession pins the
 // mutianf-review fix on #20213: an rpc_id in a server response that
 // doesn't match the active vRPC's id is a genuine protocol desync —
 // silently dropping the frame leaves the caller waiting on a session
 // the server has already decided is done with the prior call.
-// routeVRPCFrame must escalate: cancelActiveRPCs delivers a terminal
-// error to the current caller so the retry oracle picks another
-// session/AFE instead of blocking on ctx timeout.
+// routeVRPCFrame must escalate via ForceClose so the caller gets a
+// terminal error, the pool's OnClosing/OnClose hooks fire, and the
+// session leaves the AFE routing set (cancelActiveRPCs alone would
+// leave a Ready session orphaned from the AFE queue).
 func TestHandleVRPCResponse_IDMismatch_TearsDownSession(t *testing.T) {
 	s, stream := makeActive(t, SessionHooks{})
 	desc := newRoundTripDesc()
@@ -692,13 +706,23 @@ func TestHandleVRPCResponse_IDMismatch_TearsDownSession(t *testing.T) {
 		Payload: []byte("ok"),
 	})
 
+	var invokeErr error
 	select {
-	case err := <-done:
-		if err == nil {
+	case invokeErr = <-done:
+		if invokeErr == nil {
 			t.Fatal("Invoke returned nil; id-mismatch must escalate to caller error")
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Invoke did not return after id-mismatch — caller left hanging (bug this test pins)")
+	}
+	if code := status.Code(invokeErr); code != codes.Unavailable {
+		t.Errorf("Invoke err status.Code = %s, want Unavailable (id-mismatch tear-down surfaces via cancelActiveRPCs → unavailable)", code)
+	}
+	if got := State(s.state.Load()); got != StateClosed {
+		t.Errorf("session state after id-mismatch = %s, want Closed (ForceClose must fire so pool removes session from routing)", got)
+	}
+	if !containsEventOfKind(s.snapshotEvents(), SessionEventProtocolError) {
+		t.Error("session event ring missing SessionEventProtocolError entry — observability regression")
 	}
 }
 
@@ -706,8 +730,8 @@ func TestHandleVRPCResponse_IDMismatch_TearsDownSession(t *testing.T) {
 // mutianf-review scenario for frames that arrive when the session is
 // not in Ready / Closing / WaitServerClose. That combination means the
 // readLoop is running in a state it shouldn't be (client state
-// tracking bug or server retransmit long after Closed). Escalate
-// rather than drop.
+// tracking bug). Escalate via ForceClose so the OnClosing hook fires
+// and the pool removes the session from routing.
 func TestHandleVRPCResponse_WrongState_TearsDownSession(t *testing.T) {
 	s, stream := makeActive(t, SessionHooks{})
 	desc := newRoundTripDesc()
@@ -721,8 +745,12 @@ func TestHandleVRPCResponse_WrongState_TearsDownSession(t *testing.T) {
 	waitFor(t, time.Second, func() bool { return len(stream.snapshotSent()) > 0 }, "Send called")
 	sent := stream.snapshotSent()[0].GetVirtualRpc()
 
-	// Force state to Closed (a state routeVRPCFrame does NOT accept).
-	s.state.Store(int32(StateClosed))
+	// Force state to Starting — a state routeVRPCFrame does NOT accept,
+	// and one ForceClose CAN transition from (unlike Closed, which
+	// early-returns; a stray frame in Closed is a real edge case but
+	// its caller is by definition already unblocked by the prior
+	// teardown that put us in Closed).
+	s.state.Store(int32(StateStarting))
 
 	// Server response arrives in the wrong state.
 	s.handleVRPCResponse(&spb.VirtualRpcResponse{
@@ -730,13 +758,23 @@ func TestHandleVRPCResponse_WrongState_TearsDownSession(t *testing.T) {
 		Payload: []byte("ok"),
 	})
 
+	var invokeErr error
 	select {
-	case err := <-done:
-		if err == nil {
+	case invokeErr = <-done:
+		if invokeErr == nil {
 			t.Fatal("Invoke returned nil; wrong-state frame must escalate to caller error")
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Invoke did not return after wrong-state — caller left hanging")
+	}
+	if code := status.Code(invokeErr); code != codes.Unavailable {
+		t.Errorf("Invoke err status.Code = %s, want Unavailable", code)
+	}
+	if got := State(s.state.Load()); got != StateClosed {
+		t.Errorf("session state after wrong-state escalation = %s, want Closed (ForceClose must run)", got)
+	}
+	if !containsEventOfKind(s.snapshotEvents(), SessionEventProtocolError) {
+		t.Error("session event ring missing SessionEventProtocolError entry — observability regression")
 	}
 }
 
@@ -744,7 +782,10 @@ func TestHandleVRPCResponse_WrongState_TearsDownSession(t *testing.T) {
 // mutianf raised: a frame arriving while activeVRPC is nil is a legit
 // race (caller ctx.Done'd and cancelled the slot; server response
 // arrived after). This must NOT tear down a healthy session — the next
-// caller can still use it. Only the frame is dropped.
+// caller can still use it. Only the frame is dropped, and the event is
+// tagged SessionEventLateFrame (NOT SessionEventProtocolError — Igor's
+// review nit: mixing the two would swamp desync alerts with benign
+// races).
 func TestHandleVRPCResponse_NilRPC_DoesNotTearDown(t *testing.T) {
 	s, _ := makeActive(t, SessionHooks{})
 
@@ -758,6 +799,92 @@ func TestHandleVRPCResponse_NilRPC_DoesNotTearDown(t *testing.T) {
 	// not a protocol violation.
 	if got := State(s.state.Load()); got != StateReady {
 		t.Errorf("session state after nil-rpc drop = %s, want Ready (should not tear down)", got)
+	}
+	events := s.snapshotEvents()
+	if !containsEventOfKind(events, SessionEventLateFrame) {
+		t.Error("session event ring missing SessionEventLateFrame entry — observability regression")
+	}
+	if containsEventOfKind(events, SessionEventProtocolError) {
+		t.Error("nil-rpc drop must NOT emit SessionEventProtocolError — kind split preserves signal:noise for desync grep")
+	}
+}
+
+// TestHandleVRPCResponse_ClosingState_AcceptsMatchingFrame pins the
+// state-whitelist widening — the addition of Closing + WaitServerClose
+// to the accept-set needs coverage, otherwise a future tightening of
+// the whitelist reverts silently. In Closing, in-flight vRPCs must
+// still be able to receive their response so the drain completes
+// gracefully.
+func TestHandleVRPCResponse_ClosingState_AcceptsMatchingFrame(t *testing.T) {
+	s, stream := makeActive(t, SessionHooks{})
+	desc := newRoundTripDesc()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := s.Invoke(context.Background(), desc, "req")
+		done <- err
+	}()
+
+	waitFor(t, time.Second, func() bool { return len(stream.snapshotSent()) > 0 }, "Send called")
+	sent := stream.snapshotSent()[0].GetVirtualRpc()
+
+	// Simulate the graceful-close drain window: state is Closing but
+	// active vRPC still exists and the server's response is inbound.
+	s.state.Store(int32(StateClosing))
+
+	s.handleVRPCResponse(&spb.VirtualRpcResponse{
+		RpcId:   sent.RpcId,
+		Payload: []byte("ok"),
+	})
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Invoke err = %v, want nil (Closing must accept matching frames during drain)", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Invoke did not return after matching-id delivery in Closing")
+	}
+	if containsEventOfKind(s.snapshotEvents(), SessionEventProtocolError) {
+		t.Error("Closing must not classify matching frames as protocol errors")
+	}
+}
+
+// TestHandleVRPCResponse_WaitServerCloseState_AcceptsMatchingFrame is
+// the WaitServerClose sibling of the Closing test. WSC is the drain
+// window between our CloseSession send and the server's EOF; late
+// responses for in-flight vRPCs land here legitimately.
+func TestHandleVRPCResponse_WaitServerCloseState_AcceptsMatchingFrame(t *testing.T) {
+	s, stream := makeActive(t, SessionHooks{})
+	desc := newRoundTripDesc()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := s.Invoke(context.Background(), desc, "req")
+		done <- err
+	}()
+
+	waitFor(t, time.Second, func() bool { return len(stream.snapshotSent()) > 0 }, "Send called")
+	sent := stream.snapshotSent()[0].GetVirtualRpc()
+
+	// Force state to WaitServerClose (post-CloseSession-send drain).
+	s.state.Store(int32(StateWaitServerClose))
+
+	s.handleVRPCResponse(&spb.VirtualRpcResponse{
+		RpcId:   sent.RpcId,
+		Payload: []byte("ok"),
+	})
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Invoke err = %v, want nil (WaitServerClose must accept matching frames during drain)", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Invoke did not return after matching-id delivery in WaitServerClose")
+	}
+	if containsEventOfKind(s.snapshotEvents(), SessionEventProtocolError) {
+		t.Error("WaitServerClose must not classify matching frames as protocol errors")
 	}
 }
 


### PR DESCRIPTION
## Summary

Second PR in a 3-PR stack layering Session behavior on top of the merged Session struct (#20117). Adds \`Session.Invoke\` and the one-in-flight vRPC dispatch that routes server frames back to callers.

**Stacked on** #20211 (Session debug surface) — this PR's counter/tracer/event writers wire up the fields introduced there.

### What lands

**New file: \`session_vrpc.go\`** (~420 LOC)
- \`Session.Invoke\` — public entry point. Serializes \`claimSlot\` → \`Send\` → \`awaitInvokeResult\`; deliver-vs-cancel branching lives in \`routeVRPCFrame\`.
- Slot lifecycle: \`claimSlot\` / \`drainSlot\` / \`markCancelled\` / \`activeVRPC\` — \`slotMu\`-guarded, one vRPC in flight per session.
- \`handleVRPCResponse\` / \`handleVRPCErrorResponse\` + shared \`routeVRPCFrame\` — Java-parity drain path with nil-active-VRPC + id-mismatch guards.
- \`deliver\` — writes to the caller's \`resultChan\`.
- \`cancelActiveRPCs\` — session-teardown path used by \`ForceClose\` / \`handleGoAway\` / heartbeat watchdog.
- \`ForceClose\` — minimal port (\`transitionTo(Closed) → cancelActiveRPCs → signalQuiescent\`). The full lifecycle-flavored \`ForceClose\` (setCloseReason + notifyClosing + notifyClosed + stream cleanup) lands with the follow-up lifecycle PR.

**New file: \`session_vrpc_test.go\`** (~800 LOC) — 18 \`TestInvoke*\`/\`TestHandleVRPC*\` tests, all green under \`-race\`.

**Edits to \`session.go\`**
- \`heartbeatWake chan struct{}\` field (cap-1 non-blocking) + \`make(...)\` in \`NewSession\` — reactive watchdog wake channel.
- \`OnSlotDrained func()\` field on \`SessionHooks\` + \`onSlotDrained()\` dispatcher. Sole "session became free" signal; consumers wake pool waiters.
- \`Send(req)\` — mutex-guarded \`stream.Send\` wrapper. Used by this PR's \`Invoke\` and the follow-up lifecycle \`Start\`.
- \`resetHeartbeatDeadline\` + \`wakeHeartbeatLoop\` — atomic-based reactive wake pair; consumed by the follow-up lifecycle \`heartBeatLoop\`.

**Edits to \`session_test.go\`**
- Test fixtures: \`fakeStream\` / \`fakeDesc\` / \`newFakeStream\` / \`newRoundTripDesc\` / \`makeActive\` / \`waitFor\`. Consumed by both this PR's tests and the follow-up lifecycle tests.
- \`newTestSession\` signature change (\`stream, hooks\`); pre-existing 1-arg call sites now use \`newDefaultTestSession\` shortcut.

**Edits to \`debug_tracer.go\`**
- \`tagSessionVRPCCancelledDrained\` — bookkeeping tag when a server response drains a slot whose caller already \`ctx.Done\`'d.

### Stack

1. #20211 — Session debug surface (merged into origin/bigtable-session-debug)
2. **This PR** — Session vRPC dispatch + slot lifecycle
3. Next — \`session_lifecycle.go\` (Start, Close, readLoop, heartBeatLoop, handleSessionResponse/OpenSession/GoAway/Close/ErrorResponse, peerInfoExtracter). Will extend \`ForceClose\` to its full lifecycle-shaped body.

## Test plan
- [x] \`go build ./internal/transport/\` passes
- [x] \`go vet ./internal/transport/\` clean
- [x] \`go test ./internal/transport/ -race -count=1 -short -timeout 90s\` passes — 18 new \`TestInvoke*\`/\`TestHandleVRPC*\` tests plus all pre-existing tests