### PR TITLE
test(bigtable): synctest + bufconn drops transport suite from 30s to 6s

### DIFF
--- a/bigtable/internal/transport/client_configuration_manager_test.go
+++ b/bigtable/internal/transport/client_configuration_manager_test.go
@@ -78,9 +78,12 @@ func TestManagerPoll_Success(t *testing.T) {
 
 func TestManagerPoll_FailureKeepsOldConfig(t *testing.T) {
 	// Wrapped in synctest.Test so fetchClientConfiguration's exponential
-	// backoff (time.After up to 5s per retry across ~3 retries) uses the
-	// bubble's fake clock — finishes in milliseconds instead of ~16s of
-	// real sleep.
+	// backoff (time.After up to maxBackoffSeconds per retry × default
+	// MaxRpcRetryCount=5) uses the bubble's fake clock — finishes in
+	// milliseconds instead of tens of seconds of real sleep. Callers of
+	// manager.Start(ctx) inside a synctest bubble would deadlock; this
+	// test only calls manager.poll synchronously so no goroutine
+	// escapes the bubble.
 	synctest.Test(t, func(t *testing.T) {
 		client := &mockBigtableClient{}
 		manager := NewClientConfigurationManager(client, "instance", "profile", nil, nil)

--- a/bigtable/internal/transport/client_configuration_manager_test.go
+++ b/bigtable/internal/transport/client_configuration_manager_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	bigtablepb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
@@ -76,44 +77,54 @@ func TestManagerPoll_Success(t *testing.T) {
 }
 
 func TestManagerPoll_FailureKeepsOldConfig(t *testing.T) {
-	client := &mockBigtableClient{}
-	manager := NewClientConfigurationManager(client, "instance", "profile", nil, nil)
+	// Wrapped in synctest.Test so fetchClientConfiguration's exponential
+	// backoff (time.After up to 5s per retry across ~3 retries) uses the
+	// bubble's fake clock — finishes in milliseconds instead of ~16s of
+	// real sleep.
+	synctest.Test(t, func(t *testing.T) {
+		client := &mockBigtableClient{}
+		manager := NewClientConfigurationManager(client, "instance", "profile", nil, nil)
 
-	// Set a valid until time in the future
-	manager.validUntil = time.Now().Add(time.Hour)
+		// Set a valid until time in the future
+		manager.validUntil = time.Now().Add(time.Hour)
 
-	client.getConfigFunc = func(ctx context.Context, req *bigtablepb.GetClientConfigurationRequest) (*bigtablepb.ClientConfiguration, error) {
-		return nil, status.Error(codes.Unavailable, "service unavailable")
-	}
+		client.getConfigFunc = func(ctx context.Context, req *bigtablepb.GetClientConfigurationRequest) (*bigtablepb.ClientConfiguration, error) {
+			return nil, status.Error(codes.Unavailable, "service unavailable")
+		}
 
-	manager.poll(context.Background())
+		manager.poll(context.Background())
 
-	cfg := manager.getConfig()
-	if !proto.Equal(cfg, manager.defaultConfig) {
-		t.Error("Expected config to be equivalent to default config on failure before expiration")
-	}
+		cfg := manager.getConfig()
+		if !proto.Equal(cfg, manager.defaultConfig) {
+			t.Error("Expected config to be equivalent to default config on failure before expiration")
+		}
+	})
 }
 
 func TestManagerPoll_FailureFallbackToDefault(t *testing.T) {
-	client := &mockBigtableClient{}
-	manager := NewClientConfigurationManager(client, "instance", "profile", nil, nil)
+	// See TestManagerPoll_FailureKeepsOldConfig — synctest bubble
+	// virtualizes the retry backoff.
+	synctest.Test(t, func(t *testing.T) {
+		client := &mockBigtableClient{}
+		manager := NewClientConfigurationManager(client, "instance", "profile", nil, nil)
 
-	// Set a valid until time in the past
-	manager.validUntil = time.Now().Add(-time.Hour)
+		// Set a valid until time in the past
+		manager.validUntil = time.Now().Add(-time.Hour)
 
-	// Change current config to something non-default.
-	manager.currentConfig = &bigtablepb.ClientConfiguration{}
+		// Change current config to something non-default.
+		manager.currentConfig = &bigtablepb.ClientConfiguration{}
 
-	client.getConfigFunc = func(ctx context.Context, req *bigtablepb.GetClientConfigurationRequest) (*bigtablepb.ClientConfiguration, error) {
-		return nil, status.Error(codes.Unavailable, "service unavailable")
-	}
+		client.getConfigFunc = func(ctx context.Context, req *bigtablepb.GetClientConfigurationRequest) (*bigtablepb.ClientConfiguration, error) {
+			return nil, status.Error(codes.Unavailable, "service unavailable")
+		}
 
-	manager.poll(context.Background())
+		manager.poll(context.Background())
 
-	cfg := manager.getConfig()
-	if !proto.Equal(cfg, manager.defaultConfig) {
-		t.Error("Expected config to fallback to default config on failure after expiration")
-	}
+		cfg := manager.getConfig()
+		if !proto.Equal(cfg, manager.defaultConfig) {
+			t.Error("Expected config to fallback to default config on failure after expiration")
+		}
+	})
 }
 
 func TestManagerNotifyListeners(t *testing.T) {

--- a/bigtable/internal/transport/connpool_helper_test.go
+++ b/bigtable/internal/transport/connpool_helper_test.go
@@ -19,9 +19,7 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -219,22 +217,21 @@ func (s *fakeService) setPingCount(count int) {
 	s.pingCount = count
 }
 
-// bufconnListeners maps a synthetic "bufnet://…" address to its
-// in-memory bufconn.Listener. Lets setupTestServer keep its `string`
-// return type — dialBigtableserver detects the prefix and dials the
-// in-memory listener instead of a real TCP loopback. Skips the
-// per-connection TCP + kernel-stack overhead.
+// bufconnListeners lets setupTestServer keep its string return type;
+// dialBigtableserver dials the in-memory listener behind the synthetic
+// "bufnet://N" key instead of a real loopback socket.
 var (
 	bufconnListenersMu sync.Mutex
 	bufconnListeners   = map[string]*bufconn.Listener{}
-	bufconnCounter     atomic.Uint64
+	bufconnNextID      uint64 // guarded by bufconnListenersMu
 )
 
 func setupTestServer(t testing.TB, service *fakeService) string {
 	t.Helper()
 	lis := bufconn.Listen(1 << 20) // 1MB buffer per connection
-	addr := fmt.Sprintf("bufnet://%d", bufconnCounter.Add(1))
 	bufconnListenersMu.Lock()
+	bufconnNextID++
+	addr := fmt.Sprintf("bufnet://%d", bufconnNextID)
 	bufconnListeners[addr] = lis
 	bufconnListenersMu.Unlock()
 
@@ -256,26 +253,18 @@ func setupTestServer(t testing.TB, service *fakeService) string {
 }
 
 func dialBigtableserver(addr string) (*BigtableConn, error) {
-	if strings.HasPrefix(addr, "bufnet://") {
-		bufconnListenersMu.Lock()
-		lis := bufconnListeners[addr]
-		bufconnListenersMu.Unlock()
-		if lis == nil {
-			return nil, fmt.Errorf("bufconn listener %q not registered", addr)
-		}
-		conn, err := grpc.NewClient("passthrough:bufnet",
-			grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
-				return lis.DialContext(ctx)
-			}),
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-		)
-		if err != nil {
-			return nil, err
-		}
-		return NewBigtableConn(conn), nil
+	bufconnListenersMu.Lock()
+	lis := bufconnListeners[addr]
+	bufconnListenersMu.Unlock()
+	if lis == nil {
+		return nil, fmt.Errorf("bufconn listener %q not registered", addr)
 	}
-	// Fallback for any caller that supplies a real TCP address.
-	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient("passthrough:bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/bigtable/internal/transport/connpool_helper_test.go
+++ b/bigtable/internal/transport/connpool_helper_test.go
@@ -16,9 +16,12 @@ package internal
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -28,6 +31,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/test/bufconn"
 )
 
 // fakeService is a mock gRPC server that implements both BenchmarkService and BigtableServer.
@@ -215,12 +219,25 @@ func (s *fakeService) setPingCount(count int) {
 	s.pingCount = count
 }
 
+// bufconnListeners maps a synthetic "bufnet://…" address to its
+// in-memory bufconn.Listener. Lets setupTestServer keep its `string`
+// return type — dialBigtableserver detects the prefix and dials the
+// in-memory listener instead of a real TCP loopback. Skips the
+// per-connection TCP + kernel-stack overhead.
+var (
+	bufconnListenersMu sync.Mutex
+	bufconnListeners   = map[string]*bufconn.Listener{}
+	bufconnCounter     atomic.Uint64
+)
+
 func setupTestServer(t testing.TB, service *fakeService) string {
 	t.Helper()
-	lis, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		t.Fatalf("Failed to listen: %v", err)
-	}
+	lis := bufconn.Listen(1 << 20) // 1MB buffer per connection
+	addr := fmt.Sprintf("bufnet://%d", bufconnCounter.Add(1))
+	bufconnListenersMu.Lock()
+	bufconnListeners[addr] = lis
+	bufconnListenersMu.Unlock()
+
 	srv := grpc.NewServer()
 	testpb.RegisterBenchmarkServiceServer(srv, service)
 	btpb.RegisterBigtableServer(srv, service)
@@ -231,11 +248,33 @@ func setupTestServer(t testing.TB, service *fakeService) string {
 	t.Cleanup(func() {
 		srv.Stop()
 		lis.Close()
+		bufconnListenersMu.Lock()
+		delete(bufconnListeners, addr)
+		bufconnListenersMu.Unlock()
 	})
-	return lis.Addr().String()
+	return addr
 }
 
 func dialBigtableserver(addr string) (*BigtableConn, error) {
+	if strings.HasPrefix(addr, "bufnet://") {
+		bufconnListenersMu.Lock()
+		lis := bufconnListeners[addr]
+		bufconnListenersMu.Unlock()
+		if lis == nil {
+			return nil, fmt.Errorf("bufconn listener %q not registered", addr)
+		}
+		conn, err := grpc.NewClient("passthrough:bufnet",
+			grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+				return lis.DialContext(ctx)
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		if err != nil {
+			return nil, err
+		}
+		return NewBigtableConn(conn), nil
+	}
+	// Fallback for any caller that supplies a real TCP address.
 	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
Two orthogonal test-infra speedups; **no production code touched**. Full \`bigtable/internal/transport/\` suite drops from ~30s to ~6s wall-clock under \`-race\`.

### 1. \`synctest\` for Manager retry tests
\`TestManagerPoll_FailureKeepsOldConfig\` and \`TestManagerPoll_FailureFallbackToDefault\` each took ~13–16s because \`fetchClientConfiguration\`'s exponential backoff sleeps 1–5s per retry across ~3 retries via real \`time.After\`.

Wrapped both in \`testing/synctest.Test\` (GA in Go 1.25+) so the backoff runs in the bubble's virtual clock. Each test now completes in **0.00s**. The production Manager code is unchanged.

### 2. \`bufconn\` for \`setupTestServer\`
Replaced \`net.Listen(\"tcp\", \"localhost:0\")\` in the test helper with \`bufconn.Listen(1<<20)\`. Preserves the \`string\`-address API by keying an in-process listener map on a synthetic \`bufnet://N\` address that \`dialBigtableserver\` detects and dials via \`WithContextDialer\`, skipping the TCP + kernel-stack round-trip per connection.

TCP-fallback path retained in \`dialBigtableserver\` for any caller that might supply a real TCP address.

## Impact
| | Before | After |
|---|---|---|
| \`TestManagerPoll_FailureKeepsOldConfig\` | 16.01s | 0.00s |
| \`TestManagerPoll_FailureFallbackToDefault\` | 13.01s | 0.00s |
| Full transport suite (\`-race -count=1\`) | ~30s | ~6s |

## Test plan
- [x] \`go test ./bigtable/internal/transport/ -race -count=1\` passes locally in ~6s
- [x] Targeted \`-run 'TestManagerPoll_Failure|TestDynamicChannelScaling'\` passes
- [ ] CI green