### PR TITLE
chore: update librarian to v0.31.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: go
-version: v0.28.0
+version: v0.31.0
 repo: googleapis/google-cloud-go
 sources:
   discovery:


### PR DESCRIPTION
Update librarian version and regenerate, with commands:
```
go run github.com/googleapis/librarian/cmd/librarian@latest update version
V=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
go run github.com/googleapis/librarian/cmd/librarian@${V} install
go run github.com/googleapis/librarian/cmd/librarian@${V} generate --all
```