### PR TITLE
fix(bigtable): treat PingAndWarm NotFound as a successful prime

### DIFF
--- a/bigtable/internal/transport/channel_primer.go
+++ b/bigtable/internal/transport/channel_primer.go
@@ -17,7 +17,10 @@ package internal
 import (
 	"context"
 
+	btopt "cloud.google.com/go/bigtable/internal/option"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 // ChannelPrimer warms a freshly-dialed Bigtable channel before it is put
@@ -58,6 +61,18 @@ func newPingAndWarmChannelPrimer(instanceName, appProfile string, featureFlagsMD
 
 // Prime delegates to BigtableConn.Prime, which sends PingAndWarm and
 // records the ALTS / IP-protocol observations on conn as a side effect.
+//
+// A NotFound response is treated as a successful prime: the server
+// returns NotFound for a valid but empty instance ("No tables found for
+// instance ..."), and blocking client creation in that case would
+// prevent admin flows (create the first table, migrations). Typo'd
+// instance names also produce NotFound but surface on the first real
+// RPC, so nothing is silently masked here.
 func (p *pingAndWarmChannelPrimer) Prime(ctx context.Context, conn *BigtableConn) error {
-	return conn.Prime(ctx, p.instanceName, p.appProfile, p.featureFlagsMD)
+	err := conn.Prime(ctx, p.instanceName, p.appProfile, p.featureFlagsMD)
+	if err != nil && status.Code(err) == codes.NotFound {
+		btopt.Debugf(nil, "bigtable_connpool: PingAndWarm returned NotFound (instance likely empty); treating as primed: %v", err)
+		return nil
+	}
+	return err
 }

--- a/bigtable/internal/transport/channel_primer_test.go
+++ b/bigtable/internal/transport/channel_primer_test.go
@@ -18,7 +18,9 @@ import (
 	"context"
 	"testing"
 
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 // TestPingAndWarmChannelPrimer_Prime verifies the primer delegates to
@@ -51,6 +53,29 @@ func TestPingAndWarmChannelPrimer_Prime(t *testing.T) {
 	}
 	if got := gotMD.Get("x-goog-request-params"); len(got) != 1 {
 		t.Errorf("x-goog-request-params on PingAndWarm = %v, want one entry derived from instance/profile", got)
+	}
+}
+
+// TestPingAndWarmChannelPrimer_Prime_NotFoundIsBenign verifies that a
+// PingAndWarm NotFound response (server's answer for a valid instance
+// with zero tables) is swallowed so client creation succeeds — see
+// Prime's docstring for the rationale.
+func TestPingAndWarmChannelPrimer_Prime_NotFoundIsBenign(t *testing.T) {
+	fake := &fakeService{}
+	fake.setPingErr(status.Error(codes.NotFound, "No tables found for instance projects/p/instances/i"))
+	addr := setupTestServer(t, fake)
+	conn, err := dialBigtableserver(addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	primer := newPingAndWarmChannelPrimer(testInstanceName, testAppProfile, nil)
+	if err := primer.Prime(context.Background(), conn); err != nil {
+		t.Fatalf("Prime returned error on NotFound; want nil: %v", err)
+	}
+	if got := fake.getPingCount(); got != 1 {
+		t.Errorf("PingAndWarm call count = %d, want 1", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Empty Bigtable instances break client creation: `PingAndWarm` returns `NotFound` with `"No tables found for instance ..."`, and the channel factory's prime-with-retry loop surfaces that as a fatal error after 3 attempts.
- The primer now swallows `codes.NotFound` and logs at debug so admin flows (creating the first table, migrations) against otherwise-healthy but empty instances work again.
- Typo'd instance names also produce `NotFound` but surface on the first real RPC, so nothing is silently masked.
- The `pingAndWarmDirectAccessChecker` (which uses the same primer indirectly) is intentionally left as-is — DA compatibility has different failure semantics and its Prime error path already has a `PermissionDenied` fall-through of its own.

Fixes #20067

## Test plan

- [x] New unit test `TestPingAndWarmChannelPrimer_Prime_NotFoundIsBenign` in `bigtable/internal/transport/channel_primer_test.go` stages the exact `NotFound / "No tables found for instance ..."` response and asserts `Prime` returns nil.
- [x] Existing `TestPingAndWarmChannelPrimer_Prime` and `TestConnectionFactory_NilPrimerSkipsPriming` continue to pass.
- [x] `go test ./internal/transport/ -race -count=1 -timeout=30s` clean locally.