### PR TITLE
feat(bigtable): add SessionPoolImpl (two-tier pool + scaling + debug)

### DIFF
--- a/bigtable/internal/transport/afe_picker.go
+++ b/bigtable/internal/transport/afe_picker.go
@@ -18,6 +18,12 @@ import (
 	"math/rand/v2"
 )
 
+// defaultAfeRandomSubsetSize is the default K for K-choice random draws
+// in LeastInFlightAfePicker / LeastLatencyAfePicker when the caller
+// doesn't specify one. Two candidates ("power of two choices") is the
+// standard K-choice draw size.
+const defaultAfeRandomSubsetSize = 2
+
 // PickCandidate is one AFE the picker considered during a K-choice draw,
 // with the cost value the picker's decision rule used to score it.
 // Cost's interpretation depends on the picker in play: NumOutstanding

--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -1066,3 +1066,22 @@ func (m multiError) Error() string {
 	}
 	return fmt.Sprintf("%s (and %d other errors)", s, n-1)
 }
+
+// channelPickHintKey identifies the *atomic.Int32 destination the caller
+// wants BigtableChannelPool to publish the picked connEntry index into.
+type channelPickHintKey struct{}
+
+// ChannelPickHintInto returns a context that BigtableChannelPool will use to
+// publish the picked connEntry index into the supplied *atomic.Int32. The
+// caller can then read the value once the stream/invoke has returned.
+//
+// Used by Session creation to link sessions back to the channel they ride
+// on — surfaced in the sessionz / channelz debug UIs. Untouched by callers
+// that don't care: stampChannelPickHint short-circuits when the context
+// lacks the key. Passing dst == nil returns ctx unchanged.
+func ChannelPickHintInto(ctx context.Context, dst *atomic.Int32) context.Context {
+	if dst == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, channelPickHintKey{}, dst)
+}

--- a/bigtable/internal/transport/debug_tracer.go
+++ b/bigtable/internal/transport/debug_tracer.go
@@ -116,7 +116,24 @@ const (
 	tagSessionPoolStuckSessionSwept = "session_pool_stuck_session_swept"
 	tagSessionPoolDrainTimeout      = "session_pool_drain_timeout"
 	tagSessionPoolCreateFailed      = "session_pool_create_failed"
-	tagSessionPoolPickLostRace      = "session_pool_pick_lost_race"
+	// tagSessionPoolCreatePanic distinguishes a recovered panic inside
+	// Tick's createSession fanout (streamFactory / NewSession / hook
+	// wiring) from a plain error return (tagSessionPoolCreateFailed).
+	// The two paths have very different root causes — a panic indicates
+	// a client-side bug, an error is typically transient — so ops
+	// should be able to grep them apart in the debug-tag counters.
+	tagSessionPoolCreatePanic                = "session_pool_create_panic"
+	tagSessionPoolPickLostRace               = "session_pool_pick_lost_race"
+	tagSessionPoolConsecutiveFailuresTripped = "session_pool_consecutive_failures_tripped"
+
+	// tagSessionPoolCheckoutFailedCINil fires on SessionPoolImpl.Invoke's
+	// early return when CheckoutSession failed — pool returns
+	// InvokeResult{} with nil ClusterInfo, so stampAttempt downstream
+	// records TagSessionAttemptNilClusterInfo without any session ever
+	// being picked. Empirically dominates the nil-ClusterInfo population
+	// during pool cold-start (waiters ctx.Done before first session
+	// reaches Ready) and pool-close bursts (drainWaitersWithErr).
+	tagSessionPoolCheckoutFailedCINil = "session_pool_checkout_failed_ci_nil"
 
 	// sessionList bookkeeping violations.
 	//

--- a/bigtable/internal/transport/debug_tracer.go
+++ b/bigtable/internal/transport/debug_tracer.go
@@ -125,6 +125,14 @@ const (
 	tagSessionPoolCreatePanic                = "session_pool_create_panic"
 	tagSessionPoolPickLostRace               = "session_pool_pick_lost_race"
 	tagSessionPoolConsecutiveFailuresTripped = "session_pool_consecutive_failures_tripped"
+	// tagSessionPoolNoBudget fires when createSession's budget.Acquire
+	// returns an error — either poolCtx cancel (teardown) or the
+	// throttler's NewSessionCreationPenalty window expired without an
+	// existing reservation being released. The count is the pool's
+	// "opens throttled" signal; sustained emission means the budget
+	// ceiling is too low for the offered load OR opens are hanging past
+	// the penalty window.
+	tagSessionPoolNoBudget = "session_pool_no_budget"
 
 	// tagSessionPoolCheckoutFailedCINil fires on SessionPoolImpl.Invoke's
 	// early return when CheckoutSession failed — pool returns

--- a/bigtable/internal/transport/pool_sizer.go
+++ b/bigtable/internal/transport/pool_sizer.go
@@ -17,6 +17,7 @@ package internal
 import (
 	"math"
 	"sync"
+	"sync/atomic"
 
 	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
 )
@@ -53,10 +54,15 @@ type StatsFetcher func() *PoolStats
 // outside any peak-window cannot trigger a mass prune followed by a
 // cold-start scale-up on the next crest.
 type PoolSizer struct {
-	mu              sync.Mutex
-	fetcher         StatsFetcher
-	minSessions     int
-	maxSessions     int
+	mu      sync.Mutex
+	fetcher StatsFetcher
+	// minSessions / maxSessions are the authoritative pool-size bounds.
+	// Stored as atomics so hot-path readers (CheckoutSession gate,
+	// onClosing replace-check, createSession cap) can Load without
+	// taking s.mu — pool.go used to duplicate these into its own
+	// atomics; that duplication is now gone.
+	minSessions     atomic.Int32
+	maxSessions     atomic.Int32
 	headroomPct     float64 // Idle headroom as a fraction of sessions in use (e.g., 0.10 = 10%)
 	newSessionQLen  int     // server-driven per-session pending queue length; divides PendingCount
 	minIdleSessions int     // floor on the idle cushion so headroom never collapses to 0
@@ -87,15 +93,25 @@ func NewPoolSizer(fetcher StatsFetcher, minSessions, maxSessions int, headroomPc
 	if headroomPct <= 0 {
 		headroomPct = float64(defaultPoolConfig().GetHeadroom())
 	}
-	return &PoolSizer{
+	s := &PoolSizer{
 		fetcher:         fetcher,
-		minSessions:     minSessions,
-		maxSessions:     maxSessions,
 		headroomPct:     headroomPct,
 		newSessionQLen:  int(defaultPoolConfig().GetNewSessionQueueLength()),
 		minIdleSessions: defaultMinIdleSessions,
 	}
+	s.minSessions.Store(int32(minSessions))
+	s.maxSessions.Store(int32(maxSessions))
+	return s
 }
+
+// MinSessions returns the current pool-floor session count. Atomic load;
+// safe from any goroutine without taking the sizer lock. Callers that
+// need min/max/headroom as a consistent triple should use Decide instead.
+func (s *PoolSizer) MinSessions() int { return int(s.minSessions.Load()) }
+
+// MaxSessions returns the current pool-ceiling session count. Atomic
+// load; same non-locking contract as MinSessions.
+func (s *PoolSizer) MaxSessions() int { return int(s.maxSessions.Load()) }
 
 // UpdateConfig dynamically adjusts the sizer's capacity bounds,
 // headroom cushion, and per-session queue length at runtime. Called
@@ -110,8 +126,12 @@ func (s *PoolSizer) UpdateConfig(config *spb.SessionClientConfiguration_SessionP
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.minSessions = int(config.MinSessionCount)
-	s.maxSessions = int(config.MaxSessionCount)
+	// min/max are atomic so hot-path readers (pool gate + snapshot) see
+	// the new bound the moment UpdateConfig returns; s.mu still brackets
+	// the write with headroom/qlen so a Decide walking the sizer sees a
+	// coherent config triple.
+	s.minSessions.Store(config.MinSessionCount)
+	s.maxSessions.Store(config.MaxSessionCount)
 	// Mirror the constructor guard: a zero or negative headroom from
 	// the server would render as HeadroomPct=0 on the loadz trace and
 	// collapse IdleHeadroom to the MinIdleSessions floor — the pool
@@ -196,8 +216,8 @@ func (s *PoolSizer) Decide() ScaleDecision {
 	defer s.mu.Unlock()
 
 	d := ScaleDecision{
-		MinSessions:     s.minSessions,
-		MaxSessions:     s.maxSessions,
+		MinSessions:     int(s.minSessions.Load()),
+		MaxSessions:     int(s.maxSessions.Load()),
 		HeadroomPct:     s.headroomPct,
 		NewSessionQLen:  s.newSessionQLen,
 		MinIdleSessions: s.minIdleSessions,
@@ -233,7 +253,7 @@ func (s *PoolSizer) Decide() ScaleDecision {
 		d.IdleHeadroom = s.minIdleSessions
 	}
 	d.DesiredRaw = d.SessionsInUse + d.IdleHeadroom
-	d.DesiredCapacity = clamp(d.DesiredRaw, s.minSessions, s.maxSessions)
+	d.DesiredCapacity = clamp(d.DesiredRaw, d.MinSessions, d.MaxSessions)
 
 	d.ImmediateCapacity = stats.ReadyCount
 	d.EventualCapacity = stats.ReadyCount + stats.StartingCount

--- a/bigtable/internal/transport/session.go
+++ b/bigtable/internal/transport/session.go
@@ -195,6 +195,18 @@ type Session struct {
 	// Embedded so bare field access (s.tracer, s.okRpcs, s.recordEvent,
 	// ...) continues to compile once vRPC / lifecycle land.
 	sessionDebug
+
+	// loops tracks readLoop + heartbeatLoop so a supervising owner
+	// (SessionPoolImpl.Close) can wait for them to fully unwind — through
+	// their notifyClosing / notifyClosed callback chains — before it
+	// returns. Prevents readLoop's recordClose from racing package-level
+	// metric var writes across test boundaries.
+	loops sync.WaitGroup
+
+	// closeErr preserves the raw Recv error handed to handleClose. The
+	// pool surfaces this on consecutive-failure breaker trips so operators
+	// see the underlying server rejection instead of only the sentinel.
+	closeErr atomic.Pointer[error]
 }
 
 // SessionOption configures a Session at construction time.

--- a/bigtable/internal/transport/session_debug.go
+++ b/bigtable/internal/transport/session_debug.go
@@ -405,3 +405,23 @@ func WithSessionLogger(logger *log.Logger) SessionOption {
 func WithSessionPoolName(name string) SessionOption {
 	return func(s *Session) { s.tracer.setPoolName(name) }
 }
+
+// setCloseErr records the raw error that ended the stream. First writer
+// wins so a follow-up close path (e.g. cancelActiveRPCs) can't overwrite
+// the original cause. Nil is treated as "no error" and ignored.
+func (s *Session) setCloseErr(err error) {
+	if err == nil {
+		return
+	}
+	s.closeErr.CompareAndSwap(nil, &err)
+}
+
+// closeError returns the raw error that ended the stream, or nil if
+// none was recorded. Consulted by the pool to surface the underlying
+// server rejection on consecutive-failure trips.
+func (s *Session) closeError() error {
+	if p := s.closeErr.Load(); p != nil {
+		return *p
+	}
+	return nil
+}

--- a/bigtable/internal/transport/session_lifecycle.go
+++ b/bigtable/internal/transport/session_lifecycle.go
@@ -75,9 +75,21 @@ func (s *Session) Start(ctx context.Context, req *spb.OpenSessionRequest) error 
 	// is safe.
 	s.hooks.onStart(ctx)
 
-	go s.readLoop(ctx)
-	go s.heartbeatLoop(ctx)
+	// Track readLoop + heartbeatLoop so WaitGoroutines can block until
+	// their callback chains (notifyClosed → recordClose, etc.) have
+	// unwound. Owners (SessionPoolImpl.Close) call WaitGoroutines during
+	// teardown so no session-owned goroutine outlives the pool.
+	s.loops.Add(2)
+	go func() { defer s.loops.Done(); s.readLoop(ctx) }()
+	go func() { defer s.loops.Done(); s.heartbeatLoop(ctx) }()
 	return nil
+}
+
+// WaitGoroutines blocks until readLoop and heartbeatLoop have fully
+// returned (including their notifyClosed / recordClose callback
+// chains). No-op if Start was never called.
+func (s *Session) WaitGoroutines() {
+	s.loops.Wait()
 }
 
 // ForceClose immediately transitions the session to StateClosed and cancels
@@ -450,6 +462,7 @@ func (s *Session) handleClose(err error) {
 	s.notifyClosing()
 	reason := streamEndReason(err)
 	s.setCloseReason(reason)
+	s.setCloseErr(err)
 	// After setCloseReason (CompareAndSwap-once), the *final* reason may
 	// be an earlier stamp (GoAway / MissedHeartbeat / Error) or the
 	// streamEndReason we just computed. Only flag as abnormal when the

--- a/bigtable/internal/transport/session_pool.go
+++ b/bigtable/internal/transport/session_pool.go
@@ -209,15 +209,21 @@ func NewSessionPoolImpl(id uint64, poolName string, min, max int, streamFactory 
 	pool.minSessions.Store(int32(min))
 	pool.maxSessions.Store(int32(max))
 
+	// Bootstrap sizer/picker/budget/threshold from the default
+	// ClientConfiguration proto (default_client_config.go). Fallback
+	// values live in one place instead of as literals scattered here.
+	// Every real caller registers via ClientConfigurationManager, which
+	// fires UpdateConfig synchronously and replaces these with
+	// server-driven values before the pool serves traffic.
+	defaultCfg := defaultPoolConfig()
 	fetcher := func() *PoolStats { return pool.Stats() }
-	pool.sizer = NewPoolSizer(fetcher, min, max, 0.10)
-	// Bootstrap picker/budget/threshold with fallbacks. Every real
-	// caller registers via ClientConfigurationManager, which fires
-	// UpdateConfig synchronously and replaces these with server-driven
-	// values before the pool serves traffic.
-	pool.picker = pickerFromLoadBalancing(nil)
-	pool.budget = NewAdaptiveSessionThrottler(10, 10*time.Second)
-	pool.consecutiveFailureThreshold.Store(10)
+	pool.sizer = NewPoolSizer(fetcher, min, max, float64(defaultCfg.GetHeadroom()))
+	pool.picker = pickerFromLoadBalancing(defaultCfg.GetLoadBalancingOptions())
+	pool.budget = NewAdaptiveSessionThrottler(
+		int(defaultCfg.GetNewSessionCreationBudget()),
+		defaultCfg.GetNewSessionCreationPenalty().AsDuration(),
+	)
+	pool.consecutiveFailureThreshold.Store(defaultCfg.GetConsecutiveSessionFailureThreshold())
 
 	return pool
 }

--- a/bigtable/internal/transport/session_pool.go
+++ b/bigtable/internal/transport/session_pool.go
@@ -1,0 +1,553 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// SessionPoolImpl core: struct, ctor, CheckoutSession/Invoke hot path,
+// Stats, UpdateConfig. Observability ring buffers → session_pool_debug.go;
+// hooks + Close + heartbeat → session_pool_lifecycle.go; scaling driver
+// + createSession → session_pool_scaling.go.
+
+package internal
+
+import (
+	"container/list"
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	btopt "cloud.google.com/go/bigtable/internal/option"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// ErrNoSessionsAvailable is returned by CheckoutSession when a parked
+// waiter is unblocked by ctx cancellation or deadline. Wraps ctx.Err()
+// so errors.Is against either the sentinel or the ctx cause holds.
+var ErrNoSessionsAvailable = errors.New("bigtable: no sessions available")
+
+// ErrConsecutiveFailures is returned by CheckoutSession when the pool's
+// consecutive-abnormal-close circuit breaker trips. All parked waiters
+// at trip time are woken with an error that either equals this sentinel
+// or wraps it via *consecutiveFailureError (which also carries the last
+// abnormal-close cause and its gRPC status code).
+var ErrConsecutiveFailures = errors.New("bigtable: session pool tripped consecutive-failure threshold")
+
+// consecutiveFailureError decorates ErrConsecutiveFailures with the last
+// abnormal-close error captured by the pool. It preserves both:
+//   - errors.Is(err, ErrConsecutiveFailures) — so retry/observability
+//     paths that already match the sentinel keep working.
+//   - status.Code(err) — inherited from the last abnormal-close error
+//     when that error is a gRPC status (e.g. FailedPrecondition when
+//     the server rejected OpenSession because the resource is still
+//     being created). Falls back to codes.Unknown otherwise.
+//
+// Only constructed via SessionPoolImpl.consecutiveFailureErr, which
+// guarantees inner != nil.
+type consecutiveFailureError struct {
+	inner error
+}
+
+func (e *consecutiveFailureError) Error() string {
+	return fmt.Sprintf("%s (last error: %v)", ErrConsecutiveFailures.Error(), e.inner)
+}
+
+func (e *consecutiveFailureError) Is(target error) bool {
+	return target == ErrConsecutiveFailures
+}
+
+func (e *consecutiveFailureError) Unwrap() error { return e.inner }
+
+// GRPCStatus lets status.Code / status.FromError extract the gRPC code
+// from the underlying cause. Without this shim, callers doing
+// status.Code(err) == codes.FailedPrecondition would see Unknown.
+// status.FromError always returns a non-nil *Status (Unknown on ok=false),
+// so no fallback needed.
+func (e *consecutiveFailureError) GRPCStatus() *status.Status {
+	st, _ := status.FromError(e.inner)
+	return st
+}
+
+// ErrPoolClosed is returned to any CheckoutSession caller parked on
+// the waiter queue when Close() runs. Distinct from
+// ErrNoSessionsAvailable (ctx-cancel during cold-start) and
+// ErrConsecutiveFailures (circuit trip) so operators can distinguish
+// "pool is going away" from "your ctx expired while waiting."
+var ErrPoolClosed = errors.New("bigtable: session pool is closed")
+
+// waiter is one parked CheckoutSession caller. Close-exactly-once is
+// guarded by waitersMu + w.elem: enqueued while elem != nil; both wake
+// paths hold waitersMu when they nil elem out.
+type waiter struct {
+	ready chan struct{}
+	elem  *list.Element // non-nil while enqueued; nil after dequeue
+	// err, when set before close(ready), fails the waiter with a
+	// specific error instead of prompting a re-pick (used by the
+	// consecutive-failure trip).
+	err error
+}
+
+// SessionPoolImpl implements a thread-safe session pool.
+type SessionPoolImpl struct {
+	mu     sync.Mutex
+	sizer  *PoolSizer
+	picker AfePicker
+	// sl owns the AFE-aware idle-session queues, per-AFE PeakEwma
+	// trackers, and the canonical set of active SessionHandles. sl has
+	// its own lock; sl methods never call back into SessionPoolImpl, so
+	// "never take p.mu while holding sl.mu" holds by construction.
+	sl     *sessionList
+	budget SessionThrottler
+	// startingSessions holds handles dialed via createSession that have
+	// not yet reached onActive; cleared on promotion or failed-start.
+	startingSessions map[*SessionHandle]struct{}
+	// pendingStarts counts createSession goroutines that haven't yet
+	// reached streamFactory success. Prevents back-to-back Ticks in
+	// the streamFactory window from re-requesting the same delta.
+	pendingStarts int
+	// spawns tracks pool-spawned goroutines (today: createSession
+	// workers) so Close can wait them out. Session-owned goroutines
+	// are tracked separately on Session.loops.
+	spawns            sync.WaitGroup
+	closed            bool
+	scalingInProgress bool
+	// minSessions / maxSessions are the server-driven pool bounds.
+	// Writes go under p.mu so PoolSnapshot reads a consistent pair;
+	// hot-path readers Load() without the lock (no cross-field invariant
+	// with picker/budget/threshold).
+	minSessions        atomic.Int32
+	maxSessions        atomic.Int32
+	streamFactory      func(ctx context.Context) (Stream, error)
+	openSessionRequest *spb.OpenSessionRequest
+	metadata           metadata.MD
+	sessionType        SessionType
+	poolName           string
+	startOnce          sync.Once
+	// tickPending debounces tickOnce so a burst of empty-pool kicks
+	// coalesces to at most one active Tick.
+	tickPending atomic.Bool
+	// poolID is baked into every session log name for the
+	// channelz → sessionz reverse link.
+	poolID uint64
+
+	// waitersCount is the live count of CheckoutSession callers parked
+	// at the pool boundary — the "pending vRPCs" signal for the sizer.
+	waitersCount atomic.Int32
+
+	// consecutiveFailures counts abnormal session closes since the last
+	// successful session-open (cleared in onActive). Crossing the
+	// threshold trips the pool: parked waiters are woken with
+	// ErrConsecutiveFailures.
+	consecutiveFailures         atomic.Int32
+	consecutiveFailureThreshold atomic.Int32
+
+	// lastAbnormalCloseErr holds the most recent abnormal-close raw error,
+	// captured in noteAbnormalCloseIfAny. When the breaker trips we wrap
+	// this into the ErrConsecutiveFailures poison so waiters see WHY
+	// (e.g. FailedPrecondition ... still being created) instead of only
+	// the generic sentinel.
+	lastAbnormalCloseErr atomic.Pointer[error]
+
+	// m holds observability-only state (counters, ring buffers,
+	// histograms) — see poolMetrics in session_pool_debug.go.
+	m poolMetrics
+
+	// waiters is a FIFO queue of parked CheckoutSession callers. Each
+	// free-session event wakes exactly one waiter, in insertion order.
+	// Cancellation removes the waiter so no wake-up token is dropped.
+	waitersMu sync.Mutex
+	waiters   *list.List // *waiter
+
+	// poolCtx scopes the pool's lifetime; wrapped (deadline stripped,
+	// cancellation preserved) into streamFactory, budget.Acquire, and
+	// Session.Start so teardown propagates.
+	poolCtx    context.Context
+	poolCancel context.CancelFunc
+}
+
+// noteVRpcOutcome forwards the outcome to the AFE's PeakEwma trackers
+// (OK-gated). The consecutive-failure counter is NOT reset here —
+// only a successful session-open (onActive) clears it. Resetting on
+// per-vRPC OK would let one long-lived healthy session mask a run
+// of failed opens and keep the breaker from tripping.
+func (p *SessionPoolImpl) noteVRpcOutcome(sh *SessionHandle, e2e, backend time.Duration, ok bool) {
+	p.sl.RecordVRpcOutcome(sh, e2e, backend, ok)
+}
+
+// NewSessionPoolImpl creates a new SessionPoolImpl. id is baked into
+// every session log name so channelz/sessionz can reverse-link back to
+// the pool that owns each session.
+func NewSessionPoolImpl(id uint64, poolName string, min, max int, streamFactory func(ctx context.Context) (Stream, error), openSessionRequest *spb.OpenSessionRequest, md metadata.MD, sessionType SessionType) *SessionPoolImpl {
+	poolCtx, poolCancel := context.WithCancel(context.Background())
+	pool := &SessionPoolImpl{
+		poolName:           poolName,
+		poolID:             id,
+		streamFactory:      streamFactory,
+		openSessionRequest: openSessionRequest,
+		metadata:           md,
+		startingSessions:   make(map[*SessionHandle]struct{}),
+		sessionType:        sessionType,
+		waiters:            list.New(),
+		poolCtx:            poolCtx,
+		poolCancel:         poolCancel,
+		sl:                 newSessionList(),
+	}
+	pool.m.afePickCounts = make(map[AfeID]int64)
+	pool.minSessions.Store(int32(min))
+	pool.maxSessions.Store(int32(max))
+
+	fetcher := func() *PoolStats { return pool.Stats() }
+	pool.sizer = NewPoolSizer(fetcher, min, max, 0.10)
+	// Bootstrap picker/budget/threshold with fallbacks. Every real
+	// caller registers via ClientConfigurationManager, which fires
+	// UpdateConfig synchronously and replaces these with server-driven
+	// values before the pool serves traffic.
+	pool.picker = pickerFromLoadBalancing(nil)
+	pool.budget = NewAdaptiveSessionThrottler(10, 10*time.Second)
+	pool.consecutiveFailureThreshold.Store(10)
+
+	return pool
+}
+
+// CheckoutSession returns a session ready to serve one vRPC. With
+// multiPlexingLimit=1 the pool only hands out a session whose outstanding
+// count is 0; if all are busy, the caller parks on the FIFO waiter queue
+// until a drainSlot wake fires.
+func (p *SessionPoolImpl) CheckoutSession(ctx context.Context) (*SessionHandle, error) {
+	// One-shot kick if the pool is empty. Cheap check; Tick
+	// gates on its own in-progress flag so a duplicate goroutine here
+	// exits immediately.
+	p.mu.Lock()
+	closed := p.closed
+	p.mu.Unlock()
+	if !closed && p.sl.ReadyCount() == 0 {
+		p.spawnTickOnce(p.poolCtx)
+	}
+
+	for {
+		// Snapshot closed + picker under p.mu; everything after runs
+		// outside the lock so concurrent CheckoutSession calls parallelize.
+		p.mu.Lock()
+		if p.closed {
+			p.mu.Unlock()
+			return nil, ErrPoolClosed
+		}
+		picker := p.picker
+		p.mu.Unlock()
+
+		// Two-tier pick: picker chooses an AFE from the ready snapshot,
+		// then sessionList dequeues one idle session in that AFE.
+		ready := p.sl.ReadyAfes()
+		pickerName := picker.Name()
+		AfeID, picked, decision := picker.PickAfe(ready)
+		p.recordPickDecision(decision, pickerName)
+		if picked {
+			if idle := p.sl.Checkout(AfeID); idle != nil {
+				idle.IncOutstanding()
+				idle.IncPicks()
+				return idle, nil
+			}
+			// Picker chose this AFE but its ready session was taken
+			// (concurrent Checkout / OnClosing eviction). Counter tells
+			// us how often it's actually hurting throughput.
+			recordDebugTag(tagSessionPoolPickLostRace)
+		}
+
+		// Slow path: picker returned nil. Dying sessions leave sl.readyCount
+		// the instant they transition out of Ready (OnClosing), so the
+		// maxSessions gate reflects only live-or-starting sessions —
+		// a miss just means all live sessions are busy.
+		if p.sl.ReadyCount() < int(p.maxSessions.Load()) {
+			p.spawnTickOnce(p.poolCtx)
+		}
+
+		// Park in the FIFO waiter queue. Each free-session event wakes
+		// exactly one waiter (queue head). Bracket with waitersCount so
+		// the sizer (via Stats()) sees real queue depth.
+		w := &waiter{ready: make(chan struct{})}
+		p.waitersMu.Lock()
+		w.elem = p.waiters.PushBack(w)
+		p.waitersMu.Unlock()
+
+		p.waitersCount.Add(1)
+		select {
+		case <-ctx.Done():
+			p.waitersCount.Add(-1)
+			// Remove from queue so a subsequent free-session wake
+			// doesn't burn on a caller that's already given up.
+			p.removeWaiter(w)
+			return nil, fmt.Errorf("%w: %w", ErrNoSessionsAvailable, ctx.Err())
+		case <-w.ready:
+			p.waitersCount.Add(-1)
+			// A poisoned wake (drainWaitersWithErr) sets w.err before
+			// closing w.ready. Normal signalFree leaves it nil so the
+			// caller loops back to re-pick.
+			if w.err != nil {
+				return nil, w.err
+			}
+			// Woken by signalFree. Loop back to re-pick.
+		}
+	}
+}
+
+// removeWaiter pulls w out of the waiter queue if still present. Safe
+// to call from the ctx-cancel path even when signalFree has already
+// removed the waiter (checks w.elem — nil means already dequeued by
+// signalFree, which will have closed w.ready).
+func (p *SessionPoolImpl) removeWaiter(w *waiter) {
+	p.waitersMu.Lock()
+	if w.elem != nil {
+		p.waiters.Remove(w.elem)
+		w.elem = nil
+	}
+	p.waitersMu.Unlock()
+}
+
+// signalFree wakes exactly one parked CheckoutSession waiter (the FIFO
+// queue head). No-op when the queue is empty. Called from OnActive and
+// from every drainSlot success via SessionHandle.onSlotDrained
+// (SESSION_SPEC.md #2). Never blocks: wake channel is per-waiter.
+func (p *SessionPoolImpl) signalFree() {
+	p.waitersMu.Lock()
+	if e := p.waiters.Front(); e != nil {
+		w := e.Value.(*waiter)
+		p.waiters.Remove(e)
+		w.elem = nil
+		close(w.ready)
+	}
+	p.waitersMu.Unlock()
+}
+
+// drainWaitersWithErr wakes every parked CheckoutSession caller with
+// the given error. Returns the number of waiters woken. Safe on empty.
+func (p *SessionPoolImpl) drainWaitersWithErr(err error) int {
+	p.waitersMu.Lock()
+	defer p.waitersMu.Unlock()
+	n := 0
+	for {
+		e := p.waiters.Front()
+		if e == nil {
+			return n
+		}
+		w := e.Value.(*waiter)
+		p.waiters.Remove(e)
+		w.elem = nil
+		w.err = err
+		close(w.ready)
+		n++
+	}
+}
+
+// Stats snapshots ready/inUse/starting/pending counts.
+func (p *SessionPoolImpl) Stats() *PoolStats {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	ready := 0
+	inUse := 0
+	for _, sh := range p.sl.AllHandles() {
+		// Same nil-guard shape as sampleActiveUptimes and sweepStuckSessions
+		// in session_pool_lifecycle.go — sl.AllHandles is a snapshot and
+		// the underlying handle can be torn down mid-iteration by a
+		// concurrent teardown that beat this walk to sl.mu.
+		if sh == nil || sh.session == nil {
+			continue
+		}
+		if sh.session.State() == StateReady {
+			ready++
+		}
+		if sh.outstanding.Load() > 0 {
+			inUse++
+		}
+	}
+
+	return &PoolStats{
+		ReadyCount: ready,
+		InUseCount: inUse,
+		// StartingCount = sessions past streamFactory (in startingSessions)
+		// PLUS goroutines Tick has spawned but that haven't yet reached
+		// the transfer point. Both count as "in-flight scale-up capacity"
+		// so the sizer doesn't request duplicate delta in a burst.
+		StartingCount: len(p.startingSessions) + p.pendingStarts,
+		// PendingCount is the true pool-boundary queue depth —
+		// callers parked inside CheckoutSession waiting on
+		// freeSignal. The pending-rpc count is the input
+		// to the sizer.
+		PendingCount: int(p.waitersCount.Load()),
+	}
+}
+
+// UpdateConfig dynamically adjusts the pool size constraints and budget governor limits at runtime.
+// Callers are serialized by ClientConfigurationManager, so we don't
+// bracket min/max as an atomic pair here.
+func (p *SessionPoolImpl) UpdateConfig(config *spb.SessionClientConfiguration_SessionPoolConfiguration) {
+	p.m.listenerFires.Add(1)
+	p.mu.Lock()
+	// Stores stay under p.mu so PoolSnapshot (also under p.mu) reads a
+	// consistent min/max pair. Hot-path readers still Load() without
+	// the lock — atomic makes both directions safe.
+	p.minSessions.Store(int32(config.MinSessionCount))
+	p.maxSessions.Store(int32(config.MaxSessionCount))
+	if config.LoadBalancingOptions != nil {
+		p.picker = pickerFromLoadBalancing(config.LoadBalancingOptions)
+	}
+	p.mu.Unlock()
+
+	p.sizer.UpdateConfig(config)
+
+	// Budget was bootstrapped with a placeholder; UpdateConfig on
+	// registration replaces it with the server-driven ceiling + penalty.
+	if budget := int(config.GetNewSessionCreationBudget()); budget > 0 {
+		penalty := config.GetNewSessionCreationPenalty().AsDuration()
+		p.budget.UpdateConfig(budget, penalty)
+	}
+
+	// Consecutive-failure threshold: server-driven cap on how many
+	// back-to-back abnormal session closes the pool tolerates before
+	// failing all parked waiters. Zero/negative preserves the bootstrap
+	// default.
+	if thr := config.GetConsecutiveSessionFailureThreshold(); thr > 0 {
+		p.consecutiveFailureThreshold.Store(thr)
+	}
+}
+
+// pickerFromLoadBalancing builds an AfePicker from server-driven
+// LoadBalancingOptions. A nil lbo (or unknown strategy) returns the
+// default LeastInFlight picker with K=defaultAfeRandomSubsetSize, so
+// bootstrap paths and tests that skip the config wiring still work.
+// Sole LBO → picker mapping; every picker with a K knob reads its
+// RandomSubsetSize from the corresponding oneof.
+func pickerFromLoadBalancing(lbo *spb.LoadBalancingOptions) AfePicker {
+	if lbo == nil {
+		return NewLeastInFlightAfePicker(defaultAfeRandomSubsetSize)
+	}
+	switch opt := lbo.LoadBalancingStrategy.(type) {
+	case *spb.LoadBalancingOptions_Random_:
+		return NewSimpleAfePicker()
+	case *spb.LoadBalancingOptions_LeastInFlight_:
+		k := defaultAfeRandomSubsetSize
+		if opt.LeastInFlight != nil && opt.LeastInFlight.RandomSubsetSize > 0 {
+			k = int(opt.LeastInFlight.RandomSubsetSize)
+		}
+		return NewLeastInFlightAfePicker(k)
+	case *spb.LoadBalancingOptions_PeakEwma_:
+		k := defaultAfeRandomSubsetSize
+		if opt.PeakEwma != nil && opt.PeakEwma.RandomSubsetSize > 0 {
+			k = int(opt.PeakEwma.RandomSubsetSize)
+		}
+		return NewLeastLatencyAfePicker(k)
+	default:
+		return NewLeastInFlightAfePicker(defaultAfeRandomSubsetSize)
+	}
+}
+
+// Invoke runs one vRPC on a checked-out session. Server RetryInfo
+// travels via gRPC status details on the returned error.
+func (p *SessionPoolImpl) Invoke(ctx context.Context, desc VRpcDescriptor, req interface{}) (InvokeResult, error) {
+	checkoutStart := time.Now()
+	sh, err := p.CheckoutSession(ctx)
+	if err != nil {
+		// Record checkout failure so pool-exhaustion incidents show up
+		// in sessionz's slow-vRPC table and latency histograms.
+		p.recordCheckoutFailure(checkoutStart, desc, err)
+		// Attributes the resulting downstream TagSessionAttemptNilClusterInfo
+		// to the pool checkout-failure exit — otherwise the nil at
+		// stampAttempt is indistinguishable from "session picked but
+		// returned nil". Dominates during pool cold-start warmup.
+		recordDebugTag(tagSessionPoolCheckoutFailedCINil)
+		return InvokeResult{}, err
+	}
+	poolWait := time.Since(checkoutStart)
+	// Anchor Latency at checkoutStart so recorded latency includes queue
+	// wait (user-visible time).
+	start := checkoutStart
+	// Session release is driven by the session's OnSlotDrained hook
+	// (installed at createSession); this defer only decrements the caller's
+	// in-flight counter and feeds the per-AFE PeakEwma with the outcome.
+	// The AFE-wake fires from the response handler BEFORE this defer runs,
+	// so pickers may see pre-update EWMAs for one tick — accepted lag.
+	var (
+		invokeErr  error
+		backendDur time.Duration
+		latency    time.Duration
+	)
+	defer func() {
+		sh.DecOutstanding()
+		p.noteVRpcOutcome(sh, latency, backendDur, invokeErr == nil)
+	}()
+
+	var result InvokeResult
+	result, invokeErr = sh.session.Invoke(ctx, desc, req)
+	// PeerInfo is set once at session-open and never mutated; a shared
+	// read here lets callers stamp per-attempt transport labels without
+	// reaching back through the pool.
+	result.PeerInfo = sh.session.PeerInfo()
+	latency = time.Since(start)
+	// Pool-level histograms feed the debug UI (per-session ring buffers
+	// are too small). BackendLatency only records when the server
+	// populated Stats; TotalLatency records for every call.
+	p.m.totalLatencyHist.record(latency)
+	if result.Stats != nil && result.Stats.BackendLatency != nil {
+		backendDur = result.Stats.BackendLatency.AsDuration()
+		p.m.backendLatencyHist.record(backendDur)
+	}
+	// TransportLatency (wire + AFE + client-decode overhead) is now
+	// computed at the source in Session.processResult as
+	// WireLatency − BackendLatency (guarded > 0). Zero here means the
+	// server didn't populate Stats, the call errored pre-Recv, or the
+	// subtraction was non-positive (clock skew) — all cases we skip
+	// from the per-AFE transport-overhead histograms so p50 isn't
+	// dragged toward 0.
+	if result.TransportLatency > 0 {
+		p.m.transportLatencyHist.record(result.TransportLatency)
+		sh.session.RecordTransportOverhead(ctx, desc.Method(), result.TransportLatency)
+	}
+	if latency > defaultSlowThreshold {
+		ev := SlowVRpcEvent{
+			At:               start,
+			Method:           desc.Method(),
+			Latency:          latency,
+			Session:          sh.session.LogName(),
+			Success:          invokeErr == nil,
+			PoolWait:         poolWait,
+			BackendLatency:   backendDur,
+			TransportLatency: result.TransportLatency,
+			RPCIDOnSession:   result.RPCIDOnSession,
+		}
+		ev.SessionAge = start.Sub(sh.session.StartedAt())
+		// PeerInfo on the row makes cohort patterns (e.g. failures
+		// clustered on one AFE) visible without a per-session cross-ref.
+		ev.Peer = peerInfoToSnapshot(sh.session.PeerInfo())
+		ev.RemoteAddr = sh.session.RemoteAddr()
+		if invokeErr != nil {
+			// stdlib context errors don't implement GRPCStatus, so
+			// status.Code returns Unknown — classify explicitly so
+			// deadline/cancel rows label correctly.
+			switch {
+			case errors.Is(invokeErr, context.DeadlineExceeded):
+				ev.ErrCode = "DeadlineExceeded"
+			case errors.Is(invokeErr, context.Canceled):
+				ev.ErrCode = "Canceled"
+			default:
+				ev.ErrCode = status.Code(invokeErr).String()
+			}
+			btopt.Debugf(nil, "POOL %s slow vRPC failed method=%s session=%s rpc_id=%d code=%s latency=%v session_age=%v backend=%v raw_err=%v",
+				p.poolName, ev.Method, ev.Session, ev.RPCIDOnSession, ev.ErrCode, ev.Latency, ev.SessionAge, ev.BackendLatency, invokeErr)
+		}
+		p.recordSlowVRpc(ev)
+	}
+	return result, invokeErr
+}

--- a/bigtable/internal/transport/session_pool.go
+++ b/bigtable/internal/transport/session_pool.go
@@ -252,10 +252,10 @@ func (p *SessionPoolImpl) CheckoutSession(ctx context.Context) (*SessionHandle, 
 		// then sessionList dequeues one idle session in that AFE.
 		ready := p.sl.ReadyAfes()
 		pickerName := picker.Name()
-		AfeID, picked, decision := picker.PickAfe(ready)
+		afeID, picked, decision := picker.PickAfe(ready)
 		p.recordPickDecision(decision, pickerName)
 		if picked {
-			if idle := p.sl.Checkout(AfeID); idle != nil {
+			if idle := p.sl.Checkout(afeID); idle != nil {
 				idle.IncOutstanding()
 				idle.IncPicks()
 				return idle, nil

--- a/bigtable/internal/transport/session_pool.go
+++ b/bigtable/internal/transport/session_pool.go
@@ -121,15 +121,9 @@ type SessionPoolImpl struct {
 	// spawns tracks pool-spawned goroutines (today: createSession
 	// workers) so Close can wait them out. Session-owned goroutines
 	// are tracked separately on Session.loops.
-	spawns            sync.WaitGroup
-	closed            bool
-	scalingInProgress bool
-	// minSessions / maxSessions are the server-driven pool bounds.
-	// Writes go under p.mu so PoolSnapshot reads a consistent pair;
-	// hot-path readers Load() without the lock (no cross-field invariant
-	// with picker/budget/threshold).
-	minSessions        atomic.Int32
-	maxSessions        atomic.Int32
+	spawns             sync.WaitGroup
+	closed             bool
+	scalingInProgress  bool
 	streamFactory      func(ctx context.Context) (Stream, error)
 	openSessionRequest *spb.OpenSessionRequest
 	metadata           metadata.MD
@@ -206,8 +200,6 @@ func NewSessionPoolImpl(id uint64, poolName string, min, max int, streamFactory 
 		sl:                 newSessionList(),
 	}
 	pool.m.afePickCounts = make(map[AfeID]int64)
-	pool.minSessions.Store(int32(min))
-	pool.maxSessions.Store(int32(max))
 
 	// Bootstrap sizer/picker/budget/threshold from the default
 	// ClientConfiguration proto (default_client_config.go). Fallback
@@ -216,6 +208,16 @@ func NewSessionPoolImpl(id uint64, poolName string, min, max int, streamFactory 
 	// fires UpdateConfig synchronously and replaces these with
 	// server-driven values before the pool serves traffic.
 	defaultCfg := defaultPoolConfig()
+	// min/max <= 0 fall back to the same proto defaults the rest of the
+	// bootstrap reads from — otherwise a caller that instantiated the
+	// pool with zero bounds would see the sizer clamp DesiredCapacity to
+	// 0 and never open a session before UpdateConfig arrives.
+	if min <= 0 {
+		min = int(defaultCfg.GetMinSessionCount())
+	}
+	if max <= 0 {
+		max = int(defaultCfg.GetMaxSessionCount())
+	}
 	fetcher := func() *PoolStats { return pool.Stats() }
 	pool.sizer = NewPoolSizer(fetcher, min, max, float64(defaultCfg.GetHeadroom()))
 	pool.picker = pickerFromLoadBalancing(defaultCfg.GetLoadBalancingOptions())
@@ -272,11 +274,11 @@ func (p *SessionPoolImpl) CheckoutSession(ctx context.Context) (*SessionHandle, 
 			recordDebugTag(tagSessionPoolPickLostRace)
 		}
 
-		// Slow path: picker returned nil. Dying sessions leave sl.readyCount
+		// Slow path: picker returned nil or 2 checkoutSession raced and returned the same AFE id. Dying sessions leave sl.readyCount
 		// the instant they transition out of Ready (OnClosing), so the
 		// maxSessions gate reflects only live-or-starting sessions —
 		// a miss just means all live sessions are busy.
-		if p.sl.ReadyCount() < int(p.maxSessions.Load()) {
+		if p.sl.ReadyCount() < p.sizer.MaxSessions() {
 			p.spawnTickOnce(p.poolCtx)
 		}
 
@@ -342,29 +344,36 @@ func (p *SessionPoolImpl) signalFree() {
 func (p *SessionPoolImpl) drainWaitersWithErr(err error) int {
 	p.waitersMu.Lock()
 	defer p.waitersMu.Unlock()
-	n := 0
+	woken := 0
 	for {
 		e := p.waiters.Front()
 		if e == nil {
-			return n
+			return woken
 		}
 		w := e.Value.(*waiter)
 		p.waiters.Remove(e)
 		w.elem = nil
 		w.err = err
 		close(w.ready)
-		n++
+		woken++
 	}
 }
 
 // Stats snapshots ready/inUse/starting/pending counts.
+//
+// The AllHandles walk and the startingSessions read now happen under
+// disjoint locks, so a handle can transition starting → ready between
+// the two reads and be missed by both — StartingCount + ReadyCount is
+// therefore a best-effort snapshot, not a coherent sum. Sizer.Decide
+// is the sole consumer and self-corrects on the next Tick.
 func (p *SessionPoolImpl) Stats() *PoolStats {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
+	// AllHandles takes its own snapshot under sl.mu — walk it OUTSIDE
+	// p.mu so per-session Load()s can't back up under the pool lock and
+	// stall CheckoutSession. State/outstanding reads are all atomic.
+	handles := p.sl.AllHandles()
 	ready := 0
 	inUse := 0
-	for _, sh := range p.sl.AllHandles() {
+	for _, sh := range handles {
 		// Same nil-guard shape as sampleActiveUptimes and sweepStuckSessions
 		// in session_pool_lifecycle.go — sl.AllHandles is a snapshot and
 		// the underlying handle can be torn down mid-iteration by a
@@ -380,6 +389,13 @@ func (p *SessionPoolImpl) Stats() *PoolStats {
 		}
 	}
 
+	// p.mu bracket is now just around the startingSessions map read +
+	// pendingStarts int read — both plain non-atomic fields the pool
+	// mutates from Tick / createSession under p.mu.
+	p.mu.Lock()
+	startingCount := len(p.startingSessions) + p.pendingStarts
+	p.mu.Unlock()
+
 	return &PoolStats{
 		ReadyCount: ready,
 		InUseCount: inUse,
@@ -387,7 +403,7 @@ func (p *SessionPoolImpl) Stats() *PoolStats {
 		// PLUS goroutines Tick has spawned but that haven't yet reached
 		// the transfer point. Both count as "in-flight scale-up capacity"
 		// so the sizer doesn't request duplicate delta in a burst.
-		StartingCount: len(p.startingSessions) + p.pendingStarts,
+		StartingCount: startingCount,
 		// PendingCount is the true pool-boundary queue depth —
 		// callers parked inside CheckoutSession waiting on
 		// freeSignal. The pending-rpc count is the input
@@ -401,17 +417,21 @@ func (p *SessionPoolImpl) Stats() *PoolStats {
 // bracket min/max as an atomic pair here.
 func (p *SessionPoolImpl) UpdateConfig(config *spb.SessionClientConfiguration_SessionPoolConfiguration) {
 	p.m.listenerFires.Add(1)
+	// p.mu only brackets the picker swap — it's the sole non-atomic
+	// field UpdateConfig mutates that a concurrent CheckoutSession
+	// reads. sizer.UpdateConfig / budget.UpdateConfig each take their
+	// own internal lock; the consecutive-failure threshold is a raw
+	// atomic. Keeping them out of p.mu means UpdateConfig can't stall
+	// a hot-path CheckoutSession behind the sizer/budget config writes.
 	p.mu.Lock()
-	// Stores stay under p.mu so PoolSnapshot (also under p.mu) reads a
-	// consistent min/max pair. Hot-path readers still Load() without
-	// the lock — atomic makes both directions safe.
-	p.minSessions.Store(int32(config.MinSessionCount))
-	p.maxSessions.Store(int32(config.MaxSessionCount))
 	if config.LoadBalancingOptions != nil {
 		p.picker = pickerFromLoadBalancing(config.LoadBalancingOptions)
 	}
 	p.mu.Unlock()
 
+	// sizer.UpdateConfig re-stores min/max/headroom/qlen atomically
+	// under the sizer's own mu — pool no longer duplicates min/max into
+	// its own atomics.
 	p.sizer.UpdateConfig(config)
 
 	// Budget was bootstrapped with a placeholder; UpdateConfig on
@@ -476,6 +496,12 @@ func (p *SessionPoolImpl) Invoke(ctx context.Context, desc VRpcDescriptor, req i
 		recordDebugTag(tagSessionPoolCheckoutFailedCINil)
 		return InvokeResult{}, err
 	}
+	// poolWait is the queue-time spent inside CheckoutSession waiting
+	// for an idle session — the Go-side observation of what OTel /
+	// Cloud Monitoring surfaces as `client_blocking_latencies` (Java
+	// internal name: throttling latencies). Wire it into the OTel
+	// per-attempt path when the metric plumbing lands; right now it
+	// only feeds the sessionz slow-vRPC row below.
 	poolWait := time.Since(checkoutStart)
 	// Anchor Latency at checkoutStart so recorded latency includes queue
 	// wait (user-visible time).

--- a/bigtable/internal/transport/session_pool_afe_test.go
+++ b/bigtable/internal/transport/session_pool_afe_test.go
@@ -1,0 +1,209 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+)
+
+// injectActiveOnAfe is injectActiveSession but stamps the session's PeerInfo
+// with the given AFE id before registering it with sessionList so the
+// two-tier picker sees the correct bucket.
+func injectActiveOnAfe(t *testing.T, p *SessionPoolImpl, name string, afe AfeID) *SessionHandle {
+	t.Helper()
+	stream := newFakeStream()
+	sh := newSessionHandle(nil, time.Now())
+	s := NewSession(name, stream, SessionHooks{
+		OnStart:  p.onStart,
+		OnActive: func(_ *Session) { p.onActive(sh) },
+		OnClose:  func(_ *Session, err error) { p.onClose(sh, err) },
+	}, SessionTypeTable)
+	s.state.Store(int32(StateReady))
+	// Stamp PeerInfo BEFORE registering — sessionList reads AfeID() at
+	// OnSessionStarted, matching production's sync-PeerInfo invariant.
+	s.peerInfo.Store(&spb.PeerInfo{ApplicationFrontendId: int64(afe)})
+	sh.session = s
+
+	p.sl.OnSessionStarted(sh)
+	return sh
+}
+
+// checkoutAndRelease drives one round-trip through the two-tier picker:
+// CheckoutSession → simulated Invoke return (DecOutstanding + latency
+// record) plus simulated drainSlot effects (ReleaseToPool + signalFree —
+// what SessionHandle.onSlotDrained would fire in production under v3).
+// These tests bypass Session entirely (no real activeRPC slot to drain),
+// so the simulator collapses both phases into one call. Skips the real
+// Invoke path so tests don't depend on a fake vRPC responder.
+func checkoutAndRelease(t *testing.T, p *SessionPoolImpl, recordLatency time.Duration, ok bool) *SessionHandle {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	sh, err := p.CheckoutSession(ctx)
+	if err != nil {
+		t.Fatalf("CheckoutSession: %v", err)
+	}
+	sh.DecOutstanding()
+	p.sl.ReleaseToPool(sh)
+	if recordLatency > 0 {
+		p.sl.RecordVRpcOutcome(sh, recordLatency, 0, ok)
+	}
+	p.signalFree()
+	return sh
+}
+
+// TestPool_LeastInFlight_FansOutAcrossAFEs verifies the default picker
+// spreads traffic across per-AFE buckets rather than concentrating on
+// one AFE. Distribution should be roughly even under LeastInFlight when
+// every AFE has the same number of idle sessions.
+func TestPool_LeastInFlight_FansOutAcrossAFEs(t *testing.T) {
+	p := newTestPool(t, 1, 30)
+	defer p.Close()
+
+	// 3 AFEs × 2 sessions each = 6 sessions total.
+	afes := []AfeID{101, 202, 303}
+	for _, a := range afes {
+		injectActiveOnAfe(t, p, "s", a)
+		injectActiveOnAfe(t, p, "s", a)
+	}
+
+	counts := map[AfeID]int{}
+	const N = 900 // 3-way fair expected value = 300.
+	for i := 0; i < N; i++ {
+		sh := checkoutAndRelease(t, p, 0, true)
+		counts[sh.session.AfeID()]++
+	}
+
+	for _, a := range afes {
+		got := counts[a]
+		if got < 220 || got > 380 {
+			t.Errorf("AFE %d picked %d/%d times, want ~300 ±25%%", a, got, N)
+		}
+	}
+}
+
+// TestPool_LeastLatency_PrefersLowCostAFE verifies that once
+// LeastLatencyAfePicker is engaged and per-AFE PeakEwma has warmed up,
+// picks steer toward the AFE with lower e2e cost. Two AFEs, one seeded
+// with a much lower latency history.
+func TestPool_LeastLatency_PrefersLowCostAFE(t *testing.T) {
+	p := newTestPool(t, 1, 20)
+	defer p.Close()
+
+	// Switch picker to LeastLatency (subset-size = 2 = both AFEs).
+	p.picker = NewLeastLatencyAfePicker(2)
+
+	slow := injectActiveOnAfe(t, p, "slow", 1)
+	fast := injectActiveOnAfe(t, p, "fast", 2)
+
+	// Warm the per-AFE PeakEwma so the picker has real cost signal.
+	// Both AFEs get 20 OK samples; slow at 100ms, fast at 5ms.
+	for i := 0; i < 20; i++ {
+		p.sl.RecordVRpcOutcome(slow, 100*time.Millisecond, 0, true)
+		p.sl.RecordVRpcOutcome(fast, 5*time.Millisecond, 0, true)
+	}
+
+	counts := map[AfeID]int{}
+	const N = 400
+	for i := 0; i < N; i++ {
+		sh := checkoutAndRelease(t, p, 0, true)
+		counts[sh.session.AfeID()]++
+	}
+
+	if counts[2] <= counts[1] {
+		t.Errorf("fast AFE picks (%d) should exceed slow AFE picks (%d)", counts[2], counts[1])
+	}
+	// Expect strong preference — fast AFE should win ≥ 80% under K=2 =
+	// full-scan on 2 candidates (deterministic min-cost).
+	if float64(counts[2])/float64(N) < 0.90 {
+		t.Errorf("fast AFE share = %.2f%%, want ≥ 90%%", 100*float64(counts[2])/float64(N))
+	}
+}
+
+// TestPool_LeastLatency_IgnoresFailingAFELatency verifies the OK-gate
+// on per-AFE PeakEwma updates: a fast-failing AFE cannot pretend to be
+// the fastest by feeding synthetic 1ns non-OK samples. Per the
+// (SessionList.java:181-187).
+func TestPool_LeastLatency_IgnoresFailingAFELatency(t *testing.T) {
+	p := newTestPool(t, 1, 20)
+	defer p.Close()
+
+	p.picker = NewLeastLatencyAfePicker(2)
+
+	failing := injectActiveOnAfe(t, p, "failing", 1)
+	healthy := injectActiveOnAfe(t, p, "healthy", 2)
+
+	// The failing AFE gets 50 non-OK samples with an absurdly low
+	// latency. If the OK-gate is broken, these poison PeakEwma to 1ns
+	// and the picker will always pick this AFE.
+	for i := 0; i < 50; i++ {
+		p.sl.RecordVRpcOutcome(failing, 1*time.Nanosecond, 0, false)
+	}
+	// Healthy AFE gets legitimate 10ms OK samples.
+	for i := 0; i < 20; i++ {
+		p.sl.RecordVRpcOutcome(healthy, 10*time.Millisecond, 0, true)
+	}
+
+	counts := map[AfeID]int{}
+	const N = 200
+	for i := 0; i < N; i++ {
+		sh := checkoutAndRelease(t, p, 0, true)
+		counts[sh.session.AfeID()]++
+	}
+
+	// The failing AFE has E2eCost == afeE2eEwmaSeed (no OK samples ever
+	// landed, so the seed is untouched), the healthy AFE has
+	// E2eCost == ~10ms. With the seed at 1ms both AFEs look plausible
+	// to LeastLatencyPicker on first pick — but the point of THIS test
+	// is confirming the OK-gate: the failing AFE's PeakEwma stays at
+	// the seed, not 1ns. Either winner is fine; what we assert is that
+	// the failing AFE's tracker didn't get polluted by the non-OK
+	// samples.
+	if got, want := p.sl.afeHandles[1].e2eEwma.Value(), float64(afeE2eEwmaSeed); got != want {
+		t.Errorf("failing-AFE e2eEwma = %g, want %g (seed unchanged; OK-gate broken?)", got, want)
+	}
+	if got := p.sl.afeHandles[2].e2eEwma.Value(); got == 0 {
+		t.Errorf("healthy-AFE e2eEwma = 0, want > 0 (OK samples not recorded)")
+	}
+	_ = counts // pick distribution not asserted; the OK-gate invariant is
+	// what matters.
+}
+
+// TestPool_UnknownAFE_BucketedAtZero verifies the AfeID=0 sentinel path
+// used when sessions handshake without a peer-info header (older
+// backends / test injection helpers that skip peer info). Those
+// sessions still get picked, just from the shared unknown bucket.
+func TestPool_UnknownAFE_BucketedAtZero(t *testing.T) {
+	p := newTestPool(t, 1, 20)
+	defer p.Close()
+
+	// injectActiveSession (no On-Afe variant) — leaves PeerInfo nil so
+	// AfeID() returns 0.
+	injectActiveSession(t, p, "no-peer-info", time.Now())
+
+	sh := checkoutAndRelease(t, p, 0, true)
+	if got := sh.session.AfeID(); got != 0 {
+		t.Errorf("AfeID = %d, want 0 (unknown-bucket sentinel)", got)
+	}
+	// Snapshot exposes the bucket.
+	rows := p.sl.Snapshot()
+	if len(rows) != 1 || rows[0].ID != 0 {
+		t.Errorf("Snapshot = %+v, want a single AFE 0 row", rows)
+	}
+}

--- a/bigtable/internal/transport/session_pool_consecutive_failures_test.go
+++ b/bigtable/internal/transport/session_pool_consecutive_failures_test.go
@@ -29,25 +29,28 @@ import (
 )
 
 // stampCloseReason sets a Session's close reason directly. Bypasses
-// handleClose so tests can drive the noteAbnormalCloseIfAny gate
-// without wiring a fake stream teardown.
+// handleClose so tests can drive the reason-recorded path without
+// wiring a fake stream teardown. (No longer required by the trip
+// gate — kept for close-reason-histogram tests.)
 func stampCloseReason(s *Session, reason string) {
 	s.setCloseReason(reason)
 }
 
-// abnormalOnCloseFor injects a fresh Session into the pool, stamps a
-// close reason, then invokes p.onClose(sh, nil) so the abnormal-close
-// counter path runs. abnormal picks a reason isAbnormalCloseReason
-// classifies as abnormal ("StreamEnd:Unavailable"); a false argument
-// picks a clean reason ("StreamEnd:EOF").
+// abnormalOnCloseFor drives one iteration of the abnormal-close counter
+// path. The trip gate is now state-based: sh.activated == false is the
+// exact "session never reached StateReady" signal. `abnormal=true`
+// injects a starting-set handle (never activated, mirrors a
+// createSession that died before onActive fires); `abnormal=false`
+// injects an activated handle, which the state-based gate correctly
+// treats as a healthy open regardless of the close reason.
 func abnormalOnCloseFor(t testing.TB, p *SessionPoolImpl, abnormal bool) {
 	t.Helper()
-	sh := injectActiveSession(t, p, "sess", time.Now())
-	reason := "StreamEnd:EOF"
 	if abnormal {
-		reason = "StreamEnd:Unavailable"
+		sh := injectStartingSession(t, p, "starting")
+		p.onClose(sh, nil)
+		return
 	}
-	stampCloseReason(sh.session, reason)
+	sh := injectActiveSession(t, p, "active", time.Now())
 	p.onClose(sh, nil)
 }
 
@@ -77,12 +80,13 @@ func TestConsecutiveFailures_CleanCloseDoesNotIncrement(t *testing.T) {
 
 // TestConsecutiveFailures_UserReasonNotAbnormal pins the fix that keeps
 // pool-driven teardown from tripping the consecutive-failure circuit
-// breaker. Pool.Close's Phase-2 fires s.Close with
-// CLOSE_SESSION_REASON_USER on every session; closeReasonLabel maps that
-// to "User". Without the whitelist entry, isAbnormalCloseReason would
-// classify each close as abnormal and a 100-session Pool.Close would trip
-// the breaker AND drain any late-arriving waiters with
-// ErrConsecutiveFailures instead of ErrPoolClosed.
+// breaker. Pool.Close's Phase-2 fires s.Close on already-activated
+// sessions; state-based classification treats sh.activated=true as a
+// healthy open regardless of close reason, so a 100-session Pool.Close
+// cannot trip the breaker. Without the state-based gate a leaked
+// reason-string classification would fire on every teardown and drain
+// any late-arriving waiters with ErrConsecutiveFailures instead of
+// ErrPoolClosed.
 func TestConsecutiveFailures_UserReasonNotAbnormal(t *testing.T) {
 	p := newTestPool(t, 1, 10)
 
@@ -90,8 +94,9 @@ func TestConsecutiveFailures_UserReasonNotAbnormal(t *testing.T) {
 	// the second close instead of needing 10.
 	p.consecutiveFailureThreshold.Store(2)
 
-	// Fire "User" close-reason twice — the label Pool.Close's Phase-2
-	// stamps on every session.
+	// Fire "User" close-reason twice on ACTIVATED sessions — the
+	// closest fixture to Pool.Close's Phase-2 (activated sessions
+	// closed with REASON_USER). State-based gate must NOT count them.
 	for i := 0; i < 2; i++ {
 		sh := injectActiveSession(t, p, "user-close", time.Now())
 		stampCloseReason(sh.session, "User")
@@ -99,7 +104,7 @@ func TestConsecutiveFailures_UserReasonNotAbnormal(t *testing.T) {
 	}
 
 	if got := p.consecutiveFailures.Load(); got != 0 {
-		t.Fatalf("consecutiveFailures after 2 User closes = %d, want 0 (User must be whitelisted; Pool.Close would otherwise trip the breaker on every teardown)", got)
+		t.Fatalf("consecutiveFailures after 2 User closes = %d, want 0 (state-based gate must skip activated sessions; Pool.Close would otherwise trip the breaker on every teardown)", got)
 	}
 }
 
@@ -300,15 +305,14 @@ func TestConsecutiveFailures_TripCarriesLastCauseAndGRPCStatus(t *testing.T) {
 		done <- w.err
 	}()
 
-	// First bump: benign cause, doesn't trip.
-	sh1 := injectActiveSession(t, p, "s1", time.Now())
-	stampCloseReason(sh1.session, "StreamEnd:Unavailable")
+	// First bump: benign cause, doesn't trip. Starting-set handle
+	// (never activated) so the state-based gate counts it as abnormal.
+	sh1 := injectStartingSession(t, p, "s1")
 	sh1.session.setCloseErr(errors.New("transient"))
 	p.onClose(sh1, nil)
 
 	// Second bump: the cause we want propagated to the waiter.
-	sh2 := injectActiveSession(t, p, "s2", time.Now())
-	stampCloseReason(sh2.session, "StreamEnd:FailedPrecondition")
+	sh2 := injectStartingSession(t, p, "s2")
 	sh2.session.setCloseErr(serverErr)
 	p.onClose(sh2, nil)
 

--- a/bigtable/internal/transport/session_pool_consecutive_failures_test.go
+++ b/bigtable/internal/transport/session_pool_consecutive_failures_test.go
@@ -1,0 +1,371 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+// stampCloseReason sets a Session's close reason directly. Bypasses
+// handleClose so tests can drive the noteAbnormalCloseIfAny gate
+// without wiring a fake stream teardown.
+func stampCloseReason(s *Session, reason string) {
+	s.setCloseReason(reason)
+}
+
+// abnormalOnCloseFor injects a fresh Session into the pool, stamps a
+// close reason, then invokes p.onClose(sh, nil) so the abnormal-close
+// counter path runs. abnormal picks a reason isAbnormalCloseReason
+// classifies as abnormal ("StreamEnd:Unavailable"); a false argument
+// picks a clean reason ("StreamEnd:EOF").
+func abnormalOnCloseFor(t testing.TB, p *SessionPoolImpl, abnormal bool) {
+	t.Helper()
+	sh := injectActiveSession(t, p, "sess", time.Now())
+	reason := "StreamEnd:EOF"
+	if abnormal {
+		reason = "StreamEnd:Unavailable"
+	}
+	stampCloseReason(sh.session, reason)
+	p.onClose(sh, nil)
+}
+
+func TestConsecutiveFailures_AbnormalOnCloseIncrements(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+
+	if got := p.consecutiveFailures.Load(); got != 0 {
+		t.Fatalf("initial consecutiveFailures = %d, want 0", got)
+	}
+
+	// Two abnormal closes below the default threshold of 10.
+	abnormalOnCloseFor(t, p, true)
+	abnormalOnCloseFor(t, p, true)
+
+	if got := p.consecutiveFailures.Load(); got != 2 {
+		t.Fatalf("after 2 abnormal closes = %d, want 2", got)
+	}
+}
+
+func TestConsecutiveFailures_CleanCloseDoesNotIncrement(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	abnormalOnCloseFor(t, p, false)
+	if got := p.consecutiveFailures.Load(); got != 0 {
+		t.Fatalf("clean close bumped counter to %d, want 0", got)
+	}
+}
+
+// TestConsecutiveFailures_UserReasonNotAbnormal pins the fix that keeps
+// pool-driven teardown from tripping the consecutive-failure circuit
+// breaker. Pool.Close's Phase-2 fires s.Close with
+// CLOSE_SESSION_REASON_USER on every session; closeReasonLabel maps that
+// to "User". Without the whitelist entry, isAbnormalCloseReason would
+// classify each close as abnormal and a 100-session Pool.Close would trip
+// the breaker AND drain any late-arriving waiters with
+// ErrConsecutiveFailures instead of ErrPoolClosed.
+func TestConsecutiveFailures_UserReasonNotAbnormal(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+
+	// Drop threshold to 2 so a leaked-classification bug would trip on
+	// the second close instead of needing 10.
+	p.consecutiveFailureThreshold.Store(2)
+
+	// Fire "User" close-reason twice — the label Pool.Close's Phase-2
+	// stamps on every session.
+	for i := 0; i < 2; i++ {
+		sh := injectActiveSession(t, p, "user-close", time.Now())
+		stampCloseReason(sh.session, "User")
+		p.onClose(sh, nil)
+	}
+
+	if got := p.consecutiveFailures.Load(); got != 0 {
+		t.Fatalf("consecutiveFailures after 2 User closes = %d, want 0 (User must be whitelisted; Pool.Close would otherwise trip the breaker on every teardown)", got)
+	}
+}
+
+// TestConsecutiveFailures_ResetOnSessionOpen pins Java-parity reset
+// semantics: a successful session-open (onActive) clears the
+// consecutive-failure counter — NOT a successful vRPC. Under sustained
+// failures no session reaches Ready, so the counter grows toward the
+// trip threshold; a fresh session opening is the only "sustained
+// transport health" signal that clears it.
+func TestConsecutiveFailures_ResetOnSessionOpen(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	abnormalOnCloseFor(t, p, true)
+	abnormalOnCloseFor(t, p, true)
+	if got := p.consecutiveFailures.Load(); got != 2 {
+		t.Fatalf("precondition: counter = %d, want 2", got)
+	}
+
+	// Fire onActive on a fresh handle — mirrors production's
+	// createSession → hooks.onActive → p.onActive(sh) chain.
+	sh := newSessionHandle(nil, time.Now())
+	stream := newFakeStream()
+	s := NewSession("healthy", stream, SessionHooks{
+		OnStart:  p.onStart,
+		OnActive: func(_ *Session) { p.onActive(sh) },
+		OnClose:  func(_ *Session, err error) { p.onClose(sh, err) },
+	}, SessionTypeTable)
+	s.state.Store(int32(StateReady))
+	sh.session = s
+	p.onActive(sh)
+
+	if got := p.consecutiveFailures.Load(); got != 0 {
+		t.Fatalf("after successful session-open = %d, want 0", got)
+	}
+}
+
+// TestConsecutiveFailures_VRpcOutcomeDoesNotReset pins the flip side
+// of ResetOnSessionOpen: neither an OK nor a failed vRPC affects the
+// counter. Only session-open events (onActive) reset it.
+func TestConsecutiveFailures_VRpcOutcomeDoesNotReset(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	abnormalOnCloseFor(t, p, true)
+	abnormalOnCloseFor(t, p, true)
+	if got := p.consecutiveFailures.Load(); got != 2 {
+		t.Fatalf("precondition: counter = %d, want 2", got)
+	}
+
+	sh := injectActiveSession(t, p, "healthy", time.Now())
+	// OK vRPC — must NOT clear the counter.
+	p.noteVRpcOutcome(sh, time.Millisecond, time.Millisecond, true)
+	if got := p.consecutiveFailures.Load(); got != 2 {
+		t.Errorf("counter after OK vRPC = %d, want 2 (only onActive resets)", got)
+	}
+	// Failed vRPC — also must NOT touch the counter (increment happens
+	// via onClose's noteAbnormalCloseIfAny, not via vRPC outcome).
+	p.noteVRpcOutcome(sh, time.Millisecond, time.Millisecond, false)
+	if got := p.consecutiveFailures.Load(); got != 2 {
+		t.Errorf("counter after failed vRPC = %d, want 2 (vRPC outcome must not touch the counter)", got)
+	}
+}
+
+func TestConsecutiveFailures_UpdateConfigHonoredByTrip(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+
+	// Drop the threshold to 3 via UpdateConfig — same code path
+	// ClientConfigurationManager would take.
+	p.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
+		MinSessionCount:                    1,
+		MaxSessionCount:                    10,
+		ConsecutiveSessionFailureThreshold: 3,
+		NewSessionCreationBudget:           50,
+		NewSessionCreationPenalty:          durationpb.New(60 * time.Second),
+	})
+	if got := p.consecutiveFailureThreshold.Load(); got != 3 {
+		t.Fatalf("threshold after UpdateConfig = %d, want 3", got)
+	}
+
+	// Two abnormal closes stay under the trip.
+	abnormalOnCloseFor(t, p, true)
+	abnormalOnCloseFor(t, p, true)
+	if got := p.consecutiveFailures.Load(); got != 2 {
+		t.Fatalf("pre-trip counter = %d, want 2", got)
+	}
+
+	// Third abnormal close crosses the threshold and resets.
+	abnormalOnCloseFor(t, p, true)
+	if got := p.consecutiveFailures.Load(); got != 0 {
+		t.Fatalf("post-trip counter = %d, want 0 (reset by trip)", got)
+	}
+}
+
+func TestConsecutiveFailures_TripWakesParkedWaitersWithSentinel(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+
+	// Drop threshold to 2 for a snappy test. Any live handles the pool
+	// might have from setup are irrelevant to the waiter path: we park
+	// callers directly on the waiter queue via drainWaitersWithErr's
+	// wake channel semantics, which is what the trip actually calls.
+	p.consecutiveFailureThreshold.Store(2)
+
+	// Two goroutines block in the waiter queue. Rather than call
+	// CheckoutSession (which would race with any auto-scaling scheduled
+	// off the pool ctx), enqueue directly — the test exercises the
+	// wake/err contract, and CheckoutSession is separately covered.
+	const nWaiters = 3
+	results := make(chan error, nWaiters)
+	var wg sync.WaitGroup
+	waiters := make([]*waiter, 0, nWaiters)
+	for i := 0; i < nWaiters; i++ {
+		w := &waiter{ready: make(chan struct{})}
+		p.waitersMu.Lock()
+		w.elem = p.waiters.PushBack(w)
+		p.waitersMu.Unlock()
+		p.waitersCount.Add(1)
+		waiters = append(waiters, w)
+
+		wg.Add(1)
+		go func(w *waiter) {
+			defer wg.Done()
+			<-w.ready
+			p.waitersCount.Add(-1)
+			results <- w.err
+		}(w)
+	}
+
+	// Trip the threshold.
+	abnormalOnCloseFor(t, p, true)
+	abnormalOnCloseFor(t, p, true)
+
+	// All waiters must wake with ErrConsecutiveFailures within a
+	// generous but bounded window (no polling — direct chan wait
+	// backed by drainWaitersWithErr closing every ready chan).
+	waitCh := make(chan struct{})
+	go func() { wg.Wait(); close(waitCh) }()
+	select {
+	case <-waitCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiters not woken after trip")
+	}
+
+	close(results)
+	got := 0
+	for err := range results {
+		if !errors.Is(err, ErrConsecutiveFailures) {
+			t.Fatalf("waiter err = %v, want ErrConsecutiveFailures", err)
+		}
+		got++
+	}
+	if got != nWaiters {
+		t.Fatalf("woke %d waiters, want %d", got, nWaiters)
+	}
+
+	// Counter must have been reset by the trip.
+	if got := p.consecutiveFailures.Load(); got != 0 {
+		t.Fatalf("counter after trip = %d, want 0", got)
+	}
+
+	// After the trip, drainWaitersWithErr has emptied the queue.
+	p.waitersMu.Lock()
+	remaining := p.waiters.Len()
+	p.waitersMu.Unlock()
+	if remaining != 0 {
+		t.Fatalf("waiter queue after trip has %d entries, want 0", remaining)
+	}
+	_ = waiters // silence unused when the test is trimmed
+}
+
+// TestConsecutiveFailures_TripCarriesLastCauseAndGRPCStatus pins the
+// error propagation contract added alongside the abnormal-close
+// counter: when the breaker trips, waiters wake with an error that
+// (a) satisfies errors.Is(err, ErrConsecutiveFailures) — retry paths
+// still work; (b) unwraps to the last session's raw Recv error — the
+// operator sees WHY the trip happened; (c) inherits the underlying
+// gRPC status code via GRPCStatus so status.Code(err) returns the
+// server's rejection code (e.g. FailedPrecondition) instead of Unknown.
+// Without this, a still-being-created MV manifests as
+// "session pool tripped consecutive-failure threshold" with code
+// Unknown — masking the actionable server signal.
+func TestConsecutiveFailures_TripCarriesLastCauseAndGRPCStatus(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	p.consecutiveFailureThreshold.Store(2)
+
+	// The last abnormal close will carry a synthetic FailedPrecondition
+	// mirroring the shape the server emits when MV backfill is running.
+	const wantMsg = "materialized view is still being created"
+	serverErr := status.Error(codes.FailedPrecondition, wantMsg)
+
+	// One waiter is enough to observe the drain-time wrap.
+	w := &waiter{ready: make(chan struct{})}
+	p.waitersMu.Lock()
+	w.elem = p.waiters.PushBack(w)
+	p.waitersMu.Unlock()
+	p.waitersCount.Add(1)
+
+	done := make(chan error, 1)
+	go func() {
+		<-w.ready
+		p.waitersCount.Add(-1)
+		done <- w.err
+	}()
+
+	// First bump: benign cause, doesn't trip.
+	sh1 := injectActiveSession(t, p, "s1", time.Now())
+	stampCloseReason(sh1.session, "StreamEnd:Unavailable")
+	sh1.session.setCloseErr(errors.New("transient"))
+	p.onClose(sh1, nil)
+
+	// Second bump: the cause we want propagated to the waiter.
+	sh2 := injectActiveSession(t, p, "s2", time.Now())
+	stampCloseReason(sh2.session, "StreamEnd:FailedPrecondition")
+	sh2.session.setCloseErr(serverErr)
+	p.onClose(sh2, nil)
+
+	var got error
+	select {
+	case got = <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter not woken after trip")
+	}
+
+	if !errors.Is(got, ErrConsecutiveFailures) {
+		t.Fatalf("errors.Is(err, ErrConsecutiveFailures) = false; err = %v", got)
+	}
+	if code := status.Code(got); code != codes.FailedPrecondition {
+		t.Fatalf("status.Code(err) = %v, want FailedPrecondition; err = %v", code, got)
+	}
+	if !strings.Contains(got.Error(), wantMsg) {
+		t.Fatalf("err text %q missing underlying cause %q", got.Error(), wantMsg)
+	}
+}
+
+func TestConsecutiveFailures_CheckoutSessionReturnsSentinelOnTrip(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	p.consecutiveFailureThreshold.Store(1)
+
+	// No idle sessions, no scaling wired to make one — CheckoutSession
+	// will park immediately. Give it a long-ish ctx so the ctx path
+	// doesn't win the race with the trip.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	got := make(chan error, 1)
+	go func() {
+		_, err := p.CheckoutSession(ctx)
+		got <- err
+	}()
+
+	// Wait until the caller is parked, then trip.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if p.waitersCount.Load() > 0 {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if p.waitersCount.Load() == 0 {
+		t.Fatal("CheckoutSession did not park within 500ms")
+	}
+
+	abnormalOnCloseFor(t, p, true)
+
+	select {
+	case err := <-got:
+		if !errors.Is(err, ErrConsecutiveFailures) {
+			t.Fatalf("CheckoutSession err = %v, want ErrConsecutiveFailures", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("CheckoutSession did not return after trip")
+	}
+}

--- a/bigtable/internal/transport/session_pool_debug.go
+++ b/bigtable/internal/transport/session_pool_debug.go
@@ -1,0 +1,416 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Debug / observability ring buffers and histograms for SessionPoolImpl.
+// Feeds sessionz / loadz / metric exporters; none of the pool's
+// operational logic depends on it.
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"math/bits"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	btopt "cloud.google.com/go/bigtable/internal/option"
+	"google.golang.org/grpc/status"
+)
+
+// poolMetrics owns every observability-only field for SessionPoolImpl:
+// counters, ring buffers, and histograms. Embedded by value on the pool
+// and accessed as p.m.<field>.
+type poolMetrics struct {
+	// Lifecycle counters, lock-free.
+	sessionsOpened atomic.Int64
+	sessionsClosed atomic.Int64
+	listenerFires  atomic.Int64
+	closesByReason sync.Map // close-reason label → *atomic.Int64
+
+	// Scaling history ring buffer.
+	scalingHistoryMu sync.Mutex
+	scalingHistory   []ScalingEvent
+
+	// Slow-vRPC log ring buffer.
+	slowVRpcsMu sync.Mutex
+	slowVRpcs   []SlowVRpcEvent
+
+	// Time-series sparkline ring buffer + rate-computation state.
+	timeSeriesMu    sync.Mutex
+	timeSeries      []TimeSeriesSample
+	tsLastOkRpcs    int64
+	tsLastErrorRpcs int64
+
+	// Session-lifetime ring buffer.
+	lifetimesMu sync.Mutex
+	lifetimes   []time.Duration
+
+	// Picker-decision ring buffer + per-AFE counters.
+	pickHistoryMu   sync.Mutex
+	pickHistory     []PickHistoryEvent
+	pickHistoryHead int
+	afePickCounts   map[AfeID]int64
+
+	// Pool-wide latency histograms — lifetime-of-pool, survive session
+	// churn (per-session ring buffers cap at 256 samples each).
+	backendLatencyHist   latencyHist
+	totalLatencyHist     latencyHist
+	transportLatencyHist latencyHist
+}
+
+// SlowVRpcEvent is one row in the pool's slow-vRPC log.
+type SlowVRpcEvent struct {
+	At      time.Time
+	Method  string
+	Latency time.Duration
+	Session string // log name of the session that handled the call
+	Success bool
+	ErrCode string // grpc status code on failure, empty on success
+	// PoolWait is how long the caller spent inside CheckoutSession —
+	// where saturation queue wait lives.
+	PoolWait time.Duration
+	// BackendLatency is server-reported processing time; zero if the
+	// server didn't populate Stats.
+	BackendLatency time.Duration
+	// TransportLatency = (stream Send→Recv) − BackendLatency — wire +
+	// AFE + client-decode overhead outside server processing. Zero
+	// when BackendLatency is missing or the call errored pre-Recv.
+	TransportLatency time.Duration
+	// RPCIDOnSession is the per-session 1-indexed RPC id; small values
+	// indicate a freshly-opened session.
+	RPCIDOnSession int64
+	// SessionAge is time since the session entered StateReady; zero if
+	// the session never reached Ready.
+	SessionAge time.Duration
+	// Peer is the AFE/GFE the session was bound to. Empty on very young
+	// sessions where the bidi header hasn't been parsed yet.
+	Peer PeerInfoSnapshot
+	// RemoteAddr is the AFE socket address ("ip:port") from gRPC peer
+	// info; sessionz links it into tcpz for TCP_INFO lookup.
+	RemoteAddr string
+}
+
+const (
+	maxSlowVRpcs         = 100
+	defaultSlowThreshold = 10 * time.Millisecond
+	// maxTimeSeries: 5 min at the 1-Hz heartbeat.
+	maxTimeSeries = 300
+	maxLifetimes  = 512
+)
+
+// LifetimeBuckets are the sessionz lifetime buckets, smallest-first;
+// spans sub-minute churn through multi-hour long-lived sessions.
+var LifetimeBuckets = []struct {
+	Label string
+	Max   time.Duration
+}{
+	{"<10s", 10 * time.Second},
+	{"<1m", time.Minute},
+	{"<5m", 5 * time.Minute},
+	{"<30m", 30 * time.Minute},
+	{"<1h", time.Hour},
+	{"<6h", 6 * time.Hour},
+	{"<24h", 24 * time.Hour},
+	{"≥24h", time.Duration(1<<62 - 1)},
+}
+
+// recordLifetime appends a completed session lifetime to the ring buffer.
+// Called from each pool removal site that has a known createdAt for the
+// session being retired.
+func (p *SessionPoolImpl) recordLifetime(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	p.m.lifetimesMu.Lock()
+	defer p.m.lifetimesMu.Unlock()
+	if len(p.m.lifetimes) >= maxLifetimes {
+		copy(p.m.lifetimes, p.m.lifetimes[1:])
+		p.m.lifetimes = p.m.lifetimes[:len(p.m.lifetimes)-1]
+	}
+	p.m.lifetimes = append(p.m.lifetimes, d)
+}
+
+func (p *SessionPoolImpl) snapshotLifetimes() []time.Duration {
+	p.m.lifetimesMu.Lock()
+	out := make([]time.Duration, len(p.m.lifetimes))
+	copy(out, p.m.lifetimes)
+	p.m.lifetimesMu.Unlock()
+	return out
+}
+
+// Bucket i covers [2^i, 2^(i+1)) ns, spanning ~1ns .. ~1000s.
+const latencyHistBuckets = 40
+
+// latencyHist is a lock-free log2-bucket histogram sized for pool-wide
+// latency percentiles over the pool's full lifetime — constant memory,
+// atomic-add on record, ≤2× worst-case tail interpolation error.
+type latencyHist struct {
+	buckets [latencyHistBuckets]atomic.Uint64
+}
+
+// record adds one observation; non-positive durations are ignored.
+func (h *latencyHist) record(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	// floor(log2(ns)); bits.Len64(x) is one more than that.
+	ns := uint64(d)
+	b := bits.Len64(ns) - 1
+	if b < 0 {
+		b = 0
+	}
+	if b >= latencyHistBuckets {
+		b = latencyHistBuckets - 1
+	}
+	h.buckets[b].Add(1)
+}
+
+// snapshot returns p50/p95/p99 and the total sample count. Lock-free;
+// concurrent record() may skew results by at most the write rate over
+// the snapshot window.
+func (h *latencyHist) snapshot() (p50, p95, p99 time.Duration, n uint64) {
+	var counts [latencyHistBuckets]uint64
+	for i := range h.buckets {
+		counts[i] = h.buckets[i].Load()
+		n += counts[i]
+	}
+	if n == 0 {
+		return
+	}
+	p50 = interpLatencyPercentile(counts[:], n, 50)
+	p95 = interpLatencyPercentile(counts[:], n, 95)
+	p99 = interpLatencyPercentile(counts[:], n, 99)
+	return
+}
+
+// interpLatencyPercentile walks the bucket counts and linearly
+// interpolates the target position inside the containing bucket. Caller
+// guarantees n > 0.
+func interpLatencyPercentile(counts []uint64, n uint64, pct float64) time.Duration {
+	target := uint64(float64(n) * pct / 100)
+	if target == 0 {
+		target = 1
+	}
+	var cum uint64
+	for i, c := range counts {
+		if c == 0 {
+			continue
+		}
+		if cum+c >= target {
+			lo := uint64(1) << i
+			hi := uint64(1) << (i + 1)
+			frac := float64(target-cum) / float64(c)
+			return time.Duration(lo + uint64(float64(hi-lo)*frac))
+		}
+		cum += c
+	}
+	// Only reachable on numerical edge cases (target rounded above
+	// total); fall back to the last non-empty bucket's upper bound.
+	for i := len(counts) - 1; i >= 0; i-- {
+		if counts[i] > 0 {
+			return time.Duration(uint64(1) << (i + 1))
+		}
+	}
+	return 0
+}
+
+// TimeSeriesSample is one point in a pool's sparkline ring buffer.
+// All counters are deltas since the previous sample so the chart shows
+// rate-per-second rather than running totals.
+type TimeSeriesSample struct {
+	At        time.Time
+	Sessions  int
+	OkPerSec  float64
+	ErrPerSec float64
+	InUse     int
+	Pending   int
+}
+
+func (p *SessionPoolImpl) recordTimeSeries() {
+	handles := p.sl.AllHandles()
+	totalSessions := len(handles)
+	inUse := 0
+	var okTotal, errTotal int64
+	for _, sh := range handles {
+		if sh == nil || sh.session == nil {
+			continue
+		}
+		if sh.outstanding.Load() > 0 {
+			inUse++
+		}
+		okTotal += sh.session.okRpcs.Load()
+		errTotal += sh.session.errorRpcs.Load()
+	}
+	// Pending = pool-boundary queue depth, same as Stats().PendingCount.
+	pending := int(p.waitersCount.Load())
+
+	now := time.Now()
+	p.m.timeSeriesMu.Lock()
+	defer p.m.timeSeriesMu.Unlock()
+
+	var okRate, errRate float64
+	if len(p.m.timeSeries) > 0 {
+		prev := p.m.timeSeries[len(p.m.timeSeries)-1]
+		dt := now.Sub(prev.At).Seconds()
+		if dt > 0 {
+			okRate = float64(okTotal-p.m.tsLastOkRpcs) / dt
+			errRate = float64(errTotal-p.m.tsLastErrorRpcs) / dt
+		}
+	}
+	p.m.tsLastOkRpcs = okTotal
+	p.m.tsLastErrorRpcs = errTotal
+
+	sample := TimeSeriesSample{
+		At:        now,
+		Sessions:  totalSessions,
+		OkPerSec:  okRate,
+		ErrPerSec: errRate,
+		InUse:     inUse,
+		Pending:   pending,
+	}
+	if len(p.m.timeSeries) >= maxTimeSeries {
+		copy(p.m.timeSeries, p.m.timeSeries[1:])
+		p.m.timeSeries = p.m.timeSeries[:len(p.m.timeSeries)-1]
+	}
+	p.m.timeSeries = append(p.m.timeSeries, sample)
+}
+
+func (p *SessionPoolImpl) snapshotTimeSeries() []TimeSeriesSample {
+	p.m.timeSeriesMu.Lock()
+	defer p.m.timeSeriesMu.Unlock()
+	out := make([]TimeSeriesSample, len(p.m.timeSeries))
+	copy(out, p.m.timeSeries)
+	return out
+}
+
+// recordSlowVRpc appends to the slow-vRPC ring buffer. Only called from
+// SessionPoolImpl.Invoke after a call exceeds the threshold.
+func (p *SessionPoolImpl) recordSlowVRpc(ev SlowVRpcEvent) {
+	p.m.slowVRpcsMu.Lock()
+	defer p.m.slowVRpcsMu.Unlock()
+	if len(p.m.slowVRpcs) >= maxSlowVRpcs {
+		copy(p.m.slowVRpcs, p.m.slowVRpcs[1:])
+		p.m.slowVRpcs = p.m.slowVRpcs[:len(p.m.slowVRpcs)-1]
+	}
+	p.m.slowVRpcs = append(p.m.slowVRpcs, ev)
+}
+
+// recordCheckoutFailure feeds the pool latency histogram and, when the
+// wait exceeded the slow threshold, appends a slow-vRPC row for a call
+// that never got a session. Empty Session cell in the sessionz table
+// marks "checkout never returned a handle".
+func (p *SessionPoolImpl) recordCheckoutFailure(checkoutStart time.Time, desc VRpcDescriptor, err error) {
+	poolWait := time.Since(checkoutStart)
+	p.m.totalLatencyHist.record(poolWait)
+	if poolWait <= defaultSlowThreshold {
+		return
+	}
+	ev := SlowVRpcEvent{
+		At:       checkoutStart,
+		Method:   desc.Method(),
+		Latency:  poolWait,
+		PoolWait: poolWait,
+	}
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		ev.ErrCode = "DeadlineExceeded"
+	case errors.Is(err, context.Canceled):
+		ev.ErrCode = "Canceled"
+	default:
+		ev.ErrCode = status.Code(err).String()
+	}
+	btopt.Debugf(nil, "POOL %s slow checkout failed method=%s pool_wait=%v code=%s raw_err=%v",
+		p.poolName, ev.Method, poolWait, ev.ErrCode, err)
+	p.recordSlowVRpc(ev)
+}
+
+func (p *SessionPoolImpl) snapshotSlowVRpcs() []SlowVRpcEvent {
+	p.m.slowVRpcsMu.Lock()
+	defer p.m.slowVRpcsMu.Unlock()
+	out := make([]SlowVRpcEvent, len(p.m.slowVRpcs))
+	copy(out, p.m.slowVRpcs)
+	return out
+}
+
+// maxPickHistory sizes the pick-decision ring for ~1s of decisions at a
+// few thousand picks/sec.
+const maxPickHistory = 500
+
+// PickHistoryEvent is one row in the pick-decision log. Populated even
+// for no-candidate picks so loadz can show the fallback frequency.
+type PickHistoryEvent struct {
+	At       time.Time
+	Decision PickDecision
+	// PickerName is captured at record time so older entries retain
+	// their picker attribution across UpdateConfig swaps.
+	PickerName string
+}
+
+// recordPickDecision appends a picker outcome and increments the
+// per-AFE pick counter for the winner. pickerName is a parameter to
+// avoid a re-entrant p.mu acquisition (CheckoutSession already holds
+// p.mu when it reads p.picker.Name()).
+func (p *SessionPoolImpl) recordPickDecision(d PickDecision, pickerName string) {
+	ev := PickHistoryEvent{
+		At:         time.Now(),
+		Decision:   d,
+		PickerName: pickerName,
+	}
+	p.m.pickHistoryMu.Lock()
+	// Circular append: constant-time overwrite once at cap.
+	if len(p.m.pickHistory) < maxPickHistory {
+		p.m.pickHistory = append(p.m.pickHistory, ev)
+	} else {
+		p.m.pickHistory[p.m.pickHistoryHead] = ev
+		p.m.pickHistoryHead++
+		if p.m.pickHistoryHead == maxPickHistory {
+			p.m.pickHistoryHead = 0
+		}
+	}
+	if d.Winner != 0 {
+		p.m.afePickCounts[d.Winner]++
+	}
+	p.m.pickHistoryMu.Unlock()
+}
+
+// snapshotPickHistory returns a copy of the pick-decision ring,
+// oldest-first. Safe to call concurrently with recordPickDecision.
+func (p *SessionPoolImpl) snapshotPickHistory() []PickHistoryEvent {
+	p.m.pickHistoryMu.Lock()
+	defer p.m.pickHistoryMu.Unlock()
+	out := make([]PickHistoryEvent, len(p.m.pickHistory))
+	if len(p.m.pickHistory) < maxPickHistory {
+		copy(out, p.m.pickHistory)
+	} else {
+		// Full ring: oldest lives at pickHistoryHead. Copy the tail
+		// then the head so output is oldest-first.
+		n := copy(out, p.m.pickHistory[p.m.pickHistoryHead:])
+		copy(out[n:], p.m.pickHistory[:p.m.pickHistoryHead])
+	}
+	return out
+}
+
+// snapshotAfePickCounts returns a copy of the per-AFE cumulative pick
+// counter map. Used by loadz to compute actual-share vs. ideal-share.
+func (p *SessionPoolImpl) snapshotAfePickCounts() map[AfeID]int64 {
+	p.m.pickHistoryMu.Lock()
+	defer p.m.pickHistoryMu.Unlock()
+	out := make(map[AfeID]int64, len(p.m.afePickCounts))
+	for k, v := range p.m.afePickCounts {
+		out[k] = v
+	}
+	return out
+}

--- a/bigtable/internal/transport/session_pool_debug_test.go
+++ b/bigtable/internal/transport/session_pool_debug_test.go
@@ -220,9 +220,9 @@ func TestRecordSlowVRpc_RingCaps(t *testing.T) {
 
 type fakeVRpcDesc struct{ method string }
 
-func (f fakeVRpcDesc) Method() string                            { return f.method }
-func (f fakeVRpcDesc) Encode(interface{}) ([]byte, error)        { return nil, nil }
-func (f fakeVRpcDesc) Decode([]byte) (interface{}, error)        { return nil, nil }
+func (f fakeVRpcDesc) Method() string                     { return f.method }
+func (f fakeVRpcDesc) Encode(interface{}) ([]byte, error) { return nil, nil }
+func (f fakeVRpcDesc) Decode([]byte) (interface{}, error) { return nil, nil }
 
 func TestRecordCheckoutFailure_SkipsUnderThreshold(t *testing.T) {
 	p := newTestPool(t, 1, 10)

--- a/bigtable/internal/transport/session_pool_debug_test.go
+++ b/bigtable/internal/transport/session_pool_debug_test.go
@@ -1,0 +1,303 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// --- latencyHist ------------------------------------------------------------
+
+func TestLatencyHist_RecordAndSnapshot(t *testing.T) {
+	var h latencyHist
+	// Record 100 samples uniformly across 4 orders of magnitude. p50/p95/p99
+	// should land in monotonically-increasing buckets.
+	for i := 0; i < 25; i++ {
+		h.record(1 * time.Microsecond)
+	}
+	for i := 0; i < 25; i++ {
+		h.record(1 * time.Millisecond)
+	}
+	for i := 0; i < 25; i++ {
+		h.record(10 * time.Millisecond)
+	}
+	for i := 0; i < 25; i++ {
+		h.record(100 * time.Millisecond)
+	}
+	p50, p95, p99, n := h.snapshot()
+	if n != 100 {
+		t.Errorf("n = %d, want 100", n)
+	}
+	if !(p50 < p95 && p95 <= p99) {
+		t.Errorf("percentiles must be non-decreasing: p50=%v p95=%v p99=%v", p50, p95, p99)
+	}
+	// p50 falls at the boundary between the 1µs and 1ms clusters. With
+	// log2 buckets + linear-in-bucket interpolation the reported value
+	// is the top of bucket 19 (≈1.048ms). Widen to include that.
+	if p50 < time.Microsecond || p50 > 2*time.Millisecond {
+		t.Errorf("p50 = %v, want in [1µs, 2ms]", p50)
+	}
+	// p99 should land in the 100ms bucket range.
+	if p99 < 10*time.Millisecond {
+		t.Errorf("p99 = %v, want ≥10ms", p99)
+	}
+}
+
+func TestLatencyHist_IgnoresNonPositive(t *testing.T) {
+	var h latencyHist
+	h.record(0)
+	h.record(-1 * time.Second)
+	_, _, _, n := h.snapshot()
+	if n != 0 {
+		t.Errorf("n = %d, want 0 for non-positive records", n)
+	}
+}
+
+func TestLatencyHist_SnapshotEmptyReturnsZero(t *testing.T) {
+	var h latencyHist
+	p50, p95, p99, n := h.snapshot()
+	if p50 != 0 || p95 != 0 || p99 != 0 || n != 0 {
+		t.Errorf("empty snapshot = (%v,%v,%v,%d), want all zero", p50, p95, p99, n)
+	}
+}
+
+func TestLatencyHist_HandlesTailOverflow(t *testing.T) {
+	var h latencyHist
+	// A duration beyond the highest bucket (~1000s) must land in the last
+	// bucket, not panic or wrap.
+	h.record(time.Duration(1<<62) * time.Nanosecond)
+	_, _, _, n := h.snapshot()
+	if n != 1 {
+		t.Errorf("n = %d, want 1", n)
+	}
+}
+
+func TestInterpLatencyPercentile_LinearInBucket(t *testing.T) {
+	// Two samples in bucket 10 (covers [1024ns, 2048ns)). Target p50 falls
+	// mid-bucket → ~1536ns.
+	counts := make([]uint64, latencyHistBuckets)
+	counts[10] = 2
+	got := interpLatencyPercentile(counts, 2, 50)
+	if got < 1024 || got > 2048 {
+		t.Errorf("p50 = %v ns, want in [1024, 2048]", int64(got))
+	}
+}
+
+func TestInterpLatencyPercentile_EdgeFallback(t *testing.T) {
+	// Force the "target rounded above cum" fallback: n=1, target computed as
+	// max(1, floor(n*pct/100)). With pct=100, target=1 and cum reaches
+	// exactly 1 in bucket 5, so the normal path returns. Use pct>100 to
+	// stress the fallback — interpLatencyPercentile is only called with
+	// pct∈{50,95,99} in production, so we just verify it doesn't panic.
+	counts := make([]uint64, latencyHistBuckets)
+	counts[5] = 1
+	got := interpLatencyPercentile(counts, 1, 200) // beyond spec range
+	if got == 0 {
+		t.Errorf("expected non-zero fallback, got 0")
+	}
+}
+
+// --- lifetime ring ----------------------------------------------------------
+
+func TestRecordLifetime_ClampsNonPositive(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	p.recordLifetime(0)
+	p.recordLifetime(-1 * time.Second)
+	if got := len(p.snapshotLifetimes()); got != 0 {
+		t.Errorf("snapshotLifetimes len = %d, want 0", got)
+	}
+}
+
+func TestRecordLifetime_RingCaps(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	// Fill to cap + 5. Oldest 5 must drop.
+	for i := 0; i < maxLifetimes+5; i++ {
+		p.recordLifetime(time.Duration(i+1) * time.Millisecond)
+	}
+	snap := p.snapshotLifetimes()
+	if len(snap) != maxLifetimes {
+		t.Fatalf("len = %d, want %d", len(snap), maxLifetimes)
+	}
+	// First surviving sample is the 6th one appended → 6ms.
+	if snap[0] != 6*time.Millisecond {
+		t.Errorf("snap[0] = %v, want 6ms (ring must drop oldest 5)", snap[0])
+	}
+	// Last is the newest → (maxLifetimes+5)ms.
+	if want := time.Duration(maxLifetimes+5) * time.Millisecond; snap[len(snap)-1] != want {
+		t.Errorf("snap[last] = %v, want %v", snap[len(snap)-1], want)
+	}
+}
+
+// --- time series ------------------------------------------------------------
+
+func TestRecordTimeSeries_ComputesRates(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	// Inject a session with baseline counters.
+	sh := injectActiveSession(t, p, "s1", time.Now())
+	sh.session.okRpcs.Store(100)
+	sh.session.errorRpcs.Store(10)
+
+	// First sample: no prior → rates are 0.
+	p.recordTimeSeries()
+	snap := p.snapshotTimeSeries()
+	if len(snap) != 1 {
+		t.Fatalf("after first record, snapshot len = %d, want 1", len(snap))
+	}
+	if snap[0].OkPerSec != 0 || snap[0].ErrPerSec != 0 {
+		t.Errorf("first sample rates = (%v, %v), want (0, 0)", snap[0].OkPerSec, snap[0].ErrPerSec)
+	}
+	if snap[0].Sessions != 1 {
+		t.Errorf("Sessions = %d, want 1", snap[0].Sessions)
+	}
+
+	// Advance counters + record again. Delta rates fire.
+	sh.session.okRpcs.Store(200)
+	sh.session.errorRpcs.Store(15)
+	// Sleep briefly so dt > 0 (recordTimeSeries divides by dt).
+	time.Sleep(2 * time.Millisecond)
+	p.recordTimeSeries()
+	snap = p.snapshotTimeSeries()
+	if len(snap) != 2 {
+		t.Fatalf("after second record, len = %d, want 2", len(snap))
+	}
+	if snap[1].OkPerSec <= 0 {
+		t.Errorf("OkPerSec = %v, want positive (delta 100 over ~2ms)", snap[1].OkPerSec)
+	}
+	if snap[1].ErrPerSec <= 0 {
+		t.Errorf("ErrPerSec = %v, want positive (delta 5 over ~2ms)", snap[1].ErrPerSec)
+	}
+}
+
+func TestRecordTimeSeries_RingCaps(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	for i := 0; i < maxTimeSeries+3; i++ {
+		p.recordTimeSeries()
+	}
+	snap := p.snapshotTimeSeries()
+	if len(snap) != maxTimeSeries {
+		t.Errorf("len = %d, want %d (ring must cap)", len(snap), maxTimeSeries)
+	}
+}
+
+// --- slow-vRPC log ----------------------------------------------------------
+
+func TestRecordSlowVRpc_RingCaps(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	for i := 0; i < maxSlowVRpcs+7; i++ {
+		p.recordSlowVRpc(SlowVRpcEvent{Method: "M", Latency: time.Duration(i+1) * time.Millisecond})
+	}
+	snap := p.snapshotSlowVRpcs()
+	if len(snap) != maxSlowVRpcs {
+		t.Fatalf("len = %d, want %d", len(snap), maxSlowVRpcs)
+	}
+	// Newest is (maxSlowVRpcs+7)ms; oldest surviving is 8ms.
+	if snap[0].Latency != 8*time.Millisecond {
+		t.Errorf("snap[0].Latency = %v, want 8ms", snap[0].Latency)
+	}
+	want := time.Duration(maxSlowVRpcs+7) * time.Millisecond
+	if snap[len(snap)-1].Latency != want {
+		t.Errorf("snap[last].Latency = %v, want %v", snap[len(snap)-1].Latency, want)
+	}
+}
+
+type fakeVRpcDesc struct{ method string }
+
+func (f fakeVRpcDesc) Method() string                            { return f.method }
+func (f fakeVRpcDesc) Encode(interface{}) ([]byte, error)        { return nil, nil }
+func (f fakeVRpcDesc) Decode([]byte) (interface{}, error)        { return nil, nil }
+
+func TestRecordCheckoutFailure_SkipsUnderThreshold(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	// Simulate a fast checkout failure. Threshold is 10ms by default.
+	p.recordCheckoutFailure(time.Now(), fakeVRpcDesc{method: "M"}, context.DeadlineExceeded)
+	if got := len(p.snapshotSlowVRpcs()); got != 0 {
+		t.Errorf("under-threshold failure recorded: got %d slow events, want 0", got)
+	}
+}
+
+func TestRecordCheckoutFailure_ClassifiesErr(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		wantCode string
+	}{
+		{"DeadlineExceeded", context.DeadlineExceeded, "DeadlineExceeded"},
+		{"Canceled", context.Canceled, "Canceled"},
+		{"gRPC Unavailable", status.Error(codes.Unavailable, "boom"), "Unavailable"},
+		{"unknown Go error", errors.New("mystery"), "Unknown"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newTestPool(t, 1, 10)
+			// Backdate checkoutStart so poolWait > threshold.
+			start := time.Now().Add(-time.Second)
+			p.recordCheckoutFailure(start, fakeVRpcDesc{method: "M"}, tc.err)
+			snap := p.snapshotSlowVRpcs()
+			if len(snap) != 1 {
+				t.Fatalf("len = %d, want 1", len(snap))
+			}
+			if snap[0].ErrCode != tc.wantCode {
+				t.Errorf("ErrCode = %q, want %q", snap[0].ErrCode, tc.wantCode)
+			}
+			if snap[0].Session != "" {
+				t.Errorf("Session = %q, want empty (checkout failure has no session)", snap[0].Session)
+			}
+		})
+	}
+}
+
+// --- pick history / AFE counts ---------------------------------------------
+
+func TestSnapshotAfePickCounts_ReturnsCopy(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	p.recordPickDecision(PickDecision{Winner: AfeID(42), Reason: "test"}, "least-inflight")
+	p.recordPickDecision(PickDecision{Winner: AfeID(42), Reason: "test"}, "least-inflight")
+	p.recordPickDecision(PickDecision{Winner: AfeID(7), Reason: "test"}, "least-inflight")
+
+	snap := p.snapshotAfePickCounts()
+	if snap[42] != 2 {
+		t.Errorf("counts[42] = %d, want 2", snap[42])
+	}
+	if snap[7] != 1 {
+		t.Errorf("counts[7] = %d, want 1", snap[7])
+	}
+
+	// Mutating the snapshot must not touch the pool's live map.
+	snap[42] = 999
+	live := p.snapshotAfePickCounts()
+	if live[42] != 2 {
+		t.Errorf("mutating snapshot altered live counts: live[42] = %d, want 2", live[42])
+	}
+}
+
+func TestRecordPickDecision_ZeroWinnerNotCounted(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	// Winner == 0 marks "no-candidates" — must not populate afePickCounts.
+	p.recordPickDecision(PickDecision{Reason: "no-candidates"}, "least-inflight")
+	snap := p.snapshotAfePickCounts()
+	if len(snap) != 0 {
+		t.Errorf("afePickCounts populated with zero winner: %+v", snap)
+	}
+	// But the ring buffer still records the event.
+	if got := len(p.snapshotPickHistory()); got != 1 {
+		t.Errorf("pickHistory len = %d, want 1 (no-candidate events must still be logged)", got)
+	}
+}

--- a/bigtable/internal/transport/session_pool_lifecycle.go
+++ b/bigtable/internal/transport/session_pool_lifecycle.go
@@ -323,7 +323,7 @@ func (p *SessionPoolImpl) onClosing(sh *SessionHandle) {
 
 	p.sl.OnSessionClosing(sh)
 
-	if p.sl.ReadyCount() < int(p.maxSessions.Load()) {
+	if p.sl.ReadyCount() < p.sizer.MaxSessions() {
 		p.spawnTickOnce(p.poolCtx)
 	}
 }
@@ -339,7 +339,7 @@ func (p *SessionPoolImpl) onClose(sh *SessionHandle, err error) {
 		delete(p.startingSessions, sh)
 		p.mu.Unlock()
 		p.bumpStartingClose(sh.session)
-		p.noteAbnormalCloseIfAny(sh.session)
+		p.noteAbnormalCloseIfAny(sh)
 		return
 	}
 	p.mu.Unlock()
@@ -348,22 +348,43 @@ func (p *SessionPoolImpl) onClose(sh *SessionHandle, err error) {
 		// Pool.Close Phase 1 already recorded. Still safe to bump the
 		// consecutive-failure counter — Session.OnClose is once-guarded,
 		// so this method fires at most once per session.
-		p.noteAbnormalCloseIfAny(sh.session)
+		p.noteAbnormalCloseIfAny(sh)
 		return
 	}
 	p.sl.OnSessionClosed(sh)
 	p.recordSessionClose(sh.session, "")
-	p.noteAbnormalCloseIfAny(sh.session)
+	p.noteAbnormalCloseIfAny(sh)
 }
 
 // noteAbnormalCloseIfAny bumps the consecutive-failure counter when the
-// session's close reason classifies as abnormal. Crossing the threshold
-// drains every parked waiter with ErrConsecutiveFailures and resets.
-// CAS on reset guards against two goroutines double-draining.
-func (p *SessionPoolImpl) noteAbnormalCloseIfAny(s *Session) {
-	if !isAbnormalCloseReason(s.CloseReason()) {
+// session died before it ever became usable. Classification is
+// state-based via sh.activated: onActive is the sole writer of that
+// flag, so `!sh.activated.Load()` is the exact "never reached
+// StateReady" signal — no reason-string whitelist to keep in lockstep
+// with new close reasons, no accidental mis-classification when the
+// server invents a new REASON. A session that activated (even briefly)
+// is treated as a healthy open regardless of how it later died: the
+// counter is reset on every onActive so a churn pattern of activate →
+// server-side GoAway → replace converges to zero. Crossing the
+// threshold drains every parked waiter with ErrConsecutiveFailures and
+// resets. CAS on reset guards against two goroutines double-draining.
+func (p *SessionPoolImpl) noteAbnormalCloseIfAny(sh *SessionHandle) {
+	// Defensive nil-guard: production callers always pass a live sh
+	// with sh.session backfilled (createSession sets it before wiring
+	// the hook closures at session_pool_scaling.go:248). Kept so a
+	// future test double / injection path can't NPE the whole close
+	// path — the counter simply doesn't advance on a nil handle.
+	if sh == nil || sh.session == nil {
 		return
 	}
+	// State-based gate: activated=true means the session reached
+	// StateReady at least once (onActive fired). Skip the trip counter —
+	// server-initiated GoAway / heartbeat missed / stream errors on an
+	// already-Ready session are transport hiccups, not open failures.
+	if sh.activated.Load() {
+		return
+	}
+	s := sh.session
 	if e := s.closeError(); e != nil {
 		p.lastAbnormalCloseErr.Store(&e)
 	}
@@ -388,6 +409,13 @@ func (p *SessionPoolImpl) noteAbnormalCloseIfAny(s *Session) {
 	woken := p.drainWaitersWithErr(tripErr)
 	if woken > 0 {
 		recordDebugTag(tagSessionPoolConsecutiveFailuresTripped)
+		// TODO(mutianf): if consecutive trips are driven by Unimplemented
+		// (server-side session RPC not supported — the classic-path
+		// fallback signal), transition the client back to unary Bigtable
+		// RPCs instead of continuing to trip and drain. Routing flip is
+		// SessionClient / Diverter's decision, not the pool's — the pool
+		// only surfaces the trip cause; the layer above owns the choice
+		// to divert future opens to the classic (unary) path.
 	}
 }
 

--- a/bigtable/internal/transport/session_pool_lifecycle.go
+++ b/bigtable/internal/transport/session_pool_lifecycle.go
@@ -97,11 +97,16 @@ func (p *SessionPoolImpl) sweepStuckSessions() {
 
 // bumpCloseReason atomically increments the close-reason counter; the map
 // is keyed by label so the set of reasons can grow without struct churn.
+// Load-first, LoadOrStore only on miss — avoids allocating a fresh
+// atomic.Int64 on every hit-path call (close-reason bumps are frequent).
 func (p *SessionPoolImpl) bumpCloseReason(label string) {
 	if label == "" {
 		label = "Unspecified"
 	}
-	c, _ := p.m.closesByReason.LoadOrStore(label, new(atomic.Int64))
+	c, ok := p.m.closesByReason.Load(label)
+	if !ok {
+		c, _ = p.m.closesByReason.LoadOrStore(label, new(atomic.Int64))
+	}
 	c.(*atomic.Int64).Add(1)
 }
 

--- a/bigtable/internal/transport/session_pool_lifecycle.go
+++ b/bigtable/internal/transport/session_pool_lifecycle.go
@@ -1,0 +1,533 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// SessionPoolImpl lifecycle: session hooks (onStart/onActive/onClosing/
+// onClose), Close/teardown, close-reason ledger, and the background
+// maintenance ticker that drives uptime sampling and stuck-session sweeping.
+
+package internal
+
+import (
+	"context"
+	"runtime/debug"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	btopt "cloud.google.com/go/bigtable/internal/option"
+)
+
+// waitServerCloseGrace bounds StateWaitServerClose before the pool
+// force-closes the session. 5 min is long enough that a slow-but-alive
+// server still draining in-flight state after acknowledging
+// CloseSession is not force-closed as collateral damage (typical
+// server-side drain is bounded by CloseSession's own reply timeout,
+// well under a minute); a session still stuck past 5 min is almost
+// certainly a hung server or lost stream and needs reclamation.
+const waitServerCloseGrace = 5 * time.Minute
+
+// sweepStuckSessionsInterval is the cadence for the WSC-stuck sweeper.
+// Decoupled from waitServerCloseGrace so worst-case detection is
+// grace + interval (~5m30s) instead of 2×grace (10 min) — no reason
+// to make the loop wake up as slowly as the grace itself, since the
+// per-iteration work is just a stateless walk of sl.AllHandles.
+const sweepStuckSessionsInterval = 30 * time.Second
+
+// sampleActiveUptimes records each Ready session's current age into the
+// session.uptime histogram. Runs without the pool lock so tracer work
+// never blocks CheckoutSession / OnClose.
+func (p *SessionPoolImpl) sampleActiveUptimes(ctx context.Context) {
+	handles := p.sl.AllHandles()
+	for _, sh := range handles {
+		if sh == nil || sh.session == nil {
+			continue
+		}
+		if State(sh.session.state.Load()) != StateReady {
+			continue
+		}
+		sh.session.SampleUptime(ctx)
+	}
+}
+
+// sweepStuckSessions force-closes sessions parked in StateWaitServerClose
+// beyond waitServerCloseGrace. Driven by startSweepStuckSessionsLoop;
+// ForceClose calls fire outside the pool lock.
+func (p *SessionPoolImpl) sweepStuckSessions() {
+	type victim struct {
+		sess     *Session
+		stuckFor time.Duration
+	}
+	var victims []victim
+
+	for _, sh := range p.sl.AllHandles() {
+		if sh == nil || sh.session == nil {
+			continue
+		}
+		stuck := State(sh.session.state.Load()) == StateWaitServerClose
+		since := time.Since(time.Unix(0, sh.session.lastStateChangeNano.Load()))
+		if stuck && since > waitServerCloseGrace {
+			victims = append(victims, victim{sess: sh.session, stuckFor: since})
+		}
+	}
+
+	for _, v := range victims {
+		// One tag per swept victim — the count is the "stuck sessions
+		// per minute" gauge.
+		recordDebugTag(tagSessionPoolStuckSessionSwept)
+		btopt.Debugf(nil, "POOL %s sweepStuckSessions: force-closing %s stuck in WaitServerClose for %v",
+			p.poolName, v.sess.LogName(), v.stuckFor.Round(time.Second))
+		v.sess.ForceClose(&spb.CloseSessionRequest{
+			Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_ERROR,
+			Description: "stuck in WaitServerClose past grace",
+		})
+	}
+}
+
+// bumpCloseReason atomically increments the close-reason counter; the map
+// is keyed by label so the set of reasons can grow without struct churn.
+func (p *SessionPoolImpl) bumpCloseReason(label string) {
+	if label == "" {
+		label = "Unspecified"
+	}
+	c, _ := p.m.closesByReason.LoadOrStore(label, new(atomic.Int64))
+	c.(*atomic.Int64).Add(1)
+}
+
+// recordSessionClose marks a session as retired exactly once and bumps
+// sessionsClosed + the close-reason histogram. Once-flag lives on
+// Session so it dedupes across every removal site. fallbackReason is
+// used when the session hasn't recorded its own reason yet.
+func (p *SessionPoolImpl) recordSessionClose(s *Session, fallbackReason string) {
+	if s == nil {
+		return
+	}
+	if !s.poolCloseRecorded.CompareAndSwap(false, true) {
+		return
+	}
+	reason := s.CloseReason()
+	if reason == "" {
+		reason = fallbackReason
+	}
+	p.m.sessionsClosed.Add(1)
+	p.bumpCloseReason(reason)
+}
+
+// bumpStartingClose records the close for sessions that died before
+// reaching Ready — they never fire onActive, so onClose's starting
+// branch is the only close signal.
+func (p *SessionPoolImpl) bumpStartingClose(s *Session) {
+	p.recordSessionClose(s, "FailedToStart")
+}
+
+// snapshotCloseReasons returns the per-reason counts as a flat map.
+func (p *SessionPoolImpl) snapshotCloseReasons() map[string]int64 {
+	out := map[string]int64{}
+	p.m.closesByReason.Range(func(k, v interface{}) bool {
+		out[k.(string)] = v.(*atomic.Int64).Load()
+		return true
+	})
+	return out
+}
+
+// Close gracefully closes all active sessions in the pool, bounded by
+// a 30s timeout. Sessions close concurrently; Close blocks until every
+// per-session graceful Close returns (or the bounded ctx fires). Only
+// after the WaitGroup completes do we cancel poolCtx, which tears down
+// any remaining session goroutines.
+func (p *SessionPoolImpl) Close() error {
+	// Phase 1: mark closed so no new sessions are admitted.
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil
+	}
+	p.closed = true
+	p.mu.Unlock()
+
+	// Drain parked waiters with ErrPoolClosed. Without this, long-poll
+	// callers with context.Background hang past Close: only ctx-cancel
+	// or an onSlotDrained wake unblocks them, and cancelActiveRPCs
+	// intentionally skips onSlotDrained on teardown paths.
+	p.drainWaitersWithErr(ErrPoolClosed)
+
+	// Snapshot AFTER marking closed so any onActive races either see
+	// p.closed (and ForceClose without registering) or land in sl in
+	// time to be caught here.
+	snapshot := p.sl.AllHandles()
+
+	// Pre-flip closingRecorded / closeRecorded via CAS so a mid-flight
+	// onClosing (GOAWAY / heartbeat trip) that landed after AllHandles
+	// but before this loop can't double-count via its own CAS at
+	// onClosing. closingRecorded is load-bearing (recordLifetime has
+	// no inner guard); closeRecorded is symmetric — recordSessionClose
+	// already dedupes internally, but keeping the CAS reads uniform.
+	// Also drops handles from sl so a picker can't hand back a retired
+	// session before Phase-2 tears them down.
+	for _, sh := range snapshot {
+		if sh == nil || sh.session == nil {
+			continue
+		}
+		if sh.closingRecorded.CompareAndSwap(false, true) && !sh.createdAt.IsZero() {
+			p.recordLifetime(time.Since(sh.createdAt))
+		}
+		if sh.closeRecorded.CompareAndSwap(false, true) {
+			p.recordSessionClose(sh.session, "PoolClose")
+		}
+		p.sl.OnSessionClosed(sh)
+	}
+
+	// Phase 2: kick off graceful Close on every session under a bounded
+	// ctx derived from p.poolCtx (not context.Background — this pool
+	// scopes its lifetime to poolCtx). Safe because Phase 4's
+	// poolCancel runs AFTER Phase 3's wg.Wait returns, so Phase 2's
+	// session Close goroutines finish before poolCtx is cancelled.
+	closeCtx, cancel := context.WithTimeout(p.poolCtx, 30*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for _, sh := range snapshot {
+		if sh.session == nil {
+			continue
+		}
+		wg.Add(1)
+		go func(s *Session) {
+			defer wg.Done()
+			s.Close(closeCtx, &spb.CloseSessionRequest{
+				Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_USER,
+				Description: "graceful pool teardown",
+			})
+		}(sh.session)
+	}
+
+	// Phase 3: wait for graceful closes. Session.Close selects on its
+	// ctx and ForceCloses on expiry, so the WaitGroup unblocks either way.
+	wg.Wait()
+	if closeCtx.Err() != nil {
+		recordDebugTag(tagSessionPoolDrainTimeout)
+	}
+
+	// Phase 4: cancel poolCtx to bring down any lingering session
+	// goroutines (readLoop / heartbeatLoop supervisors).
+	if p.poolCancel != nil {
+		p.poolCancel()
+	}
+
+	// Phase 5: wait for every createSession worker (Tick-spawned). Their
+	// error paths touch package-level metric state, so without this wait
+	// they can outlive Close and race the next test's metrics init.
+	p.spawns.Wait()
+
+	// Phase 6: wait for every Session's goroutines to unwind. Re-snapshot
+	// AFTER spawns.Wait to catch sessions that reached sl during the tail
+	// of Phase 5. Sessions still in startingSessions never entered sl and
+	// are already accounted for via Phase 5.
+	for _, sh := range p.sl.AllHandles() {
+		if sh != nil && sh.session != nil {
+			sh.session.WaitGoroutines()
+		}
+	}
+	return nil
+}
+
+// onStart is a no-op — retained for SessionHooks shape symmetry.
+func (p *SessionPoolImpl) onStart(ctx context.Context) {}
+
+// onActive publishes a newly-started SessionHandle into sl and clears
+// its starting-set entry. The activated CAS makes this safe to invoke
+// twice; production wires each closure exactly once per Session.
+func (p *SessionPoolImpl) onActive(sh *SessionHandle) {
+	if !sh.activated.CompareAndSwap(false, true) {
+		return
+	}
+	// Keep work here allocation-only / atomic-only. Anything blocking
+	// would deadlock the read loop and heartbeat scheduler that contend
+	// for p.mu. (SessionHooks: "hooks must not block.")
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	delete(p.startingSessions, sh)
+
+	if p.closed {
+		// Dispatch async so we release p.mu before the onClose chain
+		// re-acquires it. Race window: onActive can land ~30s after
+		// Close set p.closed=true. Track on p.spawns so Phase-5 catches
+		// this goroutine; safe to Add(1) after p.closed=true because
+		// createSession's own spawns entry for this session is still
+		// pending in WaitGoroutines — the counter stays > 0.
+		p.spawns.Add(1)
+		go func() {
+			defer p.spawns.Done()
+			sh.session.ForceClose(&spb.CloseSessionRequest{
+				Reason:      spb.CloseSessionRequest_CLOSE_SESSION_REASON_ERROR,
+				Description: "pool closed before session became active",
+			})
+		}()
+		return
+	}
+
+	p.m.sessionsOpened.Add(1)
+
+	// A successful session-open signals sustained transport health;
+	// clear the consecutive-failure counter. Reset lives here (not on
+	// per-vRPC OK) so a long-lived healthy session can't mask a run
+	// of failing opens. Under sustained failures no session reaches
+	// this point, so the counter grows unimpeded toward the trip.
+	p.consecutiveFailures.Store(0)
+	p.lastAbnormalCloseErr.Store(nil)
+
+	// PeerInfo is guaranteed populated: handleOpenSession parses it
+	// synchronously before firing onActive.
+	p.sl.OnSessionStarted(sh)
+
+	// New session is immediately idle — wake any parked waiter.
+	p.signalFree()
+}
+
+// onClosing fires on the FIRST transition out of Ready (handleGoAway,
+// Close, ForceClose, or handleClose). Drops the session from the
+// picker's idle queue and the scale-up gate so replacement can start
+// before teardown completes; refCount keeps in-flight vRPCs alive
+// until onClose finalizes.
+func (p *SessionPoolImpl) onClosing(sh *SessionHandle) {
+	// Still-starting sessions never reached sl; they exit via onClose's
+	// bumpStartingClose path.
+	p.mu.Lock()
+	_, starting := p.startingSessions[sh]
+	p.mu.Unlock()
+	if starting {
+		return
+	}
+	if !sh.closingRecorded.CompareAndSwap(false, true) {
+		return // Pool.Close Phase 1 already recorded.
+	}
+	if !sh.createdAt.IsZero() {
+		p.recordLifetime(time.Since(sh.createdAt))
+	}
+
+	p.sl.OnSessionClosing(sh)
+
+	if p.sl.ReadyCount() < int(p.maxSessions.Load()) {
+		p.spawnTickOnce(p.poolCtx)
+	}
+}
+
+// onClose fires when the stream has actually closed. onClosing has
+// already dropped the session from sl.readyCount and the picker's idle
+// queue; this callback finalizes by dropping the AFE handle and
+// recording the close reason. Pool.Close's Phase 1 pre-flips
+// sh.closeRecorded so pool-driven closes short-circuit here.
+func (p *SessionPoolImpl) onClose(sh *SessionHandle, err error) {
+	p.mu.Lock()
+	if _, starting := p.startingSessions[sh]; starting {
+		delete(p.startingSessions, sh)
+		p.mu.Unlock()
+		p.bumpStartingClose(sh.session)
+		p.noteAbnormalCloseIfAny(sh.session)
+		return
+	}
+	p.mu.Unlock()
+
+	if !sh.closeRecorded.CompareAndSwap(false, true) {
+		// Pool.Close Phase 1 already recorded. Still safe to bump the
+		// consecutive-failure counter — Session.OnClose is once-guarded,
+		// so this method fires at most once per session.
+		p.noteAbnormalCloseIfAny(sh.session)
+		return
+	}
+	p.sl.OnSessionClosed(sh)
+	p.recordSessionClose(sh.session, "")
+	p.noteAbnormalCloseIfAny(sh.session)
+}
+
+// noteAbnormalCloseIfAny bumps the consecutive-failure counter when the
+// session's close reason classifies as abnormal. Crossing the threshold
+// drains every parked waiter with ErrConsecutiveFailures and resets.
+// CAS on reset guards against two goroutines double-draining.
+func (p *SessionPoolImpl) noteAbnormalCloseIfAny(s *Session) {
+	if !isAbnormalCloseReason(s.CloseReason()) {
+		return
+	}
+	if e := s.closeError(); e != nil {
+		p.lastAbnormalCloseErr.Store(&e)
+	}
+	n := p.consecutiveFailures.Add(1)
+	threshold := p.consecutiveFailureThreshold.Load()
+	if threshold <= 0 || n < threshold {
+		return
+	}
+	// Snapshot the poison BEFORE the CAS-reset so a concurrent abnormal
+	// close arriving in the reset→drain gap can't swap the "last error"
+	// out from under the waiter drain — trip attribution stays pinned
+	// to the close that actually crossed the threshold.
+	tripErr := p.consecutiveFailureErr()
+	// TODO: reconsider the CAS-reset. Alternative semantics: leave the
+	// counter elevated until a fresh session-open (onActive) clears it,
+	// so a burst of abnormal closes that keeps arriving after a trip
+	// re-drains any newly parked waiters instead of building up a
+	// second budget.
+	if !p.consecutiveFailures.CompareAndSwap(n, 0) {
+		return
+	}
+	woken := p.drainWaitersWithErr(tripErr)
+	if woken > 0 {
+		recordDebugTag(tagSessionPoolConsecutiveFailuresTripped)
+	}
+}
+
+// consecutiveFailureErr builds the error handed to parked waiters on a
+// breaker trip. When a last abnormal-close error is captured, returns a
+// *consecutiveFailureError so that (a) errors.Is against
+// ErrConsecutiveFailures still holds and (b) status.Code inherits the
+// underlying cause's gRPC code (e.g. FailedPrecondition when the server
+// rejected OpenSession because the resource is still being created).
+// Falls back to the bare sentinel when no cause is available.
+func (p *SessionPoolImpl) consecutiveFailureErr() error {
+	last := p.lastAbnormalCloseErr.Load()
+	if last == nil {
+		return ErrConsecutiveFailures
+	}
+	return &consecutiveFailureError{inner: *last}
+}
+
+// tickInterval is the cadence for the periodic Tick watchdog. 1 s
+// balances reaction to server-driven config against CPU/mu contention.
+const tickInterval = 1 * time.Second
+
+// Start brings the pool up: fires a pre-start Tick to seed min-sessions,
+// then runs the periodic Tick watchdog, AFE prune loop, and
+// WaitServerClose sweep loop. Non-blocking; idempotent via startOnce.
+func (p *SessionPoolImpl) Start(ctx context.Context) {
+	p.startOnce.Do(func() {
+		p.spawnTickOnce(ctx)
+		p.startTickLoop(ctx)
+		p.startAfePruneLoop(ctx)
+		p.startSweepStuckSessionsLoop(ctx)
+	})
+}
+
+// startTickLoop runs Tick every tickInterval until ctx cancels.
+func (p *SessionPoolImpl) startTickLoop(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(tickInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				p.tickOnce(ctx)
+			}
+		}
+	}()
+}
+
+// tickOnce runs one Tick with panic recovery + a debounce gate. The
+// tickPending CAS coalesces concurrent invocations to at most one
+// active Tick body — a burst of empty-pool kicks otherwise fires
+// redundant sampleActiveUptimes before the scalingInProgress gate
+// rejects them.
+func (p *SessionPoolImpl) tickOnce(ctx context.Context) {
+	if !p.tickPending.CompareAndSwap(false, true) {
+		return
+	}
+	defer p.tickPending.Store(false)
+	defer func() {
+		if r := recover(); r != nil {
+			btopt.Debugf(nil, "POOL %s Tick panic recovered: %v\n%s", p.poolName, r, debug.Stack())
+		}
+	}()
+	p.Tick(ctx)
+}
+
+// spawnTickOnce is the guarded `go p.tickOnce(ctx)` used at every kick
+// site. Re-checks p.closed and bumps p.spawns under p.mu so an Add
+// either lands before Close's Phase-1 Lock or is skipped — kicks
+// spawned during Close can't leak past p.spawns.Wait.
+func (p *SessionPoolImpl) spawnTickOnce(ctx context.Context) {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return
+	}
+	p.spawns.Add(1)
+	p.mu.Unlock()
+	go func() {
+		defer p.spawns.Done()
+		p.tickOnce(ctx)
+	}()
+}
+
+// startAfePruneLoop runs sl.Prune on afePruneMaxIdle cadence until ctx
+// cancels — deliberately OFF the tickInterval so sl.mu held during the
+// map walk can't contend with serving-path Checkouts.
+func (p *SessionPoolImpl) startAfePruneLoop(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(afePruneMaxIdle)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				p.pruneOnce()
+			}
+		}
+	}()
+}
+
+// pruneOnce runs one sl.Prune with panic recovery per iteration.
+func (p *SessionPoolImpl) pruneOnce() {
+	defer func() {
+		if r := recover(); r != nil {
+			btopt.Debugf(nil, "POOL %s AFE prune panic recovered: %v\n%s", p.poolName, r, debug.Stack())
+		}
+	}()
+	p.sl.Prune(time.Now())
+}
+
+// startSweepStuckSessionsLoop runs sweepStuckSessions on
+// sweepStuckSessionsInterval cadence until ctx cancels. Deliberately
+// OFF the 1s Tick — a stuck WaitServerClose session only becomes
+// actionable after waitServerCloseGrace has elapsed, so checking more
+// often just burns CPU walking sl.AllHandles. Worst-case detection is
+// waitServerCloseGrace + sweepStuckSessionsInterval.
+func (p *SessionPoolImpl) startSweepStuckSessionsLoop(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(sweepStuckSessionsInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				p.sweepStuckSessionsOnce()
+			}
+		}
+	}()
+}
+
+// sweepStuckSessionsOnce runs one sweepStuckSessions with panic
+// recovery per iteration.
+func (p *SessionPoolImpl) sweepStuckSessionsOnce() {
+	defer func() {
+		if r := recover(); r != nil {
+			btopt.Debugf(nil, "POOL %s sweepStuckSessions panic recovered: %v\n%s", p.poolName, r, debug.Stack())
+		}
+	}()
+	p.sweepStuckSessions()
+}

--- a/bigtable/internal/transport/session_pool_lifecycle_test.go
+++ b/bigtable/internal/transport/session_pool_lifecycle_test.go
@@ -1,0 +1,433 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// --- close-reason ledger ---------------------------------------------------
+
+func TestBumpCloseReason_Increments(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	p.bumpCloseReason("GoAway")
+	p.bumpCloseReason("GoAway")
+	p.bumpCloseReason("MissedHeartbeat")
+	got := p.snapshotCloseReasons()
+	if got["GoAway"] != 2 {
+		t.Errorf("GoAway count = %d, want 2", got["GoAway"])
+	}
+	if got["MissedHeartbeat"] != 1 {
+		t.Errorf("MissedHeartbeat count = %d, want 1", got["MissedHeartbeat"])
+	}
+}
+
+func TestBumpCloseReason_EmptyLabelBecomesUnspecified(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	p.bumpCloseReason("")
+	if got := p.snapshotCloseReasons()["Unspecified"]; got != 1 {
+		t.Errorf("Unspecified count = %d, want 1 (empty label must fold here)", got)
+	}
+}
+
+func TestRecordSessionClose_OnceFlag(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	sh := injectActiveSession(t, p, "s1", time.Now())
+	s := sh.session
+
+	// Multiple calls dedupe via s.poolCloseRecorded.
+	p.recordSessionClose(s, "First")
+	p.recordSessionClose(s, "SecondShouldNotFire")
+	p.recordSessionClose(s, "ThirdShouldNotFire")
+
+	if got := p.m.sessionsClosed.Load(); got != 1 {
+		t.Errorf("sessionsClosed = %d, want 1 (once-flag violated)", got)
+	}
+	reasons := p.snapshotCloseReasons()
+	if reasons["First"] != 1 {
+		t.Errorf("First count = %d, want 1", reasons["First"])
+	}
+	if _, ok := reasons["SecondShouldNotFire"]; ok {
+		t.Errorf("second-call fallback leaked into ledger: %+v", reasons)
+	}
+}
+
+func TestRecordSessionClose_UsesSessionReasonOverFallback(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	sh := injectActiveSession(t, p, "s1", time.Now())
+	sh.session.setCloseReason("GoAway")
+
+	p.recordSessionClose(sh.session, "IgnoredFallback")
+	if got := p.snapshotCloseReasons()["GoAway"]; got != 1 {
+		t.Errorf("GoAway count = %d, want 1 (session's own reason should win)", got)
+	}
+	if _, ok := p.snapshotCloseReasons()["IgnoredFallback"]; ok {
+		t.Errorf("fallback leaked despite session reason set: %+v", p.snapshotCloseReasons())
+	}
+}
+
+func TestRecordSessionClose_NilSessionIsNoOp(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	p.recordSessionClose(nil, "Anything")
+	if got := p.m.sessionsClosed.Load(); got != 0 {
+		t.Errorf("sessionsClosed = %d, want 0 for nil session", got)
+	}
+}
+
+func TestBumpStartingClose_UsesFailedToStart(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	sh := injectActiveSession(t, p, "s1", time.Now())
+	p.bumpStartingClose(sh.session)
+	if got := p.snapshotCloseReasons()["FailedToStart"]; got != 1 {
+		t.Errorf("FailedToStart count = %d, want 1", got)
+	}
+}
+
+// --- OnActive / OnClose ---------------------------------------------------
+
+func TestOnActive_DuplicateSessionSkipped(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	sh := injectActiveSession(t, p, "s1", time.Now())
+	before := p.sl.ReadyCount()
+	// Firing onActive on a handle already activated must not
+	// double-register (sh.activated CAS gate catches it).
+	p.onActive(sh)
+	if got := p.sl.ReadyCount(); got != before {
+		t.Errorf("sl.ReadyCount = %d, want %d (duplicate register)", got, before)
+	}
+}
+
+func TestOnActive_SignalsFree(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	// Park a waiter directly on the queue. onActive should wake it.
+	w := &waiter{ready: make(chan struct{})}
+	p.waitersMu.Lock()
+	w.elem = p.waiters.PushBack(w)
+	p.waitersMu.Unlock()
+
+	// Craft a fresh session + handle and fire onActive — must wake the
+	// parked waiter.
+	sh := newSessionHandle(nil, time.Now())
+	stream := newFakeStream()
+	s := NewSession("s-fresh", stream, SessionHooks{
+		OnStart:  p.onStart,
+		OnActive: func(_ *Session) { p.onActive(sh) },
+		OnClose:  func(_ *Session, err error) { p.onClose(sh, err) },
+	}, SessionTypeTable)
+	s.state.Store(int32(StateReady))
+	sh.session = s
+	p.onActive(sh)
+	select {
+	case <-w.ready:
+		// expected
+	case <-time.After(100 * time.Millisecond):
+		t.Error("onActive did not wake the parked waiter within 100ms")
+	}
+}
+
+func TestOnClose_StartingSessionBumpsFailedToStart(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	// Handle in startingSessions but never activated.
+	stream := newFakeStream()
+	sh := newSessionHandle(nil, time.Time{})
+	s := NewSession("s-starting", stream, SessionHooks{
+		OnClose: func(_ *Session, err error) { p.onClose(sh, err) },
+	}, SessionTypeTable)
+	sh.session = s
+	p.mu.Lock()
+	p.startingSessions[sh] = struct{}{}
+	p.mu.Unlock()
+
+	p.onClose(sh, nil)
+
+	p.mu.Lock()
+	_, stillThere := p.startingSessions[sh]
+	p.mu.Unlock()
+	if stillThere {
+		t.Error("handle still in startingSessions after onClose")
+	}
+	if got := p.snapshotCloseReasons()["FailedToStart"]; got != 1 {
+		t.Errorf("FailedToStart count = %d, want 1", got)
+	}
+}
+
+// --- OnClosing ------------------------------------------------------------
+
+func TestOnClosing_DropsFromReadyCountAndRecordsLifetime(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	sh := injectActiveSession(t, p, "s1", time.Now().Add(-time.Second))
+	if p.sl.ReadyCount() != 1 {
+		t.Fatalf("ReadyCount before onClosing = %d, want 1", p.sl.ReadyCount())
+	}
+
+	p.onClosing(sh)
+
+	if got := p.sl.ReadyCount(); got != 0 {
+		t.Errorf("ReadyCount after onClosing = %d, want 0 (dying sessions must free the budget)", got)
+	}
+	if got := len(p.snapshotLifetimes()); got != 1 {
+		t.Errorf("lifetimes len = %d, want 1 (createdAt was set → recordLifetime should fire)", got)
+	}
+}
+
+func TestOnClosing_StartingSessionIsNoOp(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	stream := newFakeStream()
+	sh := newSessionHandle(nil, time.Time{})
+	s := NewSession("s-starting", stream, SessionHooks{
+		OnClosing: func(_ *Session) { p.onClosing(sh) },
+	}, SessionTypeTable)
+	sh.session = s
+	p.mu.Lock()
+	p.startingSessions[sh] = struct{}{}
+	p.mu.Unlock()
+
+	p.onClosing(sh)
+
+	// Starting-branch short-circuits — closingRecorded stays unset so a
+	// later onClosing (once promoted) could still run.
+	if sh.closingRecorded.Load() {
+		t.Error("sh.closingRecorded set for starting-only handle; starting-branch must not consume the flag")
+	}
+}
+
+func TestOnClosing_ThenOnClose_UsesHandleDirectly(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	sh := injectActiveSession(t, p, "s1", time.Now().Add(-time.Second))
+
+	p.onClosing(sh)
+	p.onClose(sh, nil)
+
+	if got := p.m.sessionsClosed.Load(); got != 1 {
+		t.Errorf("sessionsClosed = %d, want 1", got)
+	}
+}
+
+// TestPoolClose_DrainsParkedWaitersWithSentinel pins Close's contract
+// to unblock every FIFO-parked CheckoutSession caller with
+// ErrPoolClosed. Without the drain in Phase-1, long-poll callers whose
+// ctx is context.Background hang past Close forever — the in-flight
+// vRPC teardown fires signalFree for only the N in-flight calls, not
+// the M > N parked waiters typical under saturation.
+//
+// Enqueue directly on the waiter queue (mirroring
+// TestConsecutiveFailures_TripWakesParkedWaitersWithSentinel) so the
+// test exercises the wake/err contract without racing auto-scaling.
+func TestPoolClose_DrainsParkedWaitersWithSentinel(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+
+	const nWaiters = 3
+	results := make(chan error, nWaiters)
+	var wg sync.WaitGroup
+	for i := 0; i < nWaiters; i++ {
+		w := &waiter{ready: make(chan struct{})}
+		p.waitersMu.Lock()
+		w.elem = p.waiters.PushBack(w)
+		p.waitersMu.Unlock()
+		p.waitersCount.Add(1)
+
+		wg.Add(1)
+		go func(w *waiter) {
+			defer wg.Done()
+			<-w.ready
+			p.waitersCount.Add(-1)
+			results <- w.err
+		}(w)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- p.Close() }()
+
+	// Waiters must wake within a bounded window driven by Phase-1
+	// drainWaitersWithErr — NOT by the in-flight-vRPC signalFree wave
+	// (there are no in-flight vRPCs in this test).
+	waitCh := make(chan struct{})
+	go func() { wg.Wait(); close(waitCh) }()
+	select {
+	case <-waitCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("parked waiters not woken by Close within 5s — Close doesn't drain the FIFO queue")
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Close err = %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("Close did not return within 30s")
+	}
+
+	close(results)
+	for err := range results {
+		if !errors.Is(err, ErrPoolClosed) {
+			t.Errorf("waiter err = %v, want ErrPoolClosed", err)
+		}
+	}
+
+	// After the drain, waiter queue must be empty.
+	p.waitersMu.Lock()
+	remaining := p.waiters.Len()
+	p.waitersMu.Unlock()
+	if remaining != 0 {
+		t.Errorf("waiter queue after Close has %d entries, want 0", remaining)
+	}
+}
+
+func TestPoolClose_RecordsLifetimeOncePerSession(t *testing.T) {
+	// Regression: Phase-1 of Pool.Close records lifetime up-front for every
+	// snapshotted handle. Phase-2 then fires s.Close per session, which
+	// drives notifyClosing → p.onClosing → recordLifetime again unless
+	// Phase-1 has tripped sh.closingRecorded. Without the flag, the
+	// lifetimes ring double-counts every session torn down during pool
+	// teardown.
+	p := newTestPool(t, 1, 10)
+	const n = 3
+	for i := 0; i < n; i++ {
+		injectActiveSession(t, p, fmt.Sprintf("s%d", i), time.Now().Add(-time.Second))
+	}
+
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close returned err = %v", err)
+	}
+
+	// Pool.Close waits on wg for all Phase-2 s.Close goroutines, and s.Close
+	// fires notifyClosing synchronously → onClosing has run by return.
+	if got := len(p.snapshotLifetimes()); got != n {
+		t.Errorf("lifetimes len = %d, want %d (one per session, not double-counted)", got, n)
+	}
+}
+
+// TestPoolClose_OnClosingBeforePhase1_NoDoubleLifetime pins the reverse
+// race ordering to TestPoolClose_RecordsLifetimeOncePerSession: a
+// notifyClosing (GOAWAY / heartbeat trip) that fires BEFORE Pool.Close's
+// Phase-1 loop must still leave exactly one lifetime recorded.
+// Previously Phase-1 did `sh.closingRecorded.Store(true)` unconditionally,
+// so the racing onClosing (which already recorded lifetime under its own
+// CAS) followed by Phase-1's Store meant Phase-1 also called
+// recordLifetime — double-count. Fix uses CompareAndSwap in Phase-1 too.
+func TestPoolClose_OnClosingBeforePhase1_NoDoubleLifetime(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	sh := injectActiveSession(t, p, "raced", time.Now().Add(-time.Second))
+
+	// Simulate the race: onClosing wins before Pool.Close's Phase-1
+	// snapshot loop reaches this handle.
+	p.onClosing(sh)
+	if got := len(p.snapshotLifetimes()); got != 1 {
+		t.Fatalf("precondition: onClosing should have recorded 1 lifetime, got %d", got)
+	}
+
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close returned err = %v", err)
+	}
+
+	if got := len(p.snapshotLifetimes()); got != 1 {
+		t.Errorf("lifetimes len after Close = %d, want 1 (Phase-1 must CAS-guard recordLifetime; racing onClosing already recorded it)", got)
+	}
+}
+
+func TestOnClosing_FiresBeforeOnClose_ViaSessionClose(t *testing.T) {
+	// End-to-end: driving Session.ForceClose() must fire OnClosing
+	// (dropping the session from sl.ReadyCount) and the eventual
+	// notifyClosed must fire OnClose.
+	p := newTestPool(t, 1, 10)
+	sh := injectActiveSession(t, p, "s1", time.Now().Add(-time.Second))
+
+	// Session.Close transitions to Closing and eventually the fakeStream
+	// close hooks flush through to notifyClosed. Use ForceClose so we
+	// don't wait on the server-side CloseSession round-trip.
+	sh.session.ForceClose(nil)
+
+	// Wait briefly for the async close path to complete.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if p.sl.ReadyCount() == 0 && p.m.sessionsClosed.Load() == 1 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	t.Errorf("after ForceClose: sl.ReadyCount=%d (want 0), sessionsClosed=%d (want 1)",
+		p.sl.ReadyCount(), p.m.sessionsClosed.Load())
+}
+
+// --- OnClose --------------------------------------------------------------
+
+func TestOnClose_IdxNotFoundStillRecords(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	// A handle neither in sl nor startingSessions — the "already
+	// proactively removed" path (onClosing already ran, or a bare-metal
+	// caller invoked onClose directly). recordSessionClose still fires
+	// so the ledger reflects reality.
+	stream := newFakeStream()
+	sh := newSessionHandle(nil, time.Time{})
+	s := NewSession("s-ghost", stream, SessionHooks{}, SessionTypeTable)
+	sh.session = s
+
+	p.onClose(sh, nil)
+	if got := p.m.sessionsClosed.Load(); got != 1 {
+		t.Errorf("sessionsClosed = %d, want 1", got)
+	}
+}
+
+// --- sweepStuckSessions ---------------------------------------------------
+
+func TestSweepStuckSessions_LeavesFreshAlone(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	sh := injectActiveSession(t, p, "s1", time.Now())
+	// Transition into WaitServerClose but keep the last-state-change
+	// stamp fresh — should be skipped.
+	sh.session.state.Store(int32(StateWaitServerClose))
+	sh.session.lastStateChangeNano.Store(time.Now().UnixNano())
+
+	p.sweepStuckSessions()
+
+	if State(sh.session.state.Load()) != StateWaitServerClose {
+		t.Errorf("fresh WaitServerClose session was swept; state = %v", State(sh.session.state.Load()))
+	}
+}
+
+func TestSweepStuckSessions_ForceClosesStale(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	sh := injectActiveSession(t, p, "s1", time.Now())
+	// Fake a session that's been in WaitServerClose past the grace window.
+	sh.session.state.Store(int32(StateWaitServerClose))
+	stale := time.Now().Add(-waitServerCloseGrace - time.Second).UnixNano()
+	sh.session.lastStateChangeNano.Store(stale)
+
+	p.sweepStuckSessions()
+
+	if State(sh.session.state.Load()) != StateClosed {
+		t.Errorf("stale WaitServerClose session state = %v, want Closed (ForceClose should have fired)",
+			State(sh.session.state.Load()))
+	}
+}
+
+// --- OnStart no-op --------------------------------------------------------
+
+func TestOnStart_NoOp(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	// OnStart takes a ctx and does nothing. Just verify it doesn't
+	// panic and doesn't touch any counters.
+	before := p.m.sessionsOpened.Load()
+	p.onStart(nil)
+	if got := p.m.sessionsOpened.Load(); got != before {
+		t.Errorf("OnStart mutated sessionsOpened: %d → %d", before, got)
+	}
+}

--- a/bigtable/internal/transport/session_pool_scaling.go
+++ b/bigtable/internal/transport/session_pool_scaling.go
@@ -188,10 +188,10 @@ func (p *SessionPoolImpl) createSession(ctx context.Context) error {
 
 	// budgetReleased is the sole gate: the success path calls
 	// budget.Release(true) explicitly and sets budgetReleased=true, so
-	// any deferred fallback only fires on failure — no need for a
-	// separate `success` local. Passing false is correct because the
-	// only way we reach the defer with budgetReleased=false is when
-	// streamFactory / cap-gate / Session.Start returned an error.
+	// any deferred fallback only fires on failure. Passing false is
+	// correct because the only way we reach the defer with
+	// budgetReleased=false is when streamFactory / cap-gate /
+	// Session.Start returned an error.
 	budgetReleased := false
 	defer func() {
 		if !budgetReleased {

--- a/bigtable/internal/transport/session_pool_scaling.go
+++ b/bigtable/internal/transport/session_pool_scaling.go
@@ -179,16 +179,23 @@ func (p *SessionPoolImpl) createSession(ctx context.Context) error {
 	}()
 
 	if err := p.budget.Acquire(dialCtx); err != nil {
+		// Distinct debug tag from create_failed so ops can grep the
+		// throttled path (budget ceiling exhausted / poolCtx cancel /
+		// penalty window elapsed) apart from stream-open errors.
+		recordDebugTag(tagSessionPoolNoBudget)
 		return fmt.Errorf("failed to acquire session creation budget: %w", err)
 	}
 
-	success := false
+	// budgetReleased is the sole gate: the success path calls
+	// budget.Release(true) explicitly and sets budgetReleased=true, so
+	// any deferred fallback only fires on failure — no need for a
+	// separate `success` local. Passing false is correct because the
+	// only way we reach the defer with budgetReleased=false is when
+	// streamFactory / cap-gate / Session.Start returned an error.
 	budgetReleased := false
 	defer func() {
-		// Success path releases early so budget isn't held for the
-		// Session's lifetime; this fallback covers failure paths.
 		if !budgetReleased {
-			p.budget.Release(success)
+			p.budget.Release(false)
 		}
 	}()
 
@@ -207,7 +214,7 @@ func (p *SessionPoolImpl) createSession(ctx context.Context) error {
 		p.mu.Unlock()
 		return fmt.Errorf("session pool is closed")
 	}
-	if p.sl.ReadyCount() >= int(p.maxSessions.Load()) {
+	if p.sl.ReadyCount() >= p.sizer.MaxSessions() {
 		p.mu.Unlock()
 		return fmt.Errorf("session pool limit reached")
 	}
@@ -257,10 +264,8 @@ func (p *SessionPoolImpl) createSession(ctx context.Context) error {
 		return fmt.Errorf("failed to start session: %w", err)
 	}
 
-	success = true
-
 	// Release budget now so the next scale-up isn't blocked by this
-	// session's lifetime (the deferred Release would otherwise fire
+	// session's lifetime (the deferred fallback would otherwise fire
 	// only after WaitGoroutines returns, i.e. after the session dies).
 	p.budget.Release(true)
 	budgetReleased = true

--- a/bigtable/internal/transport/session_pool_scaling.go
+++ b/bigtable/internal/transport/session_pool_scaling.go
@@ -1,0 +1,311 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Scaling for SessionPoolImpl: the Tick driver, createSession worker,
+// scaling-history ring buffer, reason helper, and the deadline-stripping
+// context wrapper used for long-lived dials.
+//
+// Only scale-up is actioned; negative deltas are advisory and the pool
+// shrinks passively via OnClose's replace-on-death gate.
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math/rand/v2"
+	"runtime/debug"
+	"sync/atomic"
+	"time"
+
+	btopt "cloud.google.com/go/bigtable/internal/option"
+	"google.golang.org/grpc/metadata"
+)
+
+// ScalingEvent is one row in a pool's scaling history. Requested is
+// the scale-up delta the sizer asked for (always > 0 in the ring —
+// scale-down deltas short-circuit before recordScaling). Actual pool
+// growth lags this event: handshakes complete asynchronously.
+type ScalingEvent struct {
+	At        time.Time
+	Before    int
+	Requested int
+	Launched  int // reserved for future per-action outcome; unused today
+	Reason    string
+
+	// Decision is the full sizer trace that produced Requested — every
+	// input, intermediate, and the branch taken.
+	Decision ScaleDecision
+}
+
+// maxScalingHistory ≈ 16 min of history at the 1-sec heartbeat.
+const maxScalingHistory = 1024
+
+// recordScaling appends an event to the ring buffer, dropping the oldest
+// entry when full.
+func (p *SessionPoolImpl) recordScaling(ev ScalingEvent) {
+	p.m.scalingHistoryMu.Lock()
+	defer p.m.scalingHistoryMu.Unlock()
+	if len(p.m.scalingHistory) >= maxScalingHistory {
+		copy(p.m.scalingHistory, p.m.scalingHistory[1:])
+		p.m.scalingHistory = p.m.scalingHistory[:len(p.m.scalingHistory)-1]
+	}
+	p.m.scalingHistory = append(p.m.scalingHistory, ev)
+}
+
+// snapshotScalingHistory returns a copy of the ring buffer, oldest first.
+func (p *SessionPoolImpl) snapshotScalingHistory() []ScalingEvent {
+	p.m.scalingHistoryMu.Lock()
+	defer p.m.scalingHistoryMu.Unlock()
+	out := make([]ScalingEvent, len(p.m.scalingHistory))
+	copy(out, p.m.scalingHistory)
+	return out
+}
+
+// Tick is the heartbeat/checkout-triggered driver that samples state
+// and launches new-session goroutines when the sizer requests growth.
+// Negative deltas are logged, not actioned. Stuck-session sweeping is
+// on its own loop (startSweepStuckSessionsLoop) at a coarser cadence.
+func (p *SessionPoolImpl) Tick(ctx context.Context) {
+	p.recordTimeSeries()
+	p.sampleActiveUptimes(ctx)
+
+	p.mu.Lock()
+	if p.closed || p.scalingInProgress {
+		p.mu.Unlock()
+		return
+	}
+	p.scalingInProgress = true
+	p.mu.Unlock()
+
+	defer func() {
+		p.mu.Lock()
+		p.scalingInProgress = false
+		p.mu.Unlock()
+	}()
+
+	decision := p.sizer.Decide()
+	stats := &PoolStats{
+		ReadyCount:    decision.ReadyCount,
+		StartingCount: decision.StartingCount,
+		InUseCount:    decision.InUseCount,
+		PendingCount:  decision.PendingCount,
+	}
+	delta := decision.Delta
+
+	currentSessions := p.sl.ReadyCount()
+
+	if delta <= 0 {
+		return
+	}
+
+	reason := scalingReason(stats, delta, decision.MinSessions)
+	// Record Requested = delta up-front; per-session outcomes complete
+	// asynchronously. Sessions signal readiness via OnActive →
+	// signalFree; failures bump tagSessionPoolCreateFailed.
+	p.recordScaling(ScalingEvent{
+		At:        time.Now(),
+		Before:    currentSessions,
+		Requested: delta,
+		Reason:    reason,
+		Decision:  decision,
+	})
+
+	// Reserve pendingStarts + register spawns BEFORE launching. Held
+	// under p.mu with a re-check of p.closed so Close's Phase 1
+	// synchronizes-with p.spawns.Wait — no Add races Wait.
+	// pendingStarts guards the sizer double-count; spawns guards
+	// teardown so no createSession goroutine outlives Close.
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return
+	}
+	p.pendingStarts += delta
+	p.spawns.Add(delta)
+	p.mu.Unlock()
+
+	// Fire and forget; readiness signals via OnActive → signalFree.
+	// Per-goroutine recover: tickOnce's recover fires BEFORE this
+	// goroutine runs (Tick spawns and returns), so an unhandled panic
+	// inside third-party code (NewSession / streamFactory / hook wiring)
+	// would crash the process. Distinct tag from create_failed so ops
+	// can grep panics (client bug) apart from err returns (transient).
+	// createSession's `reserved` defer balances pendingStarts on panic.
+	for i := 0; i < delta; i++ {
+		go func() {
+			defer p.spawns.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					recordDebugTag(tagSessionPoolCreatePanic)
+					btopt.Debugf(nil, "POOL %s createSession panic recovered: %v\n%s", p.poolName, r, debug.Stack())
+				}
+			}()
+			if err := p.createSession(ctx); err != nil {
+				recordDebugTag(tagSessionPoolCreateFailed)
+				btopt.Debugf(nil, "POOL %s Tick createSession failed: %v", p.poolName, err)
+			}
+		}()
+	}
+}
+
+func (p *SessionPoolImpl) createSession(ctx context.Context) error {
+	// Pool-scoped ctx with deadline stripped: a Bidi stream must not
+	// inherit a per-request timeout; cancellation still propagates.
+	dialCtx := noDeadlineButCancellableContext{Context: p.poolCtx}
+
+	// This goroutine owns one pendingStarts reservation minted by Tick.
+	// Any failure before the transfer below releases it; the transfer
+	// consumes it atomically with the startingSessions insert.
+	reserved := true
+	defer func() {
+		if reserved {
+			p.mu.Lock()
+			p.pendingStarts--
+			p.mu.Unlock()
+		}
+	}()
+
+	if err := p.budget.Acquire(dialCtx); err != nil {
+		return fmt.Errorf("failed to acquire session creation budget: %w", err)
+	}
+
+	success := false
+	budgetReleased := false
+	defer func() {
+		// Success path releases early so budget isn't held for the
+		// Session's lifetime; this fallback covers failure paths.
+		if !budgetReleased {
+			p.budget.Release(success)
+		}
+	}()
+
+	dialCtxOut := metadata.NewOutgoingContext(dialCtx, p.metadata)
+	// pickedChannel receives the channel-pool's connEntry hint; -1
+	// means the underlying pool didn't publish one.
+	var pickedChannel atomic.Int32
+	pickedChannel.Store(-1)
+	stream, err := p.streamFactory(ChannelPickHintInto(dialCtxOut, &pickedChannel))
+	if err != nil {
+		return err
+	}
+
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return fmt.Errorf("session pool is closed")
+	}
+	if p.sl.ReadyCount() >= int(p.maxSessions.Load()) {
+		p.mu.Unlock()
+		return fmt.Errorf("session pool limit reached")
+	}
+	// Session log name = {poolID}-{uniqueHex}. Random 32-bit hex tail
+	// (not a counter) so long-running pools never overflow; collision
+	// odds at N live sessions ≈ N²/2^33 (~1 in 8k at N=1000).
+	sessionName := fmt.Sprintf("%d-%08x", p.poolID, rand.Uint32())
+	p.mu.Unlock()
+
+	// Mint the SessionHandle BEFORE NewSession so per-session hook
+	// closures capture it directly — no Session→SessionHandle back-ref.
+	// sh.session / createdAt are backfilled below; closures don't fire
+	// until Session.Start runs.
+	sh := &SessionHandle{}
+	hooks := SessionHooks{
+		OnStart:  p.onStart,
+		OnActive: func(_ *Session) { p.onActive(sh) },
+		OnSlotDrained: func() {
+			p.sl.ReleaseToPool(sh)
+			p.signalFree()
+		},
+		OnClosing: func(_ *Session) { p.onClosing(sh) },
+		OnClose:   func(_ *Session, err error) { p.onClose(sh, err) },
+	}
+	s := NewSession(sessionName, stream, hooks, p.sessionType,
+		WithSessionPoolName(p.poolName), WithSessionLogger(log.Default()))
+	if hint := pickedChannel.Load(); hint >= 0 {
+		s.setChannelIndex(hint)
+	}
+
+	sh.session = s
+	sh.createdAt = time.Now()
+
+	// Transfer pendingStarts → startingSessions in one lock so a
+	// concurrent Decide() never sees a gap (both zero) or a double.
+	p.mu.Lock()
+	p.pendingStarts--
+	p.startingSessions[sh] = struct{}{}
+	p.mu.Unlock()
+	reserved = false
+
+	if err := s.Start(dialCtx, p.openSessionRequest); err != nil {
+		p.mu.Lock()
+		delete(p.startingSessions, sh)
+		p.mu.Unlock()
+		btopt.Debugf(nil, "POOL %p createSession Start failed for %s: %v", p, sessionName, err)
+		return fmt.Errorf("failed to start session: %w", err)
+	}
+
+	success = true
+
+	// Release budget now so the next scale-up isn't blocked by this
+	// session's lifetime (the deferred Release would otherwise fire
+	// only after WaitGoroutines returns, i.e. after the session dies).
+	p.budget.Release(true)
+	budgetReleased = true
+
+	// Block on WaitGoroutines so this createSession goroutine stays on
+	// p.spawns for the session's entire lifetime — Close's Phase-5 then
+	// waits for every Session's readLoop / heartbeatLoop to exit before
+	// returning.
+	s.WaitGoroutines()
+	return nil
+}
+
+// scalingReason summarizes why the sizer requested a scale delta.
+// Pure helper — same text the operator would derive from the log.
+func scalingReason(stats *PoolStats, delta int, minSessions int) string {
+	if delta > 0 {
+		switch {
+		case stats == nil:
+			return "scale up (no stats)"
+		case stats.PendingCount > 0:
+			return fmt.Sprintf("pending=%d", stats.PendingCount)
+		case stats.ReadyCount+stats.StartingCount < minSessions:
+			// Floor-driven (session churn), distinct from load-driven.
+			return fmt.Sprintf("below min sessions (ready=%d starting=%d < min=%d)",
+				stats.ReadyCount, stats.StartingCount, minSessions)
+		case stats.InUseCount > 0 && stats.ReadyCount-stats.InUseCount <= 0:
+			return fmt.Sprintf("ready=%d in_use=%d (headroom exhausted)", stats.ReadyCount, stats.InUseCount)
+		default:
+			return fmt.Sprintf("ready=%d in_use=%d (load>headroom)", stats.ReadyCount, stats.InUseCount)
+		}
+	}
+	if stats == nil {
+		return "scale down (no stats)"
+	}
+	return fmt.Sprintf("scale down: ready=%d in_use=%d", stats.ReadyCount, stats.InUseCount)
+}
+
+// noDeadlineButCancellableContext strips deadline (long-lived Bidi
+// stream must not inherit a per-request timeout) while preserving
+// cancellation, errors, and values from the parent. Built on poolCtx
+// so pool teardown unblocks dial / budget / Session.Start loops.
+type noDeadlineButCancellableContext struct {
+	context.Context
+}
+
+func (noDeadlineButCancellableContext) Deadline() (deadline time.Time, ok bool) {
+	return time.Time{}, false
+}

--- a/bigtable/internal/transport/session_pool_scaling_test.go
+++ b/bigtable/internal/transport/session_pool_scaling_test.go
@@ -1,0 +1,263 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+)
+
+// --- scalingReason ---------------------------------------------------------
+
+func TestScalingReason(t *testing.T) {
+	cases := []struct {
+		name        string
+		stats       *PoolStats
+		delta       int
+		minSessions int
+		want        string // substring the returned message must contain
+	}{
+		{
+			name:  "scale-up nil stats",
+			stats: nil,
+			delta: 3,
+			want:  "no stats",
+		},
+		{
+			name:  "scale-up with pending waiters",
+			stats: &PoolStats{PendingCount: 5, InUseCount: 2, ReadyCount: 4},
+			delta: 1,
+			want:  "pending=5",
+		},
+		{
+			name:        "scale-up below min sessions",
+			stats:       &PoolStats{PendingCount: 0, InUseCount: 0, ReadyCount: 4, StartingCount: 0},
+			delta:       1,
+			minSessions: 5,
+			want:        "below min sessions",
+		},
+		{
+			name:  "scale-up headroom exhausted",
+			stats: &PoolStats{PendingCount: 0, InUseCount: 4, ReadyCount: 4},
+			delta: 1,
+			want:  "headroom exhausted",
+		},
+		{
+			name:  "scale-up load exceeds headroom",
+			stats: &PoolStats{PendingCount: 0, InUseCount: 3, ReadyCount: 10},
+			delta: 1,
+			want:  "load>headroom",
+		},
+		{
+			name:  "scale-down nil stats",
+			stats: nil,
+			delta: -1,
+			want:  "no stats",
+		},
+		{
+			name:  "scale-down with counts",
+			stats: &PoolStats{ReadyCount: 8, InUseCount: 1},
+			delta: -3,
+			want:  "scale down",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scalingReason(tc.stats, tc.delta, tc.minSessions)
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("scalingReason(%+v, %d, %d) = %q, want substring %q",
+					tc.stats, tc.delta, tc.minSessions, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- scaling-history ring --------------------------------------------------
+
+func TestRecordScaling_RingCaps(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	for i := 0; i < maxScalingHistory+3; i++ {
+		p.recordScaling(ScalingEvent{
+			At:        time.Now(),
+			Before:    i,
+			Requested: 1,
+			Launched:  1,
+			Reason:    "test",
+		})
+	}
+	snap := p.snapshotScalingHistory()
+	if len(snap) != maxScalingHistory {
+		t.Fatalf("len = %d, want %d", len(snap), maxScalingHistory)
+	}
+	// Oldest 3 events dropped: snap[0].Before should be 3 (the 4th append).
+	if snap[0].Before != 3 {
+		t.Errorf("snap[0].Before = %d, want 3", snap[0].Before)
+	}
+	if snap[len(snap)-1].Before != maxScalingHistory+2 {
+		t.Errorf("snap[last].Before = %d, want %d", snap[len(snap)-1].Before, maxScalingHistory+2)
+	}
+}
+
+func TestSnapshotScalingHistory_ReturnsCopy(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	p.recordScaling(ScalingEvent{Before: 1})
+	p.recordScaling(ScalingEvent{Before: 2})
+
+	snap := p.snapshotScalingHistory()
+	if len(snap) != 2 {
+		t.Fatalf("len = %d, want 2", len(snap))
+	}
+	// Mutate the snapshot; live buffer must be untouched.
+	snap[0].Before = 999
+	live := p.snapshotScalingHistory()
+	if live[0].Before != 1 {
+		t.Errorf("live[0].Before = %d, want 1 (snapshot must be an independent copy)", live[0].Before)
+	}
+}
+
+// --- noDeadlineButCancellableContext ---------------------------------------
+
+func TestNoDeadlineButCancellableContext_StripsDeadline(t *testing.T) {
+	parent, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Hour))
+	defer cancel()
+
+	wrapped := noDeadlineButCancellableContext{Context: parent}
+	if _, ok := wrapped.Deadline(); ok {
+		t.Error("Deadline() returned ok=true after stripping — expected zero-value")
+	}
+}
+
+func TestNoDeadlineButCancellableContext_PreservesCancel(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	wrapped := noDeadlineButCancellableContext{Context: parent}
+
+	select {
+	case <-wrapped.Done():
+		t.Fatal("wrapped ctx.Done fired prematurely")
+	default:
+	}
+
+	cancel()
+	select {
+	case <-wrapped.Done():
+		// expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("wrapped ctx.Done did not fire within 100ms of parent cancel")
+	}
+	if wrapped.Err() == nil {
+		t.Error("wrapped.Err() = nil after cancel; expected non-nil")
+	}
+}
+
+func TestNoDeadlineButCancellableContext_PreservesValues(t *testing.T) {
+	type k struct{}
+	parent := context.WithValue(context.Background(), k{}, "sentinel")
+	wrapped := noDeadlineButCancellableContext{Context: parent}
+	if got := wrapped.Value(k{}); got != "sentinel" {
+		t.Errorf("wrapped.Value = %v, want sentinel", got)
+	}
+}
+
+// --- Tick --------------------------------------------------------
+
+func TestTick_EarlyReturnWhenClosed(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	// Mark closed BEFORE calling Tick. The function should
+	// return without recording a scaling event.
+	p.mu.Lock()
+	p.closed = true
+	p.mu.Unlock()
+
+	before := len(p.snapshotScalingHistory())
+	p.Tick(context.Background())
+	after := len(p.snapshotScalingHistory())
+	if after != before {
+		t.Errorf("scaling history grew despite closed pool: %d → %d", before, after)
+	}
+}
+
+func TestTick_ScalingInProgressGate(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	// Simulate a prior Tick still in progress. The second call
+	// must exit immediately without racing.
+	p.mu.Lock()
+	p.scalingInProgress = true
+	p.mu.Unlock()
+
+	before := len(p.snapshotScalingHistory())
+	p.Tick(context.Background())
+	after := len(p.snapshotScalingHistory())
+	if after != before {
+		t.Errorf("scaling event recorded despite scalingInProgress=true: %d → %d", before, after)
+	}
+	// Gate should NOT have been cleared by our early-return path (only
+	// the successful path's defer clears it).
+	p.mu.Lock()
+	stillGated := p.scalingInProgress
+	p.mu.Unlock()
+	if !stillGated {
+		t.Error("scalingInProgress was flipped by an early-return; the defer should only fire for the winning call")
+	}
+}
+
+// TestTick_CreateSessionPanic_PoolSurvives pins the per-goroutine recover
+// on Tick's createSession fanout. Without it, a panic inside
+// streamFactory / NewSession / hook wiring crashes the whole process
+// (tickOnce's recover fires BEFORE the fire-and-forget goroutine runs).
+// After the fix: the panic is caught, spawns.Done() still fires so
+// Close's Phase-5 wait unblocks, and createSession's own defer stack
+// balances pendingStarts even on the panic path.
+func TestTick_CreateSessionPanic_PoolSurvives(t *testing.T) {
+	panicFactory := func(_ context.Context) (Stream, error) {
+		panic("simulated streamFactory panic")
+	}
+	p := NewSessionPoolImpl(
+		uint64(1), "test-panic-pool", 1, 10, panicFactory,
+		&spb.OpenSessionRequest{ProtocolVersion: 1}, nil, SessionTypeTable,
+	)
+	t.Cleanup(func() { _ = p.Close() })
+
+	// Tick spawns a createSession goroutine; the factory panics inside
+	// createSession → the per-goroutine defer recover must catch it.
+	// If recover is missing this call crashes the test process instead
+	// of returning.
+	p.Tick(context.Background())
+
+	// spawns.Wait must unblock — proves the goroutine's `defer
+	// p.spawns.Done()` ran despite the panic (recover ordering: Done
+	// runs LAST because defers are LIFO, so recover fires first and
+	// then Done fires on unwind).
+	waitCh := make(chan struct{})
+	go func() { p.spawns.Wait(); close(waitCh) }()
+	select {
+	case <-waitCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("spawns.Wait did not return within 2s after panic — goroutine leaked past recover")
+	}
+
+	// pendingStarts must have been released by createSession's own
+	// deferred `reserved` guard, even though the goroutine unwound via
+	// panic instead of a normal error return.
+	p.mu.Lock()
+	pending := p.pendingStarts
+	p.mu.Unlock()
+	if pending != 0 {
+		t.Errorf("pendingStarts after panic = %d, want 0 (createSession's reserved-defer must release on panic too)", pending)
+	}
+}

--- a/bigtable/internal/transport/session_pool_test.go
+++ b/bigtable/internal/transport/session_pool_test.go
@@ -68,6 +68,11 @@ func newStubStreamFactory() (factory func(context.Context) (Stream, error), clos
 // minimum required state: build sh, wire hook closures, register into
 // sl. PeerInfo stays nil, so the handle lands in the AfeID=0 bucket —
 // fine for pool-level tests that don't care about AFE fanout.
+//
+// sh.activated is stamped true to match production's onActive path,
+// which is the "session reached StateReady" signal noteAbnormalCloseIfAny
+// keys off of. Tests that want a "never activated" (FailedToStart-style)
+// handle should use injectStartingSession instead.
 func injectActiveSession(t testing.TB, p *SessionPoolImpl, name string, createdAt time.Time) *SessionHandle {
 	t.Helper()
 	stream := newFakeStream()
@@ -80,8 +85,35 @@ func injectActiveSession(t testing.TB, p *SessionPoolImpl, name string, createdA
 	}, SessionTypeTable)
 	s.state.Store(int32(StateReady))
 	sh.session = s
+	sh.activated.Store(true)
 
 	p.sl.OnSessionStarted(sh)
+	return sh
+}
+
+// injectStartingSession builds a fakeStream-backed Session that has NOT
+// yet reached StateReady (StateStarting), registers it in the pool's
+// startingSessions set, and returns the handle. Used by consecutive-
+// failure tests to drive the state-based abnormal-close classification
+// (`sh.activated == false` → abnormal). Does NOT register the handle
+// with sl — mirrors production's createSession failure window between
+// startingSessions insert and onActive.
+func injectStartingSession(t testing.TB, p *SessionPoolImpl, name string) *SessionHandle {
+	t.Helper()
+	stream := newFakeStream()
+	sh := newSessionHandle(nil, time.Now())
+	s := NewSession(name, stream, SessionHooks{
+		OnStart:   p.onStart,
+		OnActive:  func(_ *Session) { p.onActive(sh) },
+		OnClosing: func(_ *Session) { p.onClosing(sh) },
+		OnClose:   func(_ *Session, err error) { p.onClose(sh, err) },
+	}, SessionTypeTable)
+	s.state.Store(int32(StateStarting))
+	sh.session = s
+
+	p.mu.Lock()
+	p.startingSessions[sh] = struct{}{}
+	p.mu.Unlock()
 	return sh
 }
 
@@ -598,8 +630,8 @@ func TestUpdateConfig_SwapsPickerAndBounds(t *testing.T) {
 	if got := p.picker.Name(); got != "simple" {
 		t.Errorf("after Random swap, picker = %q, want simple", got)
 	}
-	if p.minSessions.Load() != 4 || p.maxSessions.Load() != 40 {
-		t.Errorf("min/max = %d/%d, want 4/40", p.minSessions.Load(), p.maxSessions.Load())
+	if p.sizer.MinSessions() != 4 || p.sizer.MaxSessions() != 40 {
+		t.Errorf("min/max = %d/%d, want 4/40", p.sizer.MinSessions(), p.sizer.MaxSessions())
 	}
 
 	// Switch to PeakEwma with an explicit subset size.

--- a/bigtable/internal/transport/session_pool_test.go
+++ b/bigtable/internal/transport/session_pool_test.go
@@ -1,0 +1,698 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+)
+
+// newStubStreamFactory returns a streamFactory that hands out fresh
+// fakeStreams and a closeAll function that closes every stream the
+// factory produced. Tests that use SessionPoolImpl.CheckoutSession end
+// up triggering Tick → createSession → Session.Start, which
+// spawns a readLoop parked on fakeStream.Recv forever unless the recv
+// channel is closed. Wire closeAll into t.Cleanup so those readLoops
+// exit at end of test instead of accumulating across -count=N runs.
+func newStubStreamFactory() (factory func(context.Context) (Stream, error), closeAll func()) {
+	var mu sync.Mutex
+	var streams []*fakeStream
+	var closed bool
+	factory = func(_ context.Context) (Stream, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if closed {
+			// After closeAll ran, refuse new streams so a fire-and-forget
+			// createSession spawned by (e.g.) onClosing → spawnTickOnce
+			// after cleanup can't produce a fresh unblocked fakeStream
+			// that leaks its readLoop past p.Close.
+			return nil, errors.New("newStubStreamFactory: closed")
+		}
+		s := newFakeStream()
+		streams = append(streams, s)
+		return s, nil
+	}
+	closeAll = func() {
+		mu.Lock()
+		defer mu.Unlock()
+		closed = true
+		for _, s := range streams {
+			s.Close()
+		}
+	}
+	return factory, closeAll
+}
+
+// injectActiveSession builds a fakeStream-backed Session in StateReady,
+// wraps it in a SessionHandle, and registers it with the pool's
+// sessionList. Bypasses the real Start/handshake path so tests can
+// exercise pool-level logic in milliseconds. Since sl is now the sole
+// store of active handles, this mirrors createSession + onActive's
+// minimum required state: build sh, wire hook closures, register into
+// sl. PeerInfo stays nil, so the handle lands in the AfeID=0 bucket —
+// fine for pool-level tests that don't care about AFE fanout.
+func injectActiveSession(t testing.TB, p *SessionPoolImpl, name string, createdAt time.Time) *SessionHandle {
+	t.Helper()
+	stream := newFakeStream()
+	sh := newSessionHandle(nil, createdAt)
+	s := NewSession(name, stream, SessionHooks{
+		OnStart:   p.onStart,
+		OnActive:  func(_ *Session) { p.onActive(sh) },
+		OnClosing: func(_ *Session) { p.onClosing(sh) },
+		OnClose:   func(_ *Session, err error) { p.onClose(sh, err) },
+	}, SessionTypeTable)
+	s.state.Store(int32(StateReady))
+	sh.session = s
+
+	p.sl.OnSessionStarted(sh)
+	return sh
+}
+
+func newTestPool(t testing.TB, min, max int) *SessionPoolImpl {
+	t.Helper()
+	factory, closeStreams := newStubStreamFactory()
+	p := NewSessionPoolImpl(
+		uint64(1),
+		"test-pool",
+		min,
+		max,
+		factory,
+		&spb.OpenSessionRequest{ProtocolVersion: 1},
+		nil,
+		SessionTypeTable,
+	)
+	// Close streams before closing the pool: the pool's Close waits for
+	// per-session teardown, which requires the readLoop goroutines to
+	// exit — and they won't while parked on fakeStream.Recv.
+	t.Cleanup(func() {
+		closeStreams()
+		_ = p.Close()
+	})
+	return p
+}
+
+// TestSessionPool_Close_CompletesWithIdleSessions verifies that Close()
+// returns promptly when sessions have nothing in flight, well within the 30s
+// internal budget, and that poolCtx is cancelled after.
+func TestSessionPool_Close_CompletesWithIdleSessions(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+
+	// Three idle sessions registered with the pool. None have in-flight
+	// VRPCs, so Session.Close should flip them to Closing and signal
+	// quiescent immediately, letting the pool drain fast.
+	for i := 0; i < 3; i++ {
+		injectActiveSession(t, p, "idle", time.Now())
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- p.Close() }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Close returned err = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not return within 5s for idle sessions (budget is 30s)")
+	}
+
+	// poolCtx must be cancelled after Close.
+	select {
+	case <-p.poolCtx.Done():
+	default:
+		t.Error("poolCtx not cancelled after Close()")
+	}
+}
+
+// TestSessionPool_Close_BoundedByTimeout is skipped: constructing a stuck
+// session that ignores Close() requires real readLoop/Send plumbing that
+// blocks unrecoverably, which is hard to do safely in a unit test. The 30s
+// timeout path is exercised in integration tests.
+func TestSessionPool_Close_BoundedByTimeout(t *testing.T) {
+	t.Skip("requires a session that ignores Close — see integration tests")
+}
+
+// TestTick_NoLongerPrunesOverprovisioned verifies the passive-
+// shrink design: Tick with a scale-down delta must be a no-op
+// — the pool shrinks only via OnClose's replace-on-death gate, not via a
+// periodic prune. Regression guard against re-introducing the burst-then-
+// lull oscillation that the earlier active-scale-down design produced.
+func TestTick_NoLongerPrunesOverprovisioned(t *testing.T) {
+	p := newTestPool(t, 1, 20)
+	// 10 idle sessions, none in-flight → sizer will compute
+	// desired ≈ minSessions (5-ish) and delta will be negative.
+	// Tick must observe the negative delta and NOT shrink
+	// the pool — regression guard for the removed active-scale-down.
+	for i := 0; i < 10; i++ {
+		sh := injectActiveSession(t, p, "idle", time.Now().Add(-time.Hour))
+		_ = sh
+	}
+
+	before := p.sl.ReadyCount()
+	p.Tick(context.Background())
+	after := p.sl.ReadyCount()
+
+	if after != before {
+		t.Errorf("Tick pruned sessions: before=%d after=%d — scale-down must be advisory, not proactive", before, after)
+	}
+}
+
+// TestSizer_ScaleDownIsAdvisory confirms the sizer still RETURNS a
+// negative delta on overprovision (so ScalingHistory / callers can see
+// the intent) but the calling site (Tick) must not act on it.
+// The paired assertion above proves the caller is well-behaved; this one
+// pins the sizer contract.
+func TestSizer_ScaleDownIsAdvisory(t *testing.T) {
+	// InUse=1, Pending=0, Ready=10 → desired ≈ 2, immediate=10.
+	// Expect delta = 2 - 10 = -8 with Branch = "scale-down".
+	stats := &PoolStats{ReadyCount: 10, InUseCount: 1}
+	sizer := NewPoolSizer(func() *PoolStats { return stats }, 1, 20, 0.5)
+	d := sizer.Decide()
+	if d.Branch != "scale-down" {
+		t.Fatalf("Branch = %q, want scale-down", d.Branch)
+	}
+	if d.Delta >= 0 {
+		t.Errorf("Delta = %d, want negative (advisory scale-down)", d.Delta)
+	}
+}
+
+// TestSessionPool_Invoke_RecordsSlowCheckoutFailure pins the fix for the
+// pool-exhaustion blind spot: if CheckoutSession errors out (typically ctx
+// deadline while parked waiting on freeSignal), Invoke must still push a
+// row into the slow-vRPC ring — otherwise the exact incident an operator
+// opens sessionz to debug ("pool saturated, everything timing out") leaves
+// no evidence in the debug UI.
+func TestSessionPool_Invoke_RecordsSlowCheckoutFailure(t *testing.T) {
+	// Dial that blocks until its own ctx (poolCtx, wrapped) fires. No
+	// session ever lands, so CheckoutSession is forced to park on
+	// freeSignal until the caller's ctx cancels.
+	neverDialing := func(ctx context.Context) (Stream, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	p := NewSessionPoolImpl(
+		uint64(1),
+		"test-pool",
+		0, 1,
+		neverDialing,
+		&spb.OpenSessionRequest{ProtocolVersion: 1},
+		nil,
+		SessionTypeTable,
+	)
+	defer p.Close()
+
+	// 50ms ctx budget vs the 10ms defaultSlowThreshold means the checkout
+	// wait will comfortably exceed the slow-vRPC record threshold even on
+	// slow CI, so the record path fires deterministically.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := p.Invoke(ctx, newRoundTripDesc(), "hello")
+	if err == nil {
+		t.Fatal("Invoke on a pool that cannot dial succeeded; want ctx deadline error")
+	}
+
+	events := p.snapshotSlowVRpcs()
+	if len(events) != 1 {
+		t.Fatalf("snapshotSlowVRpcs len = %d, want 1 — checkout failure was not recorded", len(events))
+	}
+	ev := events[0]
+	if ev.Method != "RoundTrip" {
+		t.Errorf("Method = %q, want RoundTrip", ev.Method)
+	}
+	if ev.Success {
+		t.Error("Success = true, want false (checkout failed)")
+	}
+	if ev.PoolWait <= 0 {
+		t.Errorf("PoolWait = %v, want > 0", ev.PoolWait)
+	}
+	if ev.Latency != ev.PoolWait {
+		t.Errorf("Latency = %v, PoolWait = %v — must match when all time was in checkout", ev.Latency, ev.PoolWait)
+	}
+	if ev.Session != "" {
+		t.Errorf("Session = %q, want empty (no handle was ever returned)", ev.Session)
+	}
+	if ev.ErrCode != "DeadlineExceeded" {
+		t.Errorf("ErrCode = %q, want DeadlineExceeded", ev.ErrCode)
+	}
+}
+
+// TestCheckoutSession_ParkedWaiter_DeadlineExceeded pins the ctx-done
+// unwind for a caller that made it into the waiter queue: the returned
+// error must unwrap to context.DeadlineExceeded, and the waiter must be
+// dequeued cleanly (no ghost entry left for a later signalFree to burn
+// on). Together these are the contract callers rely on when their
+// per-request deadline shorter than session-open time expires while
+// they're parked — the shape of pool-side backpressure.
+func TestCheckoutSession_ParkedWaiter_DeadlineExceeded(t *testing.T) {
+	// Dial that blocks until its own ctx (poolCtx, wrapped) fires. No
+	// session ever lands, so any CheckoutSession caller is forced to
+	// park on the waiter queue until their ctx cancels.
+	neverDialing := func(ctx context.Context) (Stream, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	p := NewSessionPoolImpl(
+		uint64(1),
+		"test-pool",
+		0, 1,
+		neverDialing,
+		&spb.OpenSessionRequest{ProtocolVersion: 1},
+		nil,
+		SessionTypeTable,
+	)
+	defer p.Close()
+
+	// Short deadline so the test doesn't loiter, long enough that the
+	// caller is definitely parked before it fires. Kept as a named
+	// const so the wall-time floor below stays coupled to it.
+	const parkDeadline = 50 * time.Millisecond
+
+	// Positive parking assertion: observer goroutine watches
+	// waitersCount and closes `parked` the moment the caller enqueues.
+	// Direct evidence of the waiter path — doesn't rely on timing to
+	// infer that we parked. Stopped after CheckoutSession returns so
+	// it can't outlive the test if parking never happened.
+	parked := make(chan struct{})
+	stop := make(chan struct{})
+	go func() {
+		tick := time.NewTicker(time.Millisecond)
+		defer tick.Stop()
+		for {
+			if p.waitersCount.Load() > 0 {
+				close(parked)
+				return
+			}
+			select {
+			case <-stop:
+				return
+			case <-tick.C:
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), parkDeadline)
+	defer cancel()
+
+	start := time.Now()
+	sh, err := p.CheckoutSession(ctx)
+	waited := time.Since(start)
+	close(stop)
+
+	if err == nil {
+		t.Fatalf("CheckoutSession succeeded (handle=%v); want ctx deadline error", sh)
+	}
+	if sh != nil {
+		t.Errorf("handle = %v, want nil on error", sh)
+	}
+	if !errors.Is(err, ErrNoSessionsAvailable) {
+		t.Errorf("err = %v (type %T), want unwrappable to ErrNoSessionsAvailable (was the pool-exhaustion sentinel dropped?)", err, err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v (type %T), want unwrappable to context.DeadlineExceeded (was the ctx cause dropped?)", err, err)
+	}
+	// Positive proof we parked (independent of timing).
+	select {
+	case <-parked:
+	default:
+		t.Error("waitersCount never observed > 0 — CheckoutSession may have fast-failed before enqueuing")
+	}
+	// Wall-time sanity: floor derived from parkDeadline (80%) so
+	// scaling the deadline auto-scales the floor. Kept as a soft
+	// diagnostic — if the observer above missed a very brief parking
+	// window, a much-less-than-deadline wall time would still surface
+	// the fast-fail regression here.
+	if minPark := parkDeadline * 8 / 10; waited < minPark {
+		t.Errorf("CheckoutSession returned after %v; want ≥ %v (parkDeadline=%v)", waited, minPark, parkDeadline)
+	}
+
+	// waitersCount must have been decremented on the ctx-done path.
+	if got := p.waitersCount.Load(); got != 0 {
+		t.Errorf("waitersCount = %d after cancelled checkout, want 0", got)
+	}
+	// Direct queue inspection — belt-and-suspenders since the counter
+	// and the list are updated separately. A leftover entry here is the
+	// "ghost waiter" bug: a subsequent signalFree would consume a wake
+	// token on a caller that already returned.
+	p.waitersMu.Lock()
+	qlen := p.waiters.Len()
+	p.waitersMu.Unlock()
+	if qlen != 0 {
+		t.Errorf("waiter queue length = %d, want 0 (ghost waiter left after ctx cancel)", qlen)
+	}
+}
+
+// TestRecordPickDecision_RingWrap verifies the O(1) circular-buffer
+// implementation of pickHistory: pre-wrap events are in insertion order,
+// post-wrap events preserve oldest-first ordering, and the ring keeps
+// exactly maxPickHistory entries. Regression guard against the previous
+// shift-based implementation that memmoved the whole buffer per record
+// (~24µs p99 CheckoutSession regression at moderate QPS).
+func TestRecordPickDecision_RingWrap(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+
+	// Phase 1: fill up to cap-1 → snapshot should be insertion-ordered.
+	for i := 0; i < maxPickHistory-1; i++ {
+		p.recordPickDecision(PickDecision{Reason: "phase1", Winner: AfeID(i + 1)}, "test")
+	}
+	snap := p.snapshotPickHistory()
+	if len(snap) != maxPickHistory-1 {
+		t.Fatalf("pre-wrap snapshot len = %d, want %d", len(snap), maxPickHistory-1)
+	}
+	if snap[0].Decision.Winner != AfeID(1) || snap[len(snap)-1].Decision.Winner != AfeID(maxPickHistory-1) {
+		t.Errorf("pre-wrap ordering broken: first=%d last=%d",
+			snap[0].Decision.Winner, snap[len(snap)-1].Decision.Winner)
+	}
+
+	// Phase 2: overshoot cap by 100 → ring wraps.
+	for i := maxPickHistory - 1; i < maxPickHistory+100; i++ {
+		p.recordPickDecision(PickDecision{Reason: "phase2", Winner: AfeID(i + 1)}, "test")
+	}
+	snap = p.snapshotPickHistory()
+	if len(snap) != maxPickHistory {
+		t.Fatalf("post-wrap snapshot len = %d, want %d (ring must cap)", len(snap), maxPickHistory)
+	}
+	// After 100 overshoots, the oldest surviving Winner is 101; newest is
+	// maxPickHistory+100.
+	wantOldest := AfeID(101)
+	wantNewest := AfeID(maxPickHistory + 100)
+	if snap[0].Decision.Winner != wantOldest {
+		t.Errorf("post-wrap oldest = %d, want %d", snap[0].Decision.Winner, wantOldest)
+	}
+	if snap[len(snap)-1].Decision.Winner != wantNewest {
+		t.Errorf("post-wrap newest = %d, want %d", snap[len(snap)-1].Decision.Winner, wantNewest)
+	}
+	// Ordering must be monotonic (oldest-first).
+	for i := 1; i < len(snap); i++ {
+		if snap[i].Decision.Winner <= snap[i-1].Decision.Winner {
+			t.Fatalf("ordering broken at i=%d: snap[i-1].Winner=%d snap[i].Winner=%d",
+				i, snap[i-1].Decision.Winner, snap[i].Decision.Winner)
+		}
+	}
+}
+
+// --- core pool setters + hot-path helpers (session_pool.go) ----------------
+
+func TestNewSessionPoolImpl_Identity(t *testing.T) {
+	factory, closeStreams := newStubStreamFactory()
+	t.Cleanup(closeStreams)
+
+	p := NewSessionPoolImpl(
+		uint64(42),
+		"test-pool", 1, 10, factory, &spb.OpenSessionRequest{ProtocolVersion: 1}, nil, SessionTypeTable,
+	)
+	if p.poolID != 42 {
+		t.Errorf("poolID = %d, want 42", p.poolID)
+	}
+	p.Close()
+}
+
+// TestSignalFree_NoWaitersIsNoOp verifies the queue-based signalFree
+// exits fast when no CheckoutSession caller is parked (nothing to
+// wake). Regression guard against re-introducing a cap-1 channel or
+// any other "buffer a spare wake-up" scheme.
+func TestSignalFree_NoWaitersIsNoOp(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	done := make(chan struct{})
+	go func() {
+		p.signalFree()
+		p.signalFree()
+		p.signalFree()
+		close(done)
+	}()
+	select {
+	case <-done:
+		// expected — no blocking
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("signalFree blocked with empty waiter queue")
+	}
+	// No accumulated tokens: signalFree with no waiters is truly a no-op.
+	p.waitersMu.Lock()
+	remaining := p.waiters.Len()
+	p.waitersMu.Unlock()
+	if remaining != 0 {
+		t.Errorf("waiters queue = %d, want 0 (signalFree must not add anything)", remaining)
+	}
+}
+
+// TestSignalFree_WakesHeadWaiter parks two waiters directly on the
+// queue and verifies the first signalFree wakes exactly the first one
+// (FIFO), and a second signalFree wakes the second. Expected
+// pendingRpcs.removeFirst semantic.
+func TestSignalFree_WakesHeadWaiter(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+
+	w1 := &waiter{ready: make(chan struct{})}
+	w2 := &waiter{ready: make(chan struct{})}
+	p.waitersMu.Lock()
+	w1.elem = p.waiters.PushBack(w1)
+	w2.elem = p.waiters.PushBack(w2)
+	p.waitersMu.Unlock()
+
+	p.signalFree()
+	select {
+	case <-w1.ready:
+		// expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("head waiter not woken by first signalFree")
+	}
+	select {
+	case <-w2.ready:
+		t.Error("second waiter woken by first signalFree — FIFO broken")
+	default:
+	}
+
+	p.signalFree()
+	select {
+	case <-w2.ready:
+		// expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("second waiter not woken by second signalFree")
+	}
+}
+
+// TestRemoveWaiter_IdempotentWithSignalFree verifies the concurrency
+// contract: signalFree and removeWaiter never double-close w.ready.
+// signalFree removes+closes; if the caller subsequently ctx-cancels,
+// removeWaiter checks w.elem == nil and skips the close.
+func TestRemoveWaiter_IdempotentWithSignalFree(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+
+	w := &waiter{ready: make(chan struct{})}
+	p.waitersMu.Lock()
+	w.elem = p.waiters.PushBack(w)
+	p.waitersMu.Unlock()
+
+	// signalFree removes and closes.
+	p.signalFree()
+	select {
+	case <-w.ready:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("waiter not woken by signalFree")
+	}
+
+	// removeWaiter called AFTER signalFree must not panic (would
+	// double-close if it re-issued close on an already-closed channel).
+	p.removeWaiter(w)
+	// Sanity: w.elem stays nil.
+	p.waitersMu.Lock()
+	elem := w.elem
+	p.waitersMu.Unlock()
+	if elem != nil {
+		t.Errorf("w.elem = %p, want nil after signalFree", elem)
+	}
+}
+
+func TestStats_CountsReadyInUsePending(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	// Two ready sessions; one has outstanding=1 (in-use), other is idle.
+	sh1 := injectActiveSession(t, p, "s1", time.Now())
+	sh2 := injectActiveSession(t, p, "s2", time.Now())
+	sh1.IncOutstanding()
+	_ = sh2 // idle
+
+	// Fake three parked waiters via waitersCount (the real path is inside
+	// CheckoutSession's select; we bracket it directly here).
+	p.waitersCount.Add(3)
+
+	st := p.Stats()
+	if st.ReadyCount != 2 {
+		t.Errorf("ReadyCount = %d, want 2", st.ReadyCount)
+	}
+	if st.InUseCount != 1 {
+		t.Errorf("InUseCount = %d, want 1", st.InUseCount)
+	}
+	if st.PendingCount != 3 {
+		t.Errorf("PendingCount = %d, want 3 (must be waitersCount, not sum of outstanding)", st.PendingCount)
+	}
+	if st.StartingCount != 0 {
+		t.Errorf("StartingCount = %d, want 0", st.StartingCount)
+	}
+}
+
+// TestStats_StartingCountIncludesPendingStarts guards the sizer
+// double-count regression introduced by removing wg.Wait() in Tick
+// (commit 203aa07ecf). Tick reserves pendingStarts BEFORE spawning
+// fire-and-forget goroutines; createSession transfers each reservation
+// into startingSessions once streamFactory succeeds. During the
+// streamFactory window Stats().StartingCount MUST see the reservation
+// so a burst of Ticks doesn't re-request the same delta.
+func TestStats_StartingCountIncludesPendingStarts(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+
+	// Simulate Tick's pre-spawn reservation for delta=3.
+	p.mu.Lock()
+	p.pendingStarts = 3
+	p.mu.Unlock()
+
+	if got := p.Stats().StartingCount; got != 3 {
+		t.Errorf("StartingCount with pendingStarts=3, startingSessions=empty: got %d, want 3", got)
+	}
+
+	// Simulate one goroutine reaching the transfer point: reservation
+	// consumed, session added to startingSessions. Sum must be unchanged.
+	sh := newSessionHandle(nil, time.Now())
+	p.mu.Lock()
+	p.pendingStarts--
+	p.startingSessions[sh] = struct{}{}
+	p.mu.Unlock()
+
+	if got := p.Stats().StartingCount; got != 3 {
+		t.Errorf("StartingCount after transfer (pendingStarts=2, startingSessions=1): got %d, want 3", got)
+	}
+}
+
+func TestUpdateConfig_SwapsPickerAndBounds(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	// Default picker is LeastInFlight.
+	if got := p.picker.Name(); got != "least-inflight" {
+		t.Errorf("default picker = %q, want least-inflight", got)
+	}
+
+	// Switch to Random.
+	p.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
+		MinSessionCount: 4,
+		MaxSessionCount: 40,
+		LoadBalancingOptions: &spb.LoadBalancingOptions{
+			LoadBalancingStrategy: &spb.LoadBalancingOptions_Random_{
+				Random: &spb.LoadBalancingOptions_Random{},
+			},
+		},
+	})
+	if got := p.picker.Name(); got != "simple" {
+		t.Errorf("after Random swap, picker = %q, want simple", got)
+	}
+	if p.minSessions.Load() != 4 || p.maxSessions.Load() != 40 {
+		t.Errorf("min/max = %d/%d, want 4/40", p.minSessions.Load(), p.maxSessions.Load())
+	}
+
+	// Switch to PeakEwma with an explicit subset size.
+	p.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
+		MinSessionCount: 1,
+		MaxSessionCount: 10,
+		LoadBalancingOptions: &spb.LoadBalancingOptions{
+			LoadBalancingStrategy: &spb.LoadBalancingOptions_PeakEwma_{
+				PeakEwma: &spb.LoadBalancingOptions_PeakEwma{RandomSubsetSize: 3},
+			},
+		},
+	})
+	if got := p.picker.Name(); got != "least-latency" {
+		t.Errorf("after PeakEwma swap, picker = %q, want least-latency", got)
+	}
+	// listenerFires counter bumps once per UpdateConfig.
+	if got := p.m.listenerFires.Load(); got != 2 {
+		t.Errorf("listenerFires = %d, want 2 (one per UpdateConfig)", got)
+	}
+}
+
+// TestUpdateConfig_HonorsRandomSubsetSize is a regression guard against the
+// bug where UpdateConfig's LeastInFlight branch ignored its own
+// RandomSubsetSize (only PeakEwma read it). Server-driven K must reach the
+// picker for both K-choice strategies.
+func TestUpdateConfig_HonorsRandomSubsetSize(t *testing.T) {
+	cases := []struct {
+		name string
+		lbo  *spb.LoadBalancingOptions
+		want int
+	}{
+		{
+			name: "LeastInFlight with K=5",
+			lbo: &spb.LoadBalancingOptions{
+				LoadBalancingStrategy: &spb.LoadBalancingOptions_LeastInFlight_{
+					LeastInFlight: &spb.LoadBalancingOptions_LeastInFlight{RandomSubsetSize: 5},
+				},
+			},
+			want: 5,
+		},
+		{
+			name: "PeakEwma with K=7",
+			lbo: &spb.LoadBalancingOptions{
+				LoadBalancingStrategy: &spb.LoadBalancingOptions_PeakEwma_{
+					PeakEwma: &spb.LoadBalancingOptions_PeakEwma{RandomSubsetSize: 7},
+				},
+			},
+			want: 7,
+		},
+		{
+			name: "LeastInFlight with omitted K falls back to default",
+			lbo: &spb.LoadBalancingOptions{
+				LoadBalancingStrategy: &spb.LoadBalancingOptions_LeastInFlight_{
+					LeastInFlight: &spb.LoadBalancingOptions_LeastInFlight{}, // K=0 → fallback
+				},
+			},
+			want: defaultAfeRandomSubsetSize,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newTestPool(t, 1, 10)
+			p.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
+				MinSessionCount:      1,
+				MaxSessionCount:      10,
+				LoadBalancingOptions: tc.lbo,
+			})
+			var gotK int
+			switch pk := p.picker.(type) {
+			case *LeastInFlightAfePicker:
+				gotK = pk.RandomSubsetSize
+			case *LeastLatencyAfePicker:
+				gotK = pk.RandomSubsetSize
+			default:
+				t.Fatalf("unexpected picker type %T", p.picker)
+			}
+			if gotK != tc.want {
+				t.Errorf("picker RandomSubsetSize = %d, want %d", gotK, tc.want)
+			}
+		})
+	}
+}
+
+// TestPickerFromLoadBalancing_NilFallback verifies the constructor's
+// bootstrap path — a nil LoadBalancingOptions gives the default
+// (LeastInFlight with K=defaultAfeRandomSubsetSize).
+func TestPickerFromLoadBalancing_NilFallback(t *testing.T) {
+	picker := pickerFromLoadBalancing(nil)
+	li, ok := picker.(*LeastInFlightAfePicker)
+	if !ok {
+		t.Fatalf("nil LBO → %T, want *LeastInFlightAfePicker", picker)
+	}
+	if li.RandomSubsetSize != defaultAfeRandomSubsetSize {
+		t.Errorf("K = %d, want %d", li.RandomSubsetSize, defaultAfeRandomSubsetSize)
+	}
+}

--- a/bigtable/internal/transport/session_snapshot.go
+++ b/bigtable/internal/transport/session_snapshot.go
@@ -450,10 +450,13 @@ func (h *SessionHandle) Snapshot() SessionHandleSnapshot {
 // snapshots are taken after the pool lock is released so per-session locks
 // cannot back up under p.mu.
 func (p *SessionPoolImpl) PoolSnapshot() PoolSnapshot {
+	// min/max are now sizer-owned and served via atomic accessors,
+	// so read them outside p.mu — no p.mu bracket needed.
+	min := p.sizer.MinSessions()
+	max := p.sizer.MaxSessions()
+
 	p.mu.Lock()
 	name := p.poolName
-	min := int(p.minSessions.Load())
-	max := int(p.maxSessions.Load())
 	sessionType := p.sessionType
 	startingCount := len(p.startingSessions)
 	pickerType := "unknown"

--- a/bigtable/internal/transport/session_snapshot.go
+++ b/bigtable/internal/transport/session_snapshot.go
@@ -1,0 +1,594 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"reflect"
+	"sort"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+// openRequestMarshaler formats decoded OpenSessionRequest payloads for the
+// debug UI: multiline JSON, snake_case names, omit empties.
+var openRequestMarshaler = protojson.MarshalOptions{
+	Multiline:       true,
+	Indent:          "  ",
+	UseProtoNames:   true,
+	EmitUnpopulated: false,
+}
+
+// buildOpenRequestSnapshot decodes the OpenSessionRequest's Payload into
+// the message type indicated by sessionType and renders it (plus the
+// feature-flags wrapper) as protojson for the debug UI. Returns nil when
+// the pool has no template request (rare — only happens in tests that
+// inject a session directly).
+func buildOpenRequestSnapshot(req *spb.OpenSessionRequest, sessionType SessionType) *OpenRequestSnapshot {
+	if req == nil {
+		return nil
+	}
+	out := &OpenRequestSnapshot{ProtocolVersion: req.ProtocolVersion}
+
+	var inner proto.Message
+	switch sessionType {
+	case SessionTypeTable:
+		out.PayloadType = "OpenTableRequest"
+		inner = &spb.OpenTableRequest{}
+	case SessionTypeAuthorizedView:
+		out.PayloadType = "OpenAuthorizedViewRequest"
+		inner = &spb.OpenAuthorizedViewRequest{}
+	case SessionTypeMaterializedView:
+		out.PayloadType = "OpenMaterializedViewRequest"
+		inner = &spb.OpenMaterializedViewRequest{}
+	default:
+		out.PayloadType = "unknown"
+	}
+
+	if inner != nil && len(req.Payload) > 0 {
+		if err := proto.Unmarshal(req.Payload, inner); err == nil {
+			if b, mErr := openRequestMarshaler.Marshal(inner); mErr == nil {
+				out.PayloadJSON = string(b)
+			}
+		}
+	}
+	if req.Flags != nil {
+		if b, err := openRequestMarshaler.Marshal(req.Flags); err == nil {
+			out.FlagsJSON = string(b)
+		}
+	}
+	return out
+}
+
+// SessionSnapshot is an immutable, allocation-friendly snapshot of one
+// Session's debugging state. All fields are value types so the snapshot can
+// be marshaled (JSON / template) without re-acquiring any session lock.
+type SessionSnapshot struct {
+	LogName         string
+	State           string
+	SessionType     string
+	LastStateChange time.Time
+	OkRpcs          int64
+	ErrorRpcs       int64
+	Retries         int64
+	MsgsSent        int64
+	MsgsRecv        int64
+	// MsgsSentByType / MsgsRecvByType break the totals above down by the
+	// SessionRequest / SessionResponse oneof payload type. Keys come from the
+	// reqMsgType / respMsgType String() methods (e.g. "VirtualRpc", "Heartbeat").
+	// Buckets with a zero count are omitted to keep the rendered cell short.
+	MsgsSentByType map[string]int64
+	MsgsRecvByType map[string]int64
+	ActiveRpcs     int
+	CloseReason    string
+	// LatencyP50/95/99 are computed from the server-reported BackendLatency
+	// values cached on the session (last 256 samples). Zero when the session
+	// hasn't seen any responses with Stats populated yet.
+	LatencyP50 time.Duration
+	LatencyP95 time.Duration
+	LatencyP99 time.Duration
+	LatencyN   int // number of samples in the window
+	// ClusterCounts is the per-ClusterInformation.ClusterId response tally
+	// (e.g. {"cluster-c1": 412, "cluster-c2": 198}). Empty until the server
+	// has attached ClusterInformation to at least one response.
+	ClusterCounts map[string]int64
+	// ChannelIndex is the BigtableChannelPool connEntry index the session's
+	// bidi stream landed on, or -1 when unknown (non-Bigtable channel pool).
+	ChannelIndex      int
+	HeartbeatInterval time.Duration
+	NextHeartbeat     time.Time
+	HasRefreshConfig  bool
+	Peer              PeerInfoSnapshot
+	Handle            SessionHandleSnapshot
+	// RecentEvents is the per-session debug-event ring buffer (close,
+	// heartbeat-missed, heartbeat-alive while in-flight, ctx-done). Capped
+	// at maxSessionEvents and ordered oldest-first. Empty for healthy
+	// long-lived sessions.
+	RecentEvents []SessionEvent
+}
+
+// PeerInfoSnapshot is a JSON-friendly mirror of the relevant fields of
+// spb.PeerInfo. Empty fields indicate the server has not yet sent peer info
+// (which arrives asynchronously via the response header).
+type PeerInfoSnapshot struct {
+	TransportType              string
+	GoogleFrontendID           int64
+	ApplicationFrontendID      int64
+	ApplicationFrontendRegion  string
+	ApplicationFrontendSubzone string
+}
+
+// SessionHandleSnapshot captures the per-handle pool bookkeeping.
+// Per-session PeakEwma was moved to the per-AFE tracker on afeHandle
+// as part of the AFE-grouping refactor — surface those via the pool's
+// afez view instead.
+type SessionHandleSnapshot struct {
+	Outstanding  int64
+	LastActivity time.Time
+	Picks        int64
+}
+
+// PoolSnapshot is a snapshot of one SessionPoolImpl, including every session
+// currently in the pool. Sessions are listed in their pool order; callers may
+// re-sort as they wish.
+type PoolSnapshot struct {
+	Name          string
+	SessionType   string
+	MinSessions   int
+	MaxSessions   int
+	PickerType    string
+	ReadyCount    int
+	StartingCount int
+	InUseCount    int
+	PendingCount  int
+	TotalSessions int
+	Sessions      []SessionSnapshot
+	CapturedAt    time.Time
+	// Lifecycle aggregates surfaced via PoolSnapshot.
+	SessionsOpened int64
+	SessionsClosed int64
+	CloseReasons   map[string]int64
+	ListenerFires  int64
+	Throttler      ThrottlerSnapshot
+	ScalingHistory []ScalingEvent
+	// OpenRequest captures the OpenSessionRequest template used to handshake
+	// every session in this pool — protocol version, feature flags, and the
+	// decoded inner payload (OpenTable / OpenAuthorizedView /
+	// OpenMaterializedView). All sessions in a given pool share this exact
+	// request, so it's surfaced per-pool rather than per-session.
+	OpenRequest *OpenRequestSnapshot
+	// Pool-level aggregates derived from the per-session snapshots and
+	// non-session pool state.
+	ClusterCounts map[string]int64
+	// StateCounts is the per-state population summary across every session
+	// currently in the pool: e.g. {"Ready": 5, "Closing": 1,
+	// "WaitServerClose": 2}. Lets the debug UI render "how many are
+	// healthy right now" without rescanning each row. Keys come from
+	// State.String() so they line up with the per-session State column.
+	StateCounts map[string]int
+	// LatencyP50/95/99/N: server-reported BackendLatency aggregated
+	// across all sessions in the pool.
+	LatencyP50 time.Duration
+	LatencyP95 time.Duration
+	LatencyP99 time.Duration
+	LatencyN   int
+	// TotalLatencyP50/95/99/N: end-to-end wall-clock latency as
+	// observed by the caller of SessionPoolImpl.Invoke — includes
+	// pool-boundary checkout wait + network + decode + BackendLatency.
+	// The gap between Total and Backend percentiles is the client-side
+	// overhead (mostly CheckoutSession wait when the pool is hot).
+	TotalLatencyP50 time.Duration
+	TotalLatencyP95 time.Duration
+	TotalLatencyP99 time.Duration
+	TotalLatencyN   int
+	// TransportLatencyP50/95/99/N: ClientTransportLatency
+	// = (stream Send→Recv) − server-reported BackendLatency. Isolates
+	// wire + AFE + client-decode overhead outside server processing.
+	// Samples are excluded when either half is missing (pre-Recv
+	// failure, no server Stats) or the delta is non-positive (clock
+	// skew) so p50 isn't dragged toward 0.
+	TransportLatencyP50 time.Duration
+	TransportLatencyP95 time.Duration
+	TransportLatencyP99 time.Duration
+	TransportLatencyN   int
+	SlowVRpcs           []SlowVRpcEvent
+	// RecentEvents is the pool-wide merge of every session's RecentEvents,
+	// sorted newest-first and capped at maxPoolRecentEvents. Lets the
+	// sessionz UI render a single timeline of session-lifecycle anomalies
+	// (closes, missed heartbeats, ctx-done stalls) without scrolling
+	// through every session row.
+	RecentEvents []PoolSessionEvent
+	TimeSeries   []TimeSeriesSample
+	// Session-lifetime distribution (built from the pool's lifetime ring
+	// buffer of completed sessions). LifetimeHistogram is the bucket-label
+	// → count list in the order defined by LifetimeBuckets; percentile
+	// fields are computed over the same window.
+	LifetimeHistogram []LifetimeBucketCount
+	LifetimeP50       time.Duration
+	LifetimeP95       time.Duration
+	LifetimeP99       time.Duration
+	LifetimeN         int
+	// AFEs is the per-AFE view of the pool's sessionList — the picker's
+	// primary bucketing unit. One entry per AFE the pool has ever seen
+	// (empty buckets aged past afePruneMaxIdle are GC'd). Populated from
+	// sessionList.Snapshot so afez / sessionz can render the fanout
+	// without reaching into the internal type.
+	AFEs []AfeSnapshotRow
+}
+
+// LoadBalancingSnapshot is the pool's view of its picker state, decision
+// history, and per-AFE fanout — the input to the loadz debug page. Not
+// embedded in PoolSnapshot because it's a heavier surface (ring buffer,
+// cumulative counters) and only the loadz page consumes it; sessionz /
+// afez use the lighter AFEs slice on PoolSnapshot instead.
+type LoadBalancingSnapshot struct {
+	// PoolName / PickerName echo the pool identity + current picker so
+	// the loadz page can render self-contained rows per pool.
+	PoolName   string
+	PickerName string
+
+	// AFEs mirrors PoolSnapshot.AFEs so loadz can render the per-AFE
+	// table without cross-referencing another snapshot.
+	AFEs []AfeSnapshotRow
+
+	// PickCounts is the cumulative per-AFE pick tally over the pool's
+	// lifetime. Loadz computes actual-share as PickCounts[afe] /
+	// sum(PickCounts).
+	PickCounts map[int64]int64
+
+	// Recent is the ring buffer of the last N pick decisions,
+	// newest-last. Powers the "recent picks" table.
+	Recent []PickHistoryEvent
+
+	// CapturedAt is the snapshot wall-clock.
+	CapturedAt time.Time
+}
+
+// LifetimeBucketCount is one bar in the session-lifetime histogram.
+type LifetimeBucketCount struct {
+	Label string
+	Count int
+}
+
+// PoolSessionEvent is a SessionEvent tagged with the originating session's
+// LogName so the pool-level merged timeline in sessionz can attribute each
+// entry without nesting.
+type PoolSessionEvent struct {
+	At      time.Time
+	Kind    string
+	Session string
+	Message string
+}
+
+// maxPoolRecentEvents caps the merged pool-level event timeline so the
+// sessionz render stays bounded under high churn. Sized to comfortably
+// hold a multi-minute incident across a busy pool (≈8× the per-session
+// cap × a handful of misbehaving sessions).
+const maxPoolRecentEvents = 500
+
+// OpenRequestSnapshot is the JSON-friendly form of the OpenSessionRequest.
+// PayloadType names the inner-message kind ("OpenTable",
+// "OpenAuthorizedView", "OpenMaterializedView", or "unknown"); PayloadJSON
+// is the inner message rendered via protojson — that's the field that
+// answers "what was this session opened for?". FlagsJSON renders the
+// FeatureFlags proto so operators can see what the client asked for.
+type OpenRequestSnapshot struct {
+	ProtocolVersion int64
+	PayloadType     string
+	PayloadJSON     string
+	FlagsJSON       string
+}
+
+// Snapshot returns a debug-friendly snapshot of the session. Reads every
+// field lock-free via atomics; safe to call concurrently with Invoke and
+// with any lifecycle transition. The individual field reads are not
+// cross-consistent, but the sessionz UI treats each row as an approximate
+// point-in-time picture, which is exactly what atomics give us.
+func (s *Session) Snapshot() SessionSnapshot {
+	state := State(s.state.Load())
+	logName := s.logName
+	lastChange := time.Unix(0, s.lastStateChangeNano.Load())
+	hbInterval := time.Duration(s.heartbeatIntervalNano.Load())
+	nextHb := time.Unix(0, s.nextHeartbeatDeadlineNano.Load())
+	activeRpcs := 0
+	if rpc := s.activeVRPC(); rpc != nil {
+		activeRpcs = 1
+	}
+	peer := s.peerInfo.Load()
+	hasRefresh := s.refreshConfig.Load() != nil
+	sessionType := s.sessionType
+
+	sortedLat := s.snapshotLatencies()
+	return SessionSnapshot{
+		LogName:           logName,
+		State:             state.String(),
+		SessionType:       sessionType.String(),
+		LastStateChange:   lastChange,
+		OkRpcs:            s.okRpcs.Load(),
+		ErrorRpcs:         s.errorRpcs.Load(),
+		Retries:           s.retries.Load(),
+		MsgsSent:          s.msgsSent.Load(),
+		MsgsRecv:          s.msgsRecv.Load(),
+		MsgsSentByType:    sentByType(s),
+		MsgsRecvByType:    recvByType(s),
+		ActiveRpcs:        activeRpcs,
+		CloseReason:       s.CloseReason(),
+		ClusterCounts:     s.snapshotClusters(),
+		ChannelIndex:      int(s.ChannelIndex()),
+		LatencyP50:        percentile(sortedLat, 50),
+		LatencyP95:        percentile(sortedLat, 95),
+		LatencyP99:        percentile(sortedLat, 99),
+		LatencyN:          len(sortedLat),
+		HeartbeatInterval: hbInterval,
+		NextHeartbeat:     nextHb,
+		HasRefreshConfig:  hasRefresh,
+		Peer:              peerInfoToSnapshot(peer),
+		RecentEvents:      s.snapshotEvents(),
+	}
+}
+
+func sentByType(s *Session) map[string]int64 {
+	var out map[string]int64
+	for i := reqMsgType(0); i < numReqMsgTypes; i++ {
+		if v := s.msgsSentByType[i].Load(); v > 0 {
+			if out == nil {
+				out = make(map[string]int64, 2)
+			}
+			out[i.String()] = v
+		}
+	}
+	return out
+}
+
+func recvByType(s *Session) map[string]int64 {
+	var out map[string]int64
+	for i := respMsgType(0); i < numRespMsgTypes; i++ {
+		if v := s.msgsRecvByType[i].Load(); v > 0 {
+			if out == nil {
+				out = make(map[string]int64, 2)
+			}
+			out[i.String()] = v
+		}
+	}
+	return out
+}
+
+func peerInfoToSnapshot(p *spb.PeerInfo) PeerInfoSnapshot {
+	if p == nil {
+		return PeerInfoSnapshot{}
+	}
+	return PeerInfoSnapshot{
+		TransportType:              TransportTypeName(p.GetTransportType()),
+		GoogleFrontendID:           p.GetGoogleFrontendId(),
+		ApplicationFrontendID:      p.GetApplicationFrontendId(),
+		ApplicationFrontendRegion:  p.GetApplicationFrontendRegion(),
+		ApplicationFrontendSubzone: p.GetApplicationFrontendSubzone(),
+	}
+}
+
+// TransportTypeName maps the PeerInfo transport type enum to the short
+// label used in metric attributes and debug UIs (e.g. "cloudpath",
+// "session_directpath"). Prefer this over .String(), which yields the
+// verbose "TRANSPORT_TYPE_…" proto enum names. Exported so the outer
+// bigtable package can share the same mapping (attempt_latencies2's
+// transport_type attribute) without duplicating the switch.
+func TransportTypeName(tt spb.PeerInfo_TransportType) string {
+	switch tt {
+	case spb.PeerInfo_TRANSPORT_TYPE_EXTERNAL:
+		return "external"
+	case spb.PeerInfo_TRANSPORT_TYPE_CLOUD_PATH:
+		return "cloudpath"
+	case spb.PeerInfo_TRANSPORT_TYPE_DIRECT_ACCESS:
+		return "directpath"
+	case spb.PeerInfo_TRANSPORT_TYPE_SESSION_EXTERNAL:
+		return "session_external"
+	case spb.PeerInfo_TRANSPORT_TYPE_SESSION_CLOUD_PATH:
+		return "session_cloudpath"
+	case spb.PeerInfo_TRANSPORT_TYPE_SESSION_DIRECT_ACCESS:
+		return "session_directpath"
+	case spb.PeerInfo_TRANSPORT_TYPE_SESSION_UNKNOWN:
+		return "session_unknown"
+	default:
+		return "unknown"
+	}
+}
+
+// LoadBalancingSnapshot returns the pool's picker state + decision
+// history + per-AFE fanout — the input to the loadz debug page. Takes
+// p.mu briefly to read picker name + pool name, then hands off to the
+// ring-buffer / sessionList accessors (each has its own lock).
+func (p *SessionPoolImpl) LoadBalancingSnapshot() LoadBalancingSnapshot {
+	p.mu.Lock()
+	name := p.poolName
+	pickerName := "unknown"
+	if p.picker != nil {
+		pickerName = p.picker.Name()
+	}
+	p.mu.Unlock()
+
+	counts := p.snapshotAfePickCounts()
+	countsInt64 := make(map[int64]int64, len(counts))
+	for k, v := range counts {
+		countsInt64[int64(k)] = v
+	}
+	return LoadBalancingSnapshot{
+		PoolName:   name,
+		PickerName: pickerName,
+		AFEs:       p.sl.Snapshot(),
+		PickCounts: countsInt64,
+		Recent:     p.snapshotPickHistory(),
+		CapturedAt: time.Now(),
+	}
+}
+
+// Snapshot returns a snapshot of the per-handle pool bookkeeping using the
+// existing atomics — no lock taken.
+func (h *SessionHandle) Snapshot() SessionHandleSnapshot {
+	return SessionHandleSnapshot{
+		Outstanding:  h.outstanding.Load(),
+		LastActivity: h.GetLastActivity(),
+		Picks:        h.picks.Load(),
+	}
+}
+
+// PoolSnapshot returns a snapshot of the pool plus every session currently in
+// it. Holds p.mu only long enough to copy out the slice header; per-session
+// snapshots are taken after the pool lock is released so per-session locks
+// cannot back up under p.mu.
+func (p *SessionPoolImpl) PoolSnapshot() PoolSnapshot {
+	p.mu.Lock()
+	name := p.poolName
+	min := int(p.minSessions.Load())
+	max := int(p.maxSessions.Load())
+	sessionType := p.sessionType
+	startingCount := len(p.startingSessions)
+	pickerType := "unknown"
+	if p.picker != nil {
+		pickerType = reflect.TypeOf(p.picker).Elem().Name()
+	}
+	p.mu.Unlock()
+	handles := p.sl.AllHandles()
+
+	var throttler ThrottlerSnapshot
+	if p.budget != nil {
+		throttler = p.budget.Snapshot()
+	}
+	snap := PoolSnapshot{
+		Name:           name,
+		SessionType:    sessionType.String(),
+		MinSessions:    min,
+		MaxSessions:    max,
+		PickerType:     pickerType,
+		StartingCount:  startingCount,
+		TotalSessions:  len(handles),
+		Sessions:       make([]SessionSnapshot, 0, len(handles)),
+		CapturedAt:     time.Now(),
+		SessionsOpened: p.m.sessionsOpened.Load(),
+		SessionsClosed: p.m.sessionsClosed.Load(),
+		CloseReasons:   p.snapshotCloseReasons(),
+		ListenerFires:  p.m.listenerFires.Load(),
+		Throttler:      throttler,
+		ScalingHistory: p.snapshotScalingHistory(),
+		OpenRequest:    buildOpenRequestSnapshot(p.openSessionRequest, sessionType),
+		SlowVRpcs:      p.snapshotSlowVRpcs(),
+		TimeSeries:     p.snapshotTimeSeries(),
+		AFEs:           p.sl.Snapshot(),
+		// True pool-boundary queue depth — same source as Stats().PendingCount.
+		// Previous implementation summed per-session Outstanding, which under
+		// multiPlexingLimit=1 equals InUseCount and made the debug UI show a
+		// wrong "pending" number that never reflected real waiter backlog.
+		PendingCount: int(p.waitersCount.Load()),
+	}
+
+	// Pool-level aggregates: combine cluster counts + latency samples
+	// across every session. Pool-level latency percentiles come from the
+	// pool's lifetime histograms (see latencyHist) so they reflect every
+	// sample the pool has ever seen, not just the last 256 per active
+	// session. Per-session ring buffers are still surfaced on each row of
+	// the Sessions table.
+	aggregatedClusters := map[string]int64{}
+	stateCounts := map[string]int{}
+
+	for _, sh := range handles {
+		if sh == nil || sh.session == nil {
+			continue
+		}
+		s := sh.session.Snapshot()
+		s.Handle = sh.Snapshot()
+		snap.Sessions = append(snap.Sessions, s)
+
+		stateCounts[s.State]++
+		if s.State == StateReady.String() {
+			snap.ReadyCount++
+		}
+		if s.Handle.Outstanding > 0 {
+			snap.InUseCount++
+		}
+		for k, v := range s.ClusterCounts {
+			aggregatedClusters[k] += v
+		}
+		// Merge per-session debug events into the pool-wide timeline,
+		// tagging each with the originating session log name so the UI
+		// can attribute them without nesting per-session rows.
+		for _, ev := range s.RecentEvents {
+			snap.RecentEvents = append(snap.RecentEvents, PoolSessionEvent{
+				At:      ev.At,
+				Kind:    string(ev.Kind),
+				Session: s.LogName,
+				Message: ev.Message,
+			})
+		}
+	}
+	// Newest-first, then cap to maxPoolRecentEvents. Stable sort so events
+	// recorded in the same instant keep their per-session ordering.
+	sort.SliceStable(snap.RecentEvents, func(i, j int) bool {
+		return snap.RecentEvents[i].At.After(snap.RecentEvents[j].At)
+	})
+	if len(snap.RecentEvents) > maxPoolRecentEvents {
+		snap.RecentEvents = snap.RecentEvents[:maxPoolRecentEvents]
+	}
+	if len(stateCounts) > 0 {
+		snap.StateCounts = stateCounts
+	}
+	if len(aggregatedClusters) > 0 {
+		snap.ClusterCounts = aggregatedClusters
+	}
+	if p50, p95, p99, n := p.m.backendLatencyHist.snapshot(); n > 0 {
+		snap.LatencyP50 = p50
+		snap.LatencyP95 = p95
+		snap.LatencyP99 = p99
+		snap.LatencyN = int(n)
+	}
+	if p50, p95, p99, n := p.m.totalLatencyHist.snapshot(); n > 0 {
+		snap.TotalLatencyP50 = p50
+		snap.TotalLatencyP95 = p95
+		snap.TotalLatencyP99 = p99
+		snap.TotalLatencyN = int(n)
+	}
+	if p50, p95, p99, n := p.m.transportLatencyHist.snapshot(); n > 0 {
+		snap.TransportLatencyP50 = p50
+		snap.TransportLatencyP95 = p95
+		snap.TransportLatencyP99 = p99
+		snap.TransportLatencyN = int(n)
+	}
+
+	// Lifetime distribution: render whichever buckets actually have data
+	// — but always emit them in canonical bucket order so the UI's bar
+	// labels line up across pools.
+	lifetimes := p.snapshotLifetimes()
+	if len(lifetimes) > 0 {
+		snap.LifetimeN = len(lifetimes)
+		buckets := make([]LifetimeBucketCount, len(LifetimeBuckets))
+		for i, b := range LifetimeBuckets {
+			buckets[i].Label = b.Label
+		}
+		for _, d := range lifetimes {
+			for i, b := range LifetimeBuckets {
+				if d < b.Max {
+					buckets[i].Count++
+					break
+				}
+			}
+		}
+		snap.LifetimeHistogram = buckets
+		sort.Slice(lifetimes, func(i, j int) bool { return lifetimes[i] < lifetimes[j] })
+		snap.LifetimeP50 = percentile(lifetimes, 50)
+		snap.LifetimeP95 = percentile(lifetimes, 95)
+		snap.LifetimeP99 = percentile(lifetimes, 99)
+	}
+	return snap
+}

--- a/bigtable/internal/transport/session_snapshot_test.go
+++ b/bigtable/internal/transport/session_snapshot_test.go
@@ -1,0 +1,180 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"testing"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
+)
+
+func TestSession_CountsOkAndErrorRpcs(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+
+	for _, id := range []int64{1, 2, 3} {
+		rpc := &vrpcImpl{id: id, method: "ReadRow", resultChan: make(chan vrpcResult, 1)}
+		s.setSlotForTest(rpc)
+		s.handleVRPCResponse(&spb.VirtualRpcResponse{RpcId: id, Payload: []byte("p")})
+		s.setSlotForTest(nil)
+	}
+	for _, id := range []int64{10, 11} {
+		rpc := &vrpcImpl{id: id, method: "ReadRow", resultChan: make(chan vrpcResult, 1)}
+		s.setSlotForTest(rpc)
+		s.handleVRPCErrorResponse(&spb.ErrorResponse{
+			RpcId:  id,
+			Status: &rpcstatus.Status{Code: int32(codes.Unavailable), Message: "boom"},
+		})
+		s.setSlotForTest(nil)
+	}
+
+	if got := s.OkRpcs(); got != 3 {
+		t.Errorf("OkRpcs = %d, want 3", got)
+	}
+	if got := s.ErrorRpcs(); got != 2 {
+		t.Errorf("ErrorRpcs = %d, want 2", got)
+	}
+	if !s.HasOkRpcs() || !s.HasErrorRpcs() {
+		t.Error("HasOkRpcs/HasErrorRpcs should be true once counters are non-zero")
+	}
+
+	// Unknown rpc_id is dropped silently and must not bump either counter.
+	s.handleVRPCResponse(&spb.VirtualRpcResponse{RpcId: 999})
+	s.handleVRPCErrorResponse(&spb.ErrorResponse{
+		RpcId:  999,
+		Status: &rpcstatus.Status{Code: int32(codes.Unavailable), Message: "ghost"},
+	})
+	if got := s.OkRpcs(); got != 3 {
+		t.Errorf("OkRpcs after dropped frame = %d, want 3", got)
+	}
+	if got := s.ErrorRpcs(); got != 2 {
+		t.Errorf("ErrorRpcs after dropped frame = %d, want 2", got)
+	}
+}
+
+func TestSession_Snapshot_BasicFields(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+	s.peerInfo.Store(&spb.PeerInfo{
+		GoogleFrontendId:           42,
+		ApplicationFrontendId:      99,
+		ApplicationFrontendRegion:  "us-central1",
+		ApplicationFrontendSubzone: "us-central1-b1",
+		TransportType:              spb.PeerInfo_TRANSPORT_TYPE_SESSION_DIRECT_ACCESS,
+	})
+	s.okRpcs.Store(5)
+	s.errorRpcs.Store(1)
+
+	snap := s.Snapshot()
+	if snap.State != "Ready" {
+		t.Errorf("State = %q, want Active", snap.State)
+	}
+	if snap.LogName != "test-session" {
+		t.Errorf("LogName = %q, want test-session", snap.LogName)
+	}
+	if snap.OkRpcs != 5 || snap.ErrorRpcs != 1 {
+		t.Errorf("Ok/Err = %d/%d, want 5/1", snap.OkRpcs, snap.ErrorRpcs)
+	}
+	if snap.Peer.GoogleFrontendID != 42 {
+		t.Errorf("Peer.GoogleFrontendID = %d, want 42", snap.Peer.GoogleFrontendID)
+	}
+	if snap.Peer.ApplicationFrontendRegion != "us-central1" {
+		t.Errorf("Peer.ApplicationFrontendRegion = %q, want us-central1", snap.Peer.ApplicationFrontendRegion)
+	}
+	if snap.Peer.TransportType != "session_directpath" {
+		t.Errorf("Peer.TransportType = %q, want session_directpath", snap.Peer.TransportType)
+	}
+	if snap.SessionType != "table" {
+		t.Errorf("SessionType = %q, want table", snap.SessionType)
+	}
+}
+
+func TestSession_Snapshot_NilPeer(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+	snap := s.Snapshot()
+	// Nil peer is reported as the zero PeerInfoSnapshot so the UI can render
+	// a dash; we deliberately do NOT synthesize "unknown" here.
+	if snap.Peer.TransportType != "" {
+		t.Errorf("nil peer TransportType = %q, want empty string", snap.Peer.TransportType)
+	}
+	if snap.Peer.GoogleFrontendID != 0 {
+		t.Errorf("nil peer GFE = %d, want 0", snap.Peer.GoogleFrontendID)
+	}
+}
+
+func TestSessionHandle_Snapshot(t *testing.T) {
+	s, _ := makeActive(t, SessionHooks{})
+	h := newSessionHandle(s, time.Time{})
+	h.IncOutstanding()
+	h.IncOutstanding()
+
+	snap := h.Snapshot()
+	if snap.Outstanding != 2 {
+		t.Errorf("Outstanding = %d, want 2", snap.Outstanding)
+	}
+}
+
+func TestPoolSnapshot_AggregatesSessions(t *testing.T) {
+	pool := NewSessionPoolImpl(
+		uint64(1),
+		"test:read", 1, 5, nil, nil, nil, SessionTypeTable,
+	)
+
+	// Two active sessions, one with traffic.
+	handles := make([]*SessionHandle, 0, 2)
+	for i := 0; i < 2; i++ {
+		stream := newFakeStream()
+		s := NewSession("s", stream, SessionHooks{}, SessionTypeTable)
+		s.state.Store(int32(StateReady))
+		sh := newSessionHandle(s, time.Time{})
+		pool.sl.OnSessionStarted(sh)
+		handles = append(handles, sh)
+	}
+	handles[0].IncOutstanding()
+	handles[0].session.okRpcs.Store(10)
+	handles[1].session.errorRpcs.Store(3)
+
+	snap := pool.PoolSnapshot()
+	if snap.Name != "test:read" {
+		t.Errorf("Name = %q, want test:read", snap.Name)
+	}
+	if snap.TotalSessions != 2 || snap.ReadyCount != 2 {
+		t.Errorf("Total/Ready = %d/%d, want 2/2", snap.TotalSessions, snap.ReadyCount)
+	}
+	// InUse counts sessions with outstanding > 0. Pending is the true
+	// pool-boundary queue depth (p.waitersCount), NOT sum-of-outstanding
+	// as it used to be — this test has no CheckoutSession waiters, so
+	// PendingCount must be 0 even though one session is in use.
+	if snap.InUseCount != 1 || snap.PendingCount != 0 {
+		t.Errorf("InUse/Pending = %d/%d, want 1/0", snap.InUseCount, snap.PendingCount)
+	}
+	if snap.PickerType == "" {
+		t.Errorf("PickerType empty; expected a reflected type name")
+	}
+	if len(snap.Sessions) != 2 {
+		t.Fatalf("Sessions len = %d, want 2", len(snap.Sessions))
+	}
+	// AllHandles snapshots via map iteration — order is not stable.
+	// Assert on totals across the whole set instead of per-index.
+	var okTotal, errTotal int64
+	for _, s := range snap.Sessions {
+		okTotal += s.OkRpcs
+		errTotal += s.ErrorRpcs
+	}
+	if okTotal != 10 || errTotal != 3 {
+		t.Errorf("counts not propagated: okTotal=%d, errTotal=%d, want 10/3; snap=%+v", okTotal, errTotal, snap.Sessions)
+	}
+}


### PR DESCRIPTION
## Summary

Second of five PRs porting the session pool infrastructure from `feat/bigtable-sessionz-debug` (which powers the recycle-repro fleet).

Adds `SessionPoolImpl`: the concrete two-tier read/write session pool for one resource. ~4000 LOC across five files plus matching tests.

## Stack

- [ ] PR-1: sessionList (#20224) — per-AFE bucketing data structure. **Not yet merged.**
- [x] **PR-2 (this)** — SessionPoolImpl (pool + scaling + debug + snapshot).
- [ ] PR-3 — `SessionPool` / `Invoker` interfaces + `sessionClient` / `sessionTable` factory wiring.
- [ ] PR-4 — Debug pages (`sessionz` / `afez` / `flightz` / `loadz` under `bigtable/debugview/`).
- [ ] PR-5 — `bigtable.Client` integration + release notes.

**Because PR-1 has not landed, this PR is opened against `main` and the diff includes PR-1's commits.** Once #20224 merges the base can be re-targeted (or this branch rebased) so only PR-2's own delta shows.

## What lands

**SessionPoolImpl** (5 files, ~2400 LOC prod + ~2200 LOC tests):

- `session_pool.go` — struct + constructor + `Invoke` + `CheckoutSession` (waiter queue, deadline propagation) + pluggable picker via the AFE picker from #20204.
- `session_pool_lifecycle.go` — `SessionHooks` wiring, consecutive-failure breaker, `Close` (5-phase teardown), `WaitGoroutines` / `spawns.Wait` choreography so no session-owned goroutine outlives the pool.
- `session_pool_scaling.go` — `Tick` loop, `createSession` (dial + `OpenSession` + hook registration), `pendingStarts` / `startingSessions` accounting so scale-up decisions never double-count in-flight opens. Uses the channel-pool pick hint (`ChannelPickHintInto`, added to `connpool.go`) to attribute each session to its underlying channel.
- `session_pool_debug.go` — `PoolSnapshot` / slow-vRPC ring / per-close-reason counters / scaling-history buffer / `pickHistory` ring — the input to the sessionz / afez / loadz debug pages (landing in a later PR).
- `session_snapshot.go` — the value-typed snapshot record the debug surface consumes; no live locks escape.

**Session helpers added** (pool-facing additions to files already touched by prior PRs, kept minimal):

- `Session.loops sync.WaitGroup` + `WaitGoroutines()` — pool teardown blocks on this so `readLoop` / `heartbeatLoop` and their `notifyClosed → recordClose` callback chains fully unwind before `Close` returns. Prevents session goroutines from racing metric-var writes across test boundaries.
- `Session.closeErr atomic.Pointer[error]` + `setCloseErr` / `closeError` — preserves the raw `Recv` error handed to `handleClose`. Pool surfaces this on consecutive-failure breaker trips so operators see the underlying server rejection (e.g. `FailedPrecondition` when the resource is still being created) instead of only the sentinel.

**Supporting additions to existing files:**

- `afe_picker.go` — const `defaultAfeRandomSubsetSize = 2` (power-of-two-choices K-choice default; matches Java).
- `debug_tracer.go` — three new tag constants: `tagSessionPoolCreatePanic`, `tagSessionPoolConsecutiveFailuresTripped`, `tagSessionPoolCheckoutFailedCINil`.
- `connpool.go` — `ChannelPickHintInto(ctx, *atomic.Int32)` context helper. No-op when the channel pool doesn't consume the hint.

## What does NOT land yet

- `SessionPool` / `Invoker` interfaces (follow-up PR alongside sessionClient / sessionTable).
- `bigtable.Client` integration (PR-3+).
- Debug pages under `bigtable/debugview/` (later PR).

## Test plan

- [x] `go build ./...` passes.
- [x] `go vet ./internal/transport/` clean.
- [x] `go test ./internal/transport/ -race -count=1 -short -skip 'AfeLbSim' -timeout=180s` — passes (32s wall). ~2200 LOC of new tests across pool lifecycle, scaling, consecutive-failure breaker, AFE integration, debug surface, snapshot rendering, plus a K-choice bench.

---

# Reviewer guide

## Guide 1 — mutianf (human)

### What this PR does
Adds `SessionPoolImpl`, the layer that sits above the per-AFE `sessionList` shipped in #20224 and consumes it via a two-tier picker (AFE first, then a ready session in that AFE). It owns the session lifecycle (open / active / closing / close hooks), server-driven scaling via `PoolSizer`, a consecutive-failure circuit breaker, and the debug/observability surface (histograms + ring buffers) that feeds sessionz/loadz. New files: 5 source, 6 test, ~4.9k LOC. Nothing outside `session_pool*.go` / `session_snapshot*.go` is new logic — the small edits elsewhere are hook-plumbing scaffolding already vetted by the session/AFE subagent reviewers.

### Recommended read order
1. **`session_pool.go`** — start here. Struct field layout with per-field ownership comments (`:104-179`), the `waiter` FIFO shape (`:94-101`), `CheckoutSession` two-tier pick + parking (`:235-310`), `Invoke` (`:465-559`), `Stats` (`:361-397`), `UpdateConfig` (`:402-431`), `pickerFromLoadBalancing` (`:439-461`). Skim `session_pool_test.go` (28 tests) — the FIFO waiter, Stats, and UpdateConfig behaviors are all covered there.
2. **`session_pool_lifecycle.go`** — hooks (`onActive:255`, `onClosing:308`, `onClose:336`), `recordSessionClose` once-CAS on `Session.poolCloseRecorded` (`:117-130`), `Close`'s 6-phase teardown (`:154-247`), `noteAbnormalCloseIfAny` breaker (`:363-392`), the three ticker loops (`:426-538`). Skim `session_pool_lifecycle_test.go` — every hook + `Close`.
3. **`session_pool_scaling.go`** — `Tick` (`:81-162`), `createSession` worker (`:164-274`), `scalingReason` (`:278-299`), `noDeadlineButCancellableContext` (`:301-311`). Skim `session_pool_scaling_test.go` — the `scalingInProgress` gate and panic-safety are the only non-obvious contracts.
4. **`session_pool_debug.go`** — `poolMetrics` (`:36-72`), `latencyHist` log2 histogram (`:160-228`), the four ring buffers (slow-vRPC, time-series, lifetimes, pick-history), `recordPickDecision` (`:366-387`). Skim `session_pool_debug_test.go` — mostly ring-cap and rate-computation coverage.
5. **`session_snapshot.go`** — mostly type defs. Focus on `PoolSnapshot` (`:452-594`) and `LoadBalancingSnapshot` (`:414-436`) as the debug-view contract.
6. **`session_pool_consecutive_failures_test.go`** and **`session_pool_afe_test.go`** — end-to-end behavior verification; useful for confirming intent.

### Flow of events
- **CheckoutSession → Invoke → release.** `CheckoutSession` (`session_pool.go:235`) opportunistically kicks Tick if `sl.ReadyCount()==0`, snapshots the picker under `p.mu`, then two-tier picks outside the lock: `ReadyAfes()` → `PickAfe` → `Checkout(afeID)` (`:259-268`). Miss → park in the FIFO waiter queue (`:286-289`), bracket `waitersCount` for the sizer (`:291,300`). `Invoke` (`:465`) checks out, runs `sh.session.Invoke`, records latencies (`:508-523`), logs a slow-vRPC row if over threshold (`:524-557`); the deferred `sh.DecOutstanding()` + `noteVRpcOutcome` (`:493-496`) hands the OK-gated latency to the per-AFE PeakEwma tracker. Session release itself is driven by `OnSlotDrained` (installed at `session_pool_scaling.go:228-231`), which returns the handle to `sessionList` and calls `signalFree` — separate from the `defer` in `Invoke`.
- **Background Tick.** `startTickLoop` (`session_pool_lifecycle.go:426`) fires every 1 s → `tickOnce` debounces via `tickPending` CAS (`:447-458`) → `Tick` (`session_pool_scaling.go:81`) samples uptimes, gates on `scalingInProgress`, calls `sizer.Decide()`, and on a positive delta reserves `pendingStarts += delta` + `spawns.Add(delta)` under `p.mu` (`:131-138`) then fans out one goroutine per session. Each `createSession` acquires the budget outside `p.mu`, dials via `streamFactory`, transfers `pendingStarts → startingSessions` in one lock (`:246-249`), starts the session, and blocks on `WaitGoroutines` so it stays on `p.spawns` until the session dies.
- **Abnormal close → breaker trip.** `onClose` (`session_pool_lifecycle.go:336`) CAS's `closeRecorded`, calls `noteAbnormalCloseIfAny` (`:363`), which bumps `consecutiveFailures` and stores the raw error into `lastAbnormalCloseErr`. Crossing the threshold snapshots the poison, CAS-resets the counter, and calls `drainWaitersWithErr` — waiters get `*consecutiveFailureError` wrapping the last cause (so `errors.Is(err, ErrConsecutiveFailures)` and `status.Code(err)` both still work, `:60-82`). Counter only resets in `onActive` (`:292-293`) — a successful open, not a healthy vRPC.

### Key invariants
1. **Two-tier pick, no re-entrant `p.mu`.** `CheckoutSession` reads `p.picker` under `p.mu` (`session_pool.go:249-255`) then unlocks before calling picker/sessionList. `recordPickDecision` takes `pickerName` as a **parameter** (`session_pool_debug.go:366`, `session_pool.go:260-262`) precisely because the caller already holds no lock — but any new pool method that reads `p.picker.Name()` from a hot path must not re-take `p.mu`.
2. **Waiter FIFO with `waitersCount` bracketed.** Every `PushBack` bumps `waitersCount` (`session_pool.go:291`); every wake path (`ctx.Done`, `w.ready`) decrements it (`:294,300`). `removeWaiter` (`:316`) is idempotent via `w.elem != nil`; `signalFree` and `drainWaitersWithErr` nil out `elem` under `waitersMu` (`:329-358`). `Stats().PendingCount` reads `waitersCount.Load()` — this is the sizer's queue-depth input.
3. **Close-exactly-once accounting.** `sessionsClosed` and `closesByReason` bumps are gated by `Session.poolCloseRecorded.CompareAndSwap(false, true)` inside `recordSessionClose` (`session_pool_lifecycle.go:117-130`). `sh.closingRecorded` and `sh.closeRecorded` are per-handle CAS's protecting the lifetime histogram + the `OnClose` branch. `Close`'s Phase 1 pre-flips both CAS's on every handle (`:187-193`) so a concurrent mid-flight onClosing can't double-count.
4. **Breaker resets only on `onActive`.** `consecutiveFailures.Store(0)` and `lastAbnormalCloseErr.Store(nil)` live at `session_pool_lifecycle.go:292-293`. Not on per-vRPC OK — otherwise one long-lived healthy session would mask a run of failed opens.
5. **Hot path is atomics/RLocks; debug views take snapshots.** `Stats` is the only per-request path that briefly takes `p.mu` (`session_pool.go:362`); everything else on the vRPC path is atomic. Debug snapshotters copy under lock and format after release (`session_snapshot.go:452-594`).

### What NOT to worry about
- **Session / vRPC layer itself** — shipped in #20213 / #20215 (state machine, one-in-flight, PeerInfo timing, retry oracle, heartbeat).
- **Per-AFE `sessionList` I1-I6** — shipped in #20224, has its own tests.
- **`PoolSizer` scaling formula** — already upstream (`pool_sizer.go`); this PR only wires it and consumes `ScaleDecision`.
- **AFE pickers (`SimpleAfePicker` / `LeastInFlight` / `LeastLatency`)** — already upstream (`afe_picker.go`); this PR only builds them via `pickerFromLoadBalancing`.
- **`SessionThrottler` / `AdaptiveSessionThrottler`** — already upstream; this PR consumes `Acquire` / `Release` / `UpdateConfig`.
- **`ClientConfigurationManager` polling** — this pool receives `UpdateConfig` calls; the polling itself is elsewhere.

### Danger zones
- **Re-entrant `p.mu` on picker access.** `recordPickDecision` intentionally takes `pickerName` as a param (`session_pool_debug.go:366`). Adding a new pool method that reads `p.picker.Name()` from within a `CheckoutSession` code path is a re-entrant deadlock; pass the name in or snapshot up-front.
- **`startingSessions` / `pendingStarts` accounting.** Tick reserves `pendingStarts` under `p.mu` (`session_pool_scaling.go:131-138`), `createSession`'s `reserved` defer releases it on any early return (`:172-179`), and the transfer at `:246-249` is atomic under `p.mu`. `onActive` deletes from `startingSessions` (`session_pool_lifecycle.go:265`). Any new failure branch in `createSession` must preserve the invariant `pendingStarts + len(startingSessions) + Ready = "in-flight scale-up capacity"`.
- **`budget.Acquire` blocks; must run OUTSIDE `p.mu`.** Currently at `session_pool_scaling.go:181`, deliberately after the `defer reserved` block and before any `p.mu.Lock()`. Moving it under the lock deadlocks scale-up under budget exhaustion.
- **Slow-vRPC is fire-and-forget.** `recordSlowVRpc` (`session_pool_debug.go:301`) appends into a mutex-guarded ring; it's on the vRPC return path but bounded by threshold gating and one small mutex. Do not add I/O, logging fanout, or channel sends here.
- **`newTestPool` / bootstrap defaults.** Test helpers construct the pool without a `ClientConfigurationManager`, so the bootstrap defaults from `defaultPoolConfig()` (`session_pool.go:218-226`) are the only config those tests see. Real callers always get `UpdateConfig` synchronously on registration — verify by reading `NewSessionPoolImpl` end-to-end, not by trusting the bootstrap values.
- **`Close` phase ordering.** Phase 4 (`poolCancel`) runs AFTER Phase 3 (`wg.Wait` on graceful closes) because Phase 2's `closeCtx` derives from `p.poolCtx`; swapping order strands in-flight graceful closes on a cancelled ctx. Phase 5 (`p.spawns.Wait`) blocks on every createSession goroutine's `WaitGoroutines` — that's why createSession blocks on `s.WaitGoroutines()` at `session_pool_scaling.go:272`.

---

## Guide 2 — mutianf-bot (automated reviewer)

### REAL HAZARDS to flag

- **Re-entrant `p.mu` in pool methods called from `CheckoutSession`.** Anchor: `session_pool.go:235-310`. `p.mu` is dropped at `:255` before `PickAfe` / `Checkout` / `recordPickDecision` fire. Flag any newly-added helper called from that block that re-acquires `p.mu`, or any new method that reads `p.picker.Name()` without taking the name as a parameter (see the intentional parameter pattern at `session_pool_debug.go:366`).
- **`budget.Acquire` under `p.mu`.** Currently correctly outside the lock at `session_pool_scaling.go:181`. `SessionThrottler.Acquire` blocks on the budget semaphore; calling it while holding `p.mu` would deadlock scale-up. Flag any code path that acquires `p.mu` before line `:181` or moves `Acquire` inside a `Lock`/`Unlock` bracket.
- **`sync.Map` allocations on hit paths.** `bumpCloseReason` uses `Load` first, `LoadOrStore(k, new(atomic.Int64))` only on miss (`session_pool_lifecycle.go:102-111`) — this is the correct pattern. Flag any new `sync.Map.LoadOrStore(key, new(...))` call on a hot path that isn't gated by a preceding `Load` — that allocates on every hit.
- **Waiter counter drift.** `waitersCount.Add(+1)` at `session_pool.go:291`, `Add(-1)` on both the `ctx.Done` branch (`:294`) and the `w.ready` branch (`:300`). Flag any new wake path, timeout branch, or early-return between `:291` and `:308` that doesn't decrement, and any new enqueue site that doesn't increment. Drift here corrupts the sizer's `PendingCount` input.
- **Unbalanced `pendingStarts` / `startingSessions`.** Tick increments `pendingStarts` under `p.mu` at `session_pool_scaling.go:131-138`; `createSession`'s `reserved` defer at `:172-179` releases on early return; the transfer to `startingSessions` at `:246-249` is atomic; `onActive` deletes at `session_pool_lifecycle.go:265`; failed-start deletes at `session_pool_scaling.go:253-255`. Flag any new failure branch in `createSession` that returns without either the `reserved` defer or an explicit transfer/cleanup.
- **Missing CAS on close-once flags.** `sessionsClosed.Add(1)` sits downstream of `s.poolCloseRecorded.CompareAndSwap(false, true)` at `session_pool_lifecycle.go:121`. Lifetime histogram sits downstream of `sh.closingRecorded.CompareAndSwap(false, true)` at `:187` and `:317`. `recordSessionClose` re-entry is dedup'd at `:190` and `:347`. Flag any new counter bump / histogram record that isn't gated by the corresponding CAS.
- **Uncontrolled goroutine spawns.** Every pool-spawned goroutine must be tracked so `Close` phases 3/5/6 can drain: createSession workers use `p.spawns.Add`/`Done` under `p.mu` (`session_pool_scaling.go:137-138,149`); `spawnTickOnce` uses the same pattern (`session_pool_lifecycle.go:464-476`); the mid-Close onActive dispatch adds at `:274`. Session-owned goroutines (`readLoop`/`heartbeatLoop`) are tracked on `Session.loops` and drained via `WaitGoroutines`. Flag any bare `go func(){…}()` in these files with no WaitGroup entry.
- **Hot-path lock churn.** `p.mu` is briefly held on the fast path only at `session_pool.go:239-241` and `:249-255`. `Stats` takes `p.mu` (`:362`). Flag any new `p.mu.Lock()` inserted into `Invoke` (`:465-559`) or the pre-park stretch of `CheckoutSession` outside the two existing points.

### FALSE-POSITIVE SUPPRESSION

- **"Package name should be `transport`, not `internal`."** The directory is `bigtable/internal/transport/` but the `package` declaration is `package internal` (confirmed at `session_pool.go:20`). Package name is correct as-is; do NOT flag.
- **Local variable shadowing an exported type** where the local name is idiomatic (e.g. `afeID` local vs `AfeID` type in `CheckoutSession`). Already resolved intentionally; do NOT re-raise variants.
- **`goimports` / `gofmt` / column-alignment / trailing-newline nits.** CI (`goimports -l`, `gofmt -l`, `go vet`) already gates these. Bot echo is noise.
- **Comments referencing PR #20213 / #20215 / #20224.** Stacked-PR context, not stale references; do NOT suggest removal.
- **Test coverage complaints for `pool_sizer.go`, `afe_picker.go`, `session_list.go`, `session.go`, `session_vrpc.go`, `session_throttler.go`, `client_configuration_manager.go`, `default_client_config.go`.** All shipped in earlier PRs (#20213, #20215, #20224) with their own tests; out of scope here.
- **"Missing error wrapping"** on internal-only calls where the caller already annotates via `fmt.Errorf("POOL %s ...: %w", ...)` or via `btopt.Debugf`. Do NOT suggest adding a second wrap.
- **Retry loop / context propagation questions on `Session.Invoke`.** That's the Session layer (`session_vrpc.go`), out of scope for this PR.
- **"Consider using `sync.RWMutex` instead of `sync.Mutex` on `p.mu`."** The pool holds `p.mu` for tens of nanoseconds at a time and never for read-heavy loops; the added atomic on `RLock`/`RUnlock` would cost more than it saves. Do NOT suggest.
- **"Consider extracting anonymous goroutine into named function."** Style-only; do NOT suggest for the three ticker loops or the createSession worker.

### SCOPE BOUNDARY

Comment ONLY on:
- `bigtable/internal/transport/session_pool.go`
- `bigtable/internal/transport/session_pool_lifecycle.go`
- `bigtable/internal/transport/session_pool_scaling.go`
- `bigtable/internal/transport/session_pool_debug.go`
- `bigtable/internal/transport/session_snapshot.go`
- `bigtable/internal/transport/session_pool_*_test.go`
- `bigtable/internal/transport/session_snapshot_test.go`

Do NOT comment on additions to:
- `session.go` / `session_vrpc.go` (WaitGoroutines / closeError additions — vetted)
- `connpool.go` (`ChannelPickHintInto` helper — vetted)
- `afe_picker.go` (`defaultAfeRandomSubsetSize` constant — vetted)
- `debug_tracer.go` (3 new tags — vetted)

These are supporting scaffolding, already reviewed by the 3 subagent reviewers in this stack. Only re-raise if something looks actively unsafe.

### EFFORT SCALING

- ~4.9k LOC across 12 files. Do NOT paginate uniformly.
- **First pass — the 4 hot source files, in this order:**
  1. `session_pool.go` (559 LOC)
  2. `session_pool_lifecycle.go` (538 LOC)
  3. `session_pool_scaling.go` (311 LOC)
  4. `session_pool_debug.go` (416 LOC)
- **Second pass ONLY if a first-pass finding needs corroboration:** `session_snapshot.go` (594 LOC, mostly type defs), and the tests. Tests use `newTestPool`, which skips config wiring — do NOT flag bootstrap defaults on tests as if they were production paths.
- If a first-pass finding is a real hazard from the list above, cite the file:line and the exact anchor pattern it violates. Do not file speculative "consider" comments.
