### PR TITLE
Revert "chore(deps): run renovate on preview branch"

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -47,9 +47,5 @@
         "constraints": {
             "go": "1.25"
         }
-    },
-    "baseBranchPatterns": [
-        "main",
-        "preview"
-    ]
+    }
 }


### PR DESCRIPTION
Reverts googleapis/google-cloud-go#13840

Only need to run renovate on `main`. Preview code will exist on `main` under an internal directory, so will be updated by `renovate` as part of `main`.