### PR TITLE
chore(datastore): add snippet metadata to extra-files in release-please config

### DIFF
--- a/datastore/examples/admin/apiv1/snippet_metadata.google.datastore.admin.v1.json
+++ b/datastore/examples/admin/apiv1/snippet_metadata.google.datastore.admin.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/datastore/admin/apiv1",
-    "version": "1.25.0"
+    "version": "1.26.0"
   },
   "snippets": [
     {

--- a/release-please-bulk-config.json
+++ b/release-please-bulk-config.json
@@ -829,7 +829,14 @@
       ]
     },
     "datastore": {
-      "component": "datastore"
+      "component": "datastore",
+      "extra-files": [
+        {
+          "jsonpath": "$.clientLibrary.version",
+          "path": "examples/admin/apiv1/snippet_metadata.google.datastore.admin.v1.json",
+          "type": "json"
+        }
+      ]
     },
     "datastream": {
       "component": "datastream",


### PR DESCRIPTION
Add `extra-files` for `datastore/examples/admin/apiv1/snippet_metadata.google.datastore.admin.v1.json` so that release-please automatically updates the snippet metadata version on release.

Without this, release pull requests have discrepancies in the generation and check was failing : https://github.com/googleapis/google-cloud-go/actions/runs/30049859257/job/89349382354

```
HEAD detached at pull/20195/merge
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   datastore/examples/admin/apiv1/snippet_metadata.google.datastore.admin.v1.json

no changes added to commit (use "git add" and/or "git commit -a")
==================== GIT DIFF ====================
diff --git a/datastore/examples/admin/apiv1/snippet_metadata.google.datastore.admin.v1.json b/datastore/examples/admin/apiv1/snippet_metadata.google.datastore.admin.v1.json
index a3572dc4..76b5c431 100644
--- a/datastore/examples/admin/apiv1/snippet_metadata.google.datastore.admin.v1.json
+++ b/datastore/examples/admin/apiv1/snippet_metadata.google.datastore.admin.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/datastore/admin/apiv1",
-    "version": "1.25.0"
+    "version": "1.26.0"
   },
   "snippets": [
     {
==================================================
Regeneration failed. Please run 'librarian generate --all' to update the generated files.
Error: Process completed with exit code 1.
```