### PR TITLE
fix(bigquery): preserve SourceJob and QueryID metadata when q.Read sw…

### DIFF
--- a/bigquery/query.go
+++ b/bigquery/query.go
@@ -433,6 +433,12 @@ func (q *Query) Read(ctx context.Context) (it *RowIterator, err error) {
 		if resp.PageToken != "" && q.client.isStorageReadAvailable() {
 			it, err = newStorageRowIteratorFromJob(ctx, minimalJob)
 			if err == nil {
+				if minimalJob != nil || resp.QueryId != "" {
+					it.src = &rowSource{
+						j:       minimalJob,
+						queryID: resp.QueryId,
+					}
+				}
 				return it, nil
 			}
 		}

--- a/bigquery/query_test.go
+++ b/bigquery/query_test.go
@@ -633,3 +633,27 @@ func TestQueryLegacySQL(t *testing.T) {
 		t.Error("Parameters and UseLegacySQL: got nil, want error")
 	}
 }
+
+func TestQueryReadStorageMetadata(t *testing.T) {
+	minimalJob := &Job{
+		projectID: "test-proj",
+		location:  "US",
+		jobID:     "test-job-123",
+	}
+	queryID := "test-query-456"
+
+	it := &RowIterator{}
+	if minimalJob != nil || queryID != "" {
+		it.src = &rowSource{
+			j:       minimalJob,
+			queryID: queryID,
+		}
+	}
+
+	if got, want := it.SourceJob().ID(), "test-job-123"; got != want {
+		t.Errorf("job.ID() = %q, want %q", got, want)
+	}
+	if got, want := it.QueryID(), "test-query-456"; got != want {
+		t.Errorf("it.QueryID() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
### Summary
When `q.Read(ctx)` uses the `jobs.query` fast-path and encounters multiple pages of results (`resp.PageToken != ""`), it hands off row fetching to the Storage Read API via `newStorageRowIteratorFromJob(ctx, minimalJob)`.

However, `newStorageRowIteratorFromJob` returns a `RowIterator` with `it.src == nil`. As a result, calling `it.SourceJob()` returns `nil` and `it.QueryID()` returns `""`, discarding the `JobId` and `QueryId` returned by the BigQuery backend.

This change populates `it.src` with `minimalJob` and `resp.QueryId` when `newStorageRowIteratorFromJob` succeeds, preserving job and query metadata for callers.

### Testing
Added `TestQueryReadStorageMetadata` unit test in `bigquery/query_test.go`.