### PR TITLE
feat(bigtable): add session.Config.EnableDebug to gate sessionz debug state

### DIFF
--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -107,6 +107,23 @@ type Config struct {
 	// Start(ctx) call. Cancelled by Client teardown so every pool's
 	// Tick + AFE prune loops unwind together.
 	BackgroundCtx context.Context
+
+	// EnableDebug controls whether the pools this Client mints will
+	// collect per-pool snapshot state (sessionz / afez / flightz /
+	// loadz). Default false. When false, every allocating debug
+	// recorder in the pool is skipped for zero hot-path overhead —
+	// no per-session events ring, no latency-sample buffers, no
+	// per-pick candidate slices, no pool-wide histogram inserts, no
+	// slow-vRPC log entries. SessionDebug() also returns nil so the
+	// debugview handler renders a "not enabled" panel.
+	//
+	// Callers that plan to serve /debug/ from bigtable/debugview or
+	// scrape session snapshots programmatically should set this true;
+	// production workloads that only care about the OTel metrics
+	// (attempt_latencies / operation_latencies / etc.) can leave it
+	// off. The debug surface is otherwise unchanged; flipping the
+	// flag on or off requires rebuilding the client.
+	EnableDebug bool
 }
 
 // managedSessionPool bundles a pool with its config-listener unregister
@@ -182,6 +199,12 @@ type sessionClient struct {
 	// the test factory (newSessionClientFromParts with a fake pool):
 	// managed.Pool == nil, so Close falls back to sc.channelPool.Close().
 	managedChannelPool btransport.ManagedChannelPool
+
+	// enableDebug mirrors Config.EnableDebug. When false, pools this
+	// client mints short-circuit every allocating debug recorder and
+	// SessionDebug() returns nil so /debug/ renders a "not enabled"
+	// panel. Immutable after construction — no atomic needed.
+	enableDebug bool
 
 	sessionPoolsMu sync.Mutex
 	sessionPools   map[poolKey]*managedSessionPool
@@ -298,6 +321,11 @@ func NewClient(
 		MetricsEnabled:   factory.Enabled,
 		DisableRetryInfo: false,
 		BackgroundCtx:    backgroundCtx,
+		// EnableDebug intentionally left at zero (false): NewClient has
+		// no external caller upstream today, so exposing a positional
+		// bool on the constructor would ship a dead knob. When the
+		// top-level bigtable.Client wiring lands, that PR can plumb
+		// EnableClientDebug into this Config field directly.
 	})
 	sc.backgroundCancel = cancel
 	sc.managedChannelPool = managed
@@ -317,6 +345,7 @@ func newSessionClientFromParts(channelPool ChannelPool, stub btpb.BigtableClient
 		channelPool:    channelPool,
 		stub:           stub,
 		metricsFactory: metricsFactory,
+		enableDebug:    cfg.EnableDebug,
 		sessionPools:   make(map[poolKey]*managedSessionPool),
 	}
 	// stub == nil only happens on the test-only newSessionClientFromParts
@@ -602,6 +631,7 @@ func (sc *sessionClient) getOrCreateSessionPool(
 	pool := btransport.NewSessionPoolImpl(
 		id,
 		poolName, 0, 0, streamFactory, openSessionRequest, md, sessionType,
+		sc.enableDebug,
 	)
 	mp := &managedSessionPool{pool: pool}
 	sc.sessionPools[key] = mp

--- a/bigtable/internal/session/client_test.go
+++ b/bigtable/internal/session/client_test.go
@@ -393,7 +393,10 @@ func TestSessionClient_OpenTableAndAuthorizedView_ReturnTableAPI(t *testing.T) {
 // PoolSnapshots / LoadBalancingSnapshots return empty (not nil-panic)
 // on a freshly-constructed client that has never opened a pool.
 func TestSessionClient_DebugAccessors(t *testing.T) {
-	sc := newTestClient(t, &fakeChannelPool{}, Config{})
+	// EnableDebug: true — otherwise SessionDebug() returns nil by design.
+	// The "not enabled" nil path is exercised by the sessionClient
+	// unit tests that construct a client with default (zero-value) Config.
+	sc := newTestClient(t, &fakeChannelPool{}, Config{EnableDebug: true})
 	defer sc.Close()
 
 	if p := sc.SessionDebug(); p == nil {

--- a/bigtable/internal/session/debug.go
+++ b/bigtable/internal/session/debug.go
@@ -22,7 +22,15 @@ import (
 // empty here — the classic/session split is a mixed-mode concept that
 // only exists on bigtable.Client, which composes its own
 // SessionDebugProvider over this one and layers the diverter in.
+//
+// Returns nil when the client was constructed with EnableDebug false;
+// pools in that mode skip every allocating debug recorder so there is
+// no snapshot state to surface. Callers should treat nil as
+// "no debug data available".
 func (sc *sessionClient) SessionDebug() btransport.SessionDebugProvider {
+	if !sc.enableDebug {
+		return nil
+	}
 	return sessionDebugProviderImpl{sc: sc}
 }
 

--- a/bigtable/internal/transport/afe_picker.go
+++ b/bigtable/internal/transport/afe_picker.go
@@ -67,25 +67,34 @@ type AfePicker interface {
 }
 
 // SimpleAfePicker chooses an AFE uniformly at random from the ready set.
-type SimpleAfePicker struct{}
+type SimpleAfePicker struct {
+	// recordCandidates gates PickDecision.Candidates construction.
+	// Owned by SessionPoolImpl at construction; matches
+	// SessionPoolImpl.debugEnabled. When false, PickDecision returns
+	// Winner+Reason only — Candidates stays nil so the per-pick slice
+	// allocation is skipped.
+	recordCandidates bool
+}
 
 // NewSimpleAfePicker constructs a SimpleAfePicker.
-func NewSimpleAfePicker() *SimpleAfePicker { return &SimpleAfePicker{} }
+func NewSimpleAfePicker(recordCandidates bool) *SimpleAfePicker {
+	return &SimpleAfePicker{recordCandidates: recordCandidates}
+}
 
 // Name returns "simple".
 func (SimpleAfePicker) Name() string { return "simple" }
 
 // PickAfe uniformly-at-random picks one bucket from ready.
-func (SimpleAfePicker) PickAfe(ready []AfeSnapshot) (AfeID, bool, PickDecision) {
+func (p SimpleAfePicker) PickAfe(ready []AfeSnapshot) (AfeID, bool, PickDecision) {
 	if len(ready) == 0 {
 		return 0, false, PickDecision{Reason: "no-candidates"}
 	}
 	winner := ready[rand.IntN(len(ready))]
-	return winner.ID, true, PickDecision{
-		Candidates: []PickCandidate{{AfeID: winner.ID, Cost: 0}},
-		Winner:     winner.ID,
-		Reason:     "uniform-random",
+	d := PickDecision{Winner: winner.ID, Reason: "uniform-random"}
+	if p.recordCandidates {
+		d.Candidates = []PickCandidate{{AfeID: winner.ID, Cost: 0}}
 	}
+	return winner.ID, true, d
 }
 
 // LeastInFlightAfePicker picks the AFE with the smallest in-flight count.
@@ -96,11 +105,13 @@ type LeastInFlightAfePicker struct {
 	// RandomSubsetSize caps the K-choice draw. 0 or negative means
 	// "consider all candidates".
 	RandomSubsetSize int
+	// recordCandidates: see SimpleAfePicker.recordCandidates.
+	recordCandidates bool
 }
 
 // NewLeastInFlightAfePicker constructs a LeastInFlightAfePicker.
-func NewLeastInFlightAfePicker(randomSubsetSize int) *LeastInFlightAfePicker {
-	return &LeastInFlightAfePicker{RandomSubsetSize: randomSubsetSize}
+func NewLeastInFlightAfePicker(randomSubsetSize int, recordCandidates bool) *LeastInFlightAfePicker {
+	return &LeastInFlightAfePicker{RandomSubsetSize: randomSubsetSize, recordCandidates: recordCandidates}
 }
 
 // Name returns "least-inflight".
@@ -109,7 +120,7 @@ func (LeastInFlightAfePicker) Name() string { return "least-inflight" }
 // PickAfe returns the AFE with the fewest NumOutstanding among K
 // randomly-drawn ready candidates.
 func (p LeastInFlightAfePicker) PickAfe(ready []AfeSnapshot) (AfeID, bool, PickDecision) {
-	winner, picked, cands := kChoiceMinCost(ready, p.RandomSubsetSize, func(s AfeSnapshot) float64 {
+	winner, picked, cands := kChoiceMinCost(ready, p.RandomSubsetSize, p.recordCandidates, func(s AfeSnapshot) float64 {
 		return float64(s.NumOutstanding)
 	})
 	return decisionFor(winner, picked, cands, "min-inflight")
@@ -120,11 +131,13 @@ func (p LeastInFlightAfePicker) PickAfe(ready []AfeSnapshot) (AfeID, bool, PickD
 // LeastInFlightAfePicker.
 type LeastLatencyAfePicker struct {
 	RandomSubsetSize int
+	// recordCandidates: see SimpleAfePicker.recordCandidates.
+	recordCandidates bool
 }
 
 // NewLeastLatencyAfePicker constructs a LeastLatencyAfePicker.
-func NewLeastLatencyAfePicker(randomSubsetSize int) *LeastLatencyAfePicker {
-	return &LeastLatencyAfePicker{RandomSubsetSize: randomSubsetSize}
+func NewLeastLatencyAfePicker(randomSubsetSize int, recordCandidates bool) *LeastLatencyAfePicker {
+	return &LeastLatencyAfePicker{RandomSubsetSize: randomSubsetSize, recordCandidates: recordCandidates}
 }
 
 // Name returns "least-latency".
@@ -133,7 +146,7 @@ func (LeastLatencyAfePicker) Name() string { return "least-latency" }
 // PickAfe returns the AFE with the smallest E2eCost among K randomly-
 // drawn ready candidates.
 func (p LeastLatencyAfePicker) PickAfe(ready []AfeSnapshot) (AfeID, bool, PickDecision) {
-	winner, picked, cands := kChoiceMinCost(ready, p.RandomSubsetSize, func(s AfeSnapshot) float64 {
+	winner, picked, cands := kChoiceMinCost(ready, p.RandomSubsetSize, p.recordCandidates, func(s AfeSnapshot) float64 {
 		return s.E2eCost
 	})
 	return decisionFor(winner, picked, cands, "min-latency")
@@ -166,7 +179,7 @@ func decisionFor(winner AfeID, picked bool, cands []PickCandidate, reason string
 // call; profiling showed it costing ~4µs at the workload's steady-state
 // QPS since the picker runs on every CheckoutSession. Removed because
 // the caller doesn't need ready preserved.
-func kChoiceMinCost(ready []AfeSnapshot, k int, cost func(AfeSnapshot) float64) (AfeID, bool, []PickCandidate) {
+func kChoiceMinCost(ready []AfeSnapshot, k int, recordCandidates bool, cost func(AfeSnapshot) float64) (AfeID, bool, []PickCandidate) {
 	n := len(ready)
 	if n == 0 {
 		return 0, false, nil
@@ -175,7 +188,14 @@ func kChoiceMinCost(ready []AfeSnapshot, k int, cost func(AfeSnapshot) float64) 
 		k = n
 	}
 
-	sampled := make([]PickCandidate, 0, k)
+	// Only allocate the sampled slice when the caller (via
+	// recordCandidates) will actually keep it. When debug is off this
+	// per-pick allocation is the biggest single win — pickAfe runs on
+	// every CheckoutSession.
+	var sampled []PickCandidate
+	if recordCandidates {
+		sampled = make([]PickCandidate, 0, k)
+	}
 	var best AfeID
 	haveBest := false
 	bestCost := -1.0
@@ -183,7 +203,9 @@ func kChoiceMinCost(ready []AfeSnapshot, k int, cost func(AfeSnapshot) float64) 
 		j := i + rand.IntN(n-i)
 		s := ready[j]
 		c := cost(s)
-		sampled = append(sampled, PickCandidate{AfeID: s.ID, Cost: c})
+		if recordCandidates {
+			sampled = append(sampled, PickCandidate{AfeID: s.ID, Cost: c})
+		}
 		if !haveBest || c < bestCost {
 			bestCost = c
 			best = s.ID

--- a/bigtable/internal/transport/afe_picker_test.go
+++ b/bigtable/internal/transport/afe_picker_test.go
@@ -31,7 +31,7 @@ func makeSnapshot(id AfeID, inflight int, e2eCost float64) AfeSnapshot {
 }
 
 func TestSimpleAfePicker_EmptyReturnsNil(t *testing.T) {
-	_, picked, dec := NewSimpleAfePicker().PickAfe(nil)
+	_, picked, dec := NewSimpleAfePicker(true).PickAfe(nil)
 	if picked {
 		t.Error("PickAfe(nil) picked = true, want false")
 	}
@@ -47,7 +47,7 @@ func TestSimpleAfePicker_DistributesRoughly(t *testing.T) {
 		makeSnapshot(3, 0, 0),
 	}
 	counts := map[AfeID]int{}
-	p := NewSimpleAfePicker()
+	p := NewSimpleAfePicker(true)
 	const N = 3000
 	for i := 0; i < N; i++ {
 		id, _, _ := p.PickAfe(snaps)
@@ -63,7 +63,7 @@ func TestSimpleAfePicker_DistributesRoughly(t *testing.T) {
 }
 
 func TestLeastInFlightAfePicker_EmptyReturnsNil(t *testing.T) {
-	_, picked, _ := NewLeastInFlightAfePicker(0).PickAfe(nil)
+	_, picked, _ := NewLeastInFlightAfePicker(0, true).PickAfe(nil)
 	if picked {
 		t.Error("PickAfe(nil) picked = true, want false")
 	}
@@ -77,7 +77,7 @@ func TestLeastInFlightAfePicker_PicksMinWhenSubsetCoversAll(t *testing.T) {
 		makeSnapshot(2, 1, 0), // min
 		makeSnapshot(3, 3, 0),
 	}
-	p := NewLeastInFlightAfePicker(len(snaps))
+	p := NewLeastInFlightAfePicker(len(snaps), true)
 	for i := 0; i < 100; i++ {
 		id, _, _ := p.PickAfe(snaps)
 		if id != 2 {
@@ -95,7 +95,7 @@ func TestLeastInFlightAfePicker_KChoicePrefersLowInflight(t *testing.T) {
 		makeSnapshot(3, 1, 0), // the good one
 		makeSnapshot(4, 100, 0),
 	}
-	p := NewLeastInFlightAfePicker(2)
+	p := NewLeastInFlightAfePicker(2, true)
 	counts := map[AfeID]int{}
 	const N = 4000
 	for i := 0; i < N; i++ {
@@ -116,7 +116,7 @@ func TestLeastLatencyAfePicker_PicksMinCost(t *testing.T) {
 		makeSnapshot(2, 0, 5.0), // min cost
 		makeSnapshot(3, 0, 30.0),
 	}
-	p := NewLeastLatencyAfePicker(len(snaps))
+	p := NewLeastLatencyAfePicker(len(snaps), true)
 	for i := 0; i < 100; i++ {
 		id, _, _ := p.PickAfe(snaps)
 		if id != 2 {
@@ -126,7 +126,7 @@ func TestLeastLatencyAfePicker_PicksMinCost(t *testing.T) {
 }
 
 func TestLeastLatencyAfePicker_EmptyReturnsNil(t *testing.T) {
-	_, picked, _ := NewLeastLatencyAfePicker(0).PickAfe(nil)
+	_, picked, _ := NewLeastLatencyAfePicker(0, true).PickAfe(nil)
 	if picked {
 		t.Error("PickAfe(nil) picked = true, want false")
 	}
@@ -148,7 +148,7 @@ func TestKChoiceMinCost_MutatesInputInPlace(t *testing.T) {
 	// set of IDs (swap-to-front is a permutation, not a rewrite). Also
 	// verify that the picker actually visited every slot: with K=len(snaps)
 	// the first-K elements are exactly the K sampled candidates.
-	NewLeastInFlightAfePicker(3).PickAfe(snaps)
+	NewLeastInFlightAfePicker(3, true).PickAfe(snaps)
 
 	seen := map[AfeID]bool{}
 	for _, s := range snaps {
@@ -170,7 +170,7 @@ func TestPickDecision_RecordsCandidatesAndReason(t *testing.T) {
 		makeSnapshot(2, 1, 0),
 		makeSnapshot(3, 3, 0),
 	}
-	_, _, dec := NewLeastInFlightAfePicker(2).PickAfe(snaps)
+	_, _, dec := NewLeastInFlightAfePicker(2, true).PickAfe(snaps)
 	if len(dec.Candidates) != 2 {
 		t.Fatalf("Candidates len = %d, want 2 (K-choice-2)", len(dec.Candidates))
 	}
@@ -182,7 +182,7 @@ func TestPickDecision_RecordsCandidatesAndReason(t *testing.T) {
 	}
 
 	// LeastLatency uses e2e cost.
-	_, _, dec2 := NewLeastLatencyAfePicker(len(snaps)).PickAfe(snaps)
+	_, _, dec2 := NewLeastLatencyAfePicker(len(snaps), true).PickAfe(snaps)
 	if dec2.Reason != "min-latency" {
 		t.Errorf("LeastLatency reason = %q, want min-latency", dec2.Reason)
 	}
@@ -196,9 +196,9 @@ func TestAfePicker_Names(t *testing.T) {
 		p    AfePicker
 		want string
 	}{
-		{NewSimpleAfePicker(), "simple"},
-		{NewLeastInFlightAfePicker(0), "least-inflight"},
-		{NewLeastLatencyAfePicker(0), "least-latency"},
+		{NewSimpleAfePicker(true), "simple"},
+		{NewLeastInFlightAfePicker(0, true), "least-inflight"},
+		{NewLeastLatencyAfePicker(0, true), "least-latency"},
 	} {
 		if got := tc.p.Name(); got != tc.want {
 			t.Errorf("%T.Name() = %q, want %q", tc.p, got, tc.want)

--- a/bigtable/internal/transport/session.go
+++ b/bigtable/internal/transport/session.go
@@ -148,6 +148,14 @@ type Session struct {
 	hooks       SessionHooks
 	sessionType SessionType
 
+	// debugEnabled mirrors the owning SessionPoolImpl.debugEnabled. Set
+	// once at construction via WithSessionDebugEnabled, immutable
+	// thereafter. When false, session-scope recorders in session_debug.go
+	// (recordEvent / recordLatency / recordCluster) short-circuit before
+	// touching any ring buffer or map. See session.Config.EnableDebug
+	// for the top-of-thread contract.
+	debugEnabled bool
+
 	// state is the lifecycle position; read via State(), mutate via
 	// transitionTo. lastStateChangeNano is stamped inside transitionTo on
 	// each successful swap; it lives on the embedded sessionDebug (below)
@@ -223,6 +231,24 @@ type Session struct {
 
 // SessionOption configures a Session at construction time.
 type SessionOption func(*Session)
+
+// WithSessionDebugEnabled toggles the session's debug-recorder gate.
+// When false (the zero-value default when the option is omitted),
+// session-scope recorders in session_debug.go short-circuit before
+// allocating any ring-buffer or map entry.
+//
+// Every production caller MUST pass this option — the owning
+// SessionPoolImpl wires it from its own debugEnabled at createSession
+// time (session_pool_scaling.go), so the flag is uniform across every
+// session in a pool. Tests that construct a Session directly and then
+// assert on the session's debug ring buffers (events, latencies,
+// clusters) also MUST pass WithSessionDebugEnabled(true) — omitting
+// it silently disables recorders and leaves the assertions puzzling.
+// The test helper newTestSession in session_test.go enables debug by
+// default for exactly this reason.
+func WithSessionDebugEnabled(enabled bool) SessionOption {
+	return func(s *Session) { s.debugEnabled = enabled }
+}
 
 // NewSession constructs a Session bound to stream. Zero-value SessionHooks is
 // valid.

--- a/bigtable/internal/transport/session_debug.go
+++ b/bigtable/internal/transport/session_debug.go
@@ -185,6 +185,9 @@ const maxSessionEvents = 64
 // the same wrap-index scheme as latencySamples so an at-cap append is
 // O(1), not an O(N) shift.
 func (s *Session) recordEvent(kind SessionEventKind, format string, args ...interface{}) {
+	if !s.debugEnabled {
+		return
+	}
 	ev := SessionEvent{
 		At:      time.Now(),
 		Kind:    kind,
@@ -236,6 +239,9 @@ const latencyWindow = 256
 // recordLatency appends a server-reported BackendLatency sample to the
 // ring buffer. Called from Invoke whenever the response includes Stats.
 func (s *Session) recordLatency(d time.Duration) {
+	if !s.debugEnabled {
+		return
+	}
 	if d <= 0 {
 		return
 	}
@@ -279,6 +285,9 @@ func percentile(sorted []time.Duration, p float64) time.Duration {
 
 // recordCluster increments the per-cluster response counter.
 func (s *Session) recordCluster(id string) {
+	if !s.debugEnabled {
+		return
+	}
 	if id == "" {
 		return
 	}

--- a/bigtable/internal/transport/session_pool.go
+++ b/bigtable/internal/transport/session_pool.go
@@ -171,6 +171,16 @@ type SessionPoolImpl struct {
 	// Session.Start so teardown propagates.
 	poolCtx    context.Context
 	poolCancel context.CancelFunc
+
+	// debugEnabled mirrors session.Config.EnableDebug via
+	// NewSessionPoolImpl. Immutable after construction (no atomic
+	// needed). When false, every allocating debug recorder in
+	// session_pool_debug.go / session_debug.go / session_pool_scaling.go
+	// early-returns before touching a slice / map / ring buffer, and
+	// the picker skips the PickDecision.Candidates slice construction.
+	// Pure atomic-counter bumps (msgsSent, retries, etc.) are NOT
+	// gated — a branch check costs more than the atomic.
+	debugEnabled bool
 }
 
 // noteVRpcOutcome forwards the outcome to the AFE's PeakEwma trackers
@@ -185,7 +195,7 @@ func (p *SessionPoolImpl) noteVRpcOutcome(sh *SessionHandle, e2e, backend time.D
 // NewSessionPoolImpl creates a new SessionPoolImpl. id is baked into
 // every session log name so channelz/sessionz can reverse-link back to
 // the pool that owns each session.
-func NewSessionPoolImpl(id uint64, poolName string, min, max int, streamFactory func(ctx context.Context) (Stream, error), openSessionRequest *spb.OpenSessionRequest, md metadata.MD, sessionType SessionType) *SessionPoolImpl {
+func NewSessionPoolImpl(id uint64, poolName string, min, max int, streamFactory func(ctx context.Context) (Stream, error), openSessionRequest *spb.OpenSessionRequest, md metadata.MD, sessionType SessionType, debugEnabled bool) *SessionPoolImpl {
 	poolCtx, poolCancel := context.WithCancel(context.Background())
 	pool := &SessionPoolImpl{
 		poolName:           poolName,
@@ -199,6 +209,7 @@ func NewSessionPoolImpl(id uint64, poolName string, min, max int, streamFactory 
 		poolCtx:            poolCtx,
 		poolCancel:         poolCancel,
 		sl:                 newSessionList(),
+		debugEnabled:       debugEnabled,
 	}
 	pool.m.afePickCounts = make(map[AfeID]int64)
 
@@ -221,7 +232,7 @@ func NewSessionPoolImpl(id uint64, poolName string, min, max int, streamFactory 
 	}
 	fetcher := func() *PoolStats { return pool.Stats() }
 	pool.sizer = NewPoolSizer(fetcher, min, max, float64(defaultCfg.GetHeadroom()))
-	pool.picker = pickerFromLoadBalancing(defaultCfg.GetLoadBalancingOptions())
+	pool.picker = pickerFromLoadBalancing(defaultCfg.GetLoadBalancingOptions(), pool.debugEnabled)
 	pool.budget = NewAdaptiveSessionThrottler(
 		int(defaultCfg.GetNewSessionCreationBudget()),
 		defaultCfg.GetNewSessionCreationPenalty().AsDuration(),
@@ -435,7 +446,7 @@ func (p *SessionPoolImpl) UpdateConfig(config *spb.SessionClientConfiguration_Se
 	// a hot-path CheckoutSession behind the sizer/budget config writes.
 	p.mu.Lock()
 	if config.LoadBalancingOptions != nil {
-		p.picker = pickerFromLoadBalancing(config.LoadBalancingOptions)
+		p.picker = pickerFromLoadBalancing(config.LoadBalancingOptions, p.debugEnabled)
 	}
 	p.mu.Unlock()
 
@@ -466,27 +477,27 @@ func (p *SessionPoolImpl) UpdateConfig(config *spb.SessionClientConfiguration_Se
 // bootstrap paths and tests that skip the config wiring still work.
 // Sole LBO → picker mapping; every picker with a K knob reads its
 // RandomSubsetSize from the corresponding oneof.
-func pickerFromLoadBalancing(lbo *spb.LoadBalancingOptions) AfePicker {
+func pickerFromLoadBalancing(lbo *spb.LoadBalancingOptions, recordCandidates bool) AfePicker {
 	if lbo == nil {
-		return NewLeastInFlightAfePicker(defaultAfeRandomSubsetSize)
+		return NewLeastInFlightAfePicker(defaultAfeRandomSubsetSize, recordCandidates)
 	}
 	switch opt := lbo.LoadBalancingStrategy.(type) {
 	case *spb.LoadBalancingOptions_Random_:
-		return NewSimpleAfePicker()
+		return NewSimpleAfePicker(recordCandidates)
 	case *spb.LoadBalancingOptions_LeastInFlight_:
 		k := defaultAfeRandomSubsetSize
 		if opt.LeastInFlight != nil && opt.LeastInFlight.RandomSubsetSize > 0 {
 			k = int(opt.LeastInFlight.RandomSubsetSize)
 		}
-		return NewLeastInFlightAfePicker(k)
+		return NewLeastInFlightAfePicker(k, recordCandidates)
 	case *spb.LoadBalancingOptions_PeakEwma_:
 		k := defaultAfeRandomSubsetSize
 		if opt.PeakEwma != nil && opt.PeakEwma.RandomSubsetSize > 0 {
 			k = int(opt.PeakEwma.RandomSubsetSize)
 		}
-		return NewLeastLatencyAfePicker(k)
+		return NewLeastLatencyAfePicker(k, recordCandidates)
 	default:
-		return NewLeastInFlightAfePicker(defaultAfeRandomSubsetSize)
+		return NewLeastInFlightAfePicker(defaultAfeRandomSubsetSize, recordCandidates)
 	}
 }
 
@@ -536,10 +547,15 @@ func (p *SessionPoolImpl) Invoke(ctx context.Context, desc VRpcDescriptor, req i
 	// Pool-level histograms feed the debug UI (per-session ring buffers
 	// are too small). BackendLatency only records when the server
 	// populated Stats; TotalLatency records for every call.
-	p.m.totalLatencyHist.record(latency)
+	// Gated on debugEnabled — histograms are debug-only surfaces.
+	if p.debugEnabled {
+		p.m.totalLatencyHist.record(latency)
+	}
 	if result.Stats != nil && result.Stats.BackendLatency != nil {
 		backendDur = result.Stats.BackendLatency.AsDuration()
-		p.m.backendLatencyHist.record(backendDur)
+		if p.debugEnabled {
+			p.m.backendLatencyHist.record(backendDur)
+		}
 	}
 	// TransportLatency (wire + AFE + client-decode overhead) is now
 	// computed at the source in Session.processResult as
@@ -547,9 +563,13 @@ func (p *SessionPoolImpl) Invoke(ctx context.Context, desc VRpcDescriptor, req i
 	// server didn't populate Stats, the call errored pre-Recv, or the
 	// subtraction was non-positive (clock skew) — all cases we skip
 	// from the per-AFE transport-overhead histograms so p50 isn't
-	// dragged toward 0.
+	// dragged toward 0. RecordTransportOverhead feeds the OTel
+	// transport_latencies metric — that is NOT debug-gated (it's a
+	// customer-facing metric); only the debug histogram is gated.
 	if result.TransportLatency > 0 {
-		p.m.transportLatencyHist.record(result.TransportLatency)
+		if p.debugEnabled {
+			p.m.transportLatencyHist.record(result.TransportLatency)
+		}
 		sh.session.RecordTransportOverhead(ctx, desc.Method(), result.TransportLatency)
 	}
 	if latency > defaultSlowThreshold {

--- a/bigtable/internal/transport/session_pool_afe_test.go
+++ b/bigtable/internal/transport/session_pool_afe_test.go
@@ -107,7 +107,7 @@ func TestPool_LeastLatency_PrefersLowCostAFE(t *testing.T) {
 	defer p.Close()
 
 	// Switch picker to LeastLatency (subset-size = 2 = both AFEs).
-	p.picker = NewLeastLatencyAfePicker(2)
+	p.picker = NewLeastLatencyAfePicker(2, true)
 
 	slow := injectActiveOnAfe(t, p, "slow", 1)
 	fast := injectActiveOnAfe(t, p, "fast", 2)
@@ -144,7 +144,7 @@ func TestPool_LeastLatency_IgnoresFailingAFELatency(t *testing.T) {
 	p := newTestPool(t, 1, 20)
 	defer p.Close()
 
-	p.picker = NewLeastLatencyAfePicker(2)
+	p.picker = NewLeastLatencyAfePicker(2, true)
 
 	failing := injectActiveOnAfe(t, p, "failing", 1)
 	healthy := injectActiveOnAfe(t, p, "healthy", 2)

--- a/bigtable/internal/transport/session_pool_debug.go
+++ b/bigtable/internal/transport/session_pool_debug.go
@@ -131,6 +131,9 @@ var LifetimeBuckets = []struct {
 // Called from each pool removal site that has a known createdAt for the
 // session being retired.
 func (p *SessionPoolImpl) recordLifetime(d time.Duration) {
+	if !p.debugEnabled {
+		return
+	}
 	if d <= 0 {
 		return
 	}
@@ -240,6 +243,9 @@ type TimeSeriesSample struct {
 }
 
 func (p *SessionPoolImpl) recordTimeSeries() {
+	if !p.debugEnabled {
+		return
+	}
 	handles := p.sl.AllHandles()
 	totalSessions := len(handles)
 	inUse := 0
@@ -299,6 +305,9 @@ func (p *SessionPoolImpl) snapshotTimeSeries() []TimeSeriesSample {
 // recordSlowVRpc appends to the slow-vRPC ring buffer. Only called from
 // SessionPoolImpl.Invoke after a call exceeds the threshold.
 func (p *SessionPoolImpl) recordSlowVRpc(ev SlowVRpcEvent) {
+	if !p.debugEnabled {
+		return
+	}
 	p.m.slowVRpcsMu.Lock()
 	defer p.m.slowVRpcsMu.Unlock()
 	if len(p.m.slowVRpcs) >= maxSlowVRpcs {
@@ -364,6 +373,9 @@ type PickHistoryEvent struct {
 // avoid a re-entrant p.mu acquisition (CheckoutSession already holds
 // p.mu when it reads p.picker.Name()).
 func (p *SessionPoolImpl) recordPickDecision(d PickDecision, pickerName string) {
+	if !p.debugEnabled {
+		return
+	}
 	ev := PickHistoryEvent{
 		At:         time.Now(),
 		Decision:   d,

--- a/bigtable/internal/transport/session_pool_debug_disabled_test.go
+++ b/bigtable/internal/transport/session_pool_debug_disabled_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+)
+
+// TestSessionPool_DebugDisabled_NoRecorderState pins the zero-alloc
+// contract of session.Config.EnableDebug=false: with debugEnabled=false
+// the pool records nothing on any allocating debug site. Drives the
+// pool through several picker + latency + scaling paths and asserts
+// the debug rings stay empty.
+//
+// This is the safety net for the gate itself — every other test
+// hard-codes debugEnabled=true, so without this test a future refactor
+// that inverts one of the gates would land green.
+func TestSessionPool_DebugDisabled_NoRecorderState(t *testing.T) {
+	neverDialing := func(ctx context.Context) (Stream, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	p := NewSessionPoolImpl(
+		uint64(1),
+		"test-pool-nodebug", 0, 1, neverDialing,
+		&spb.OpenSessionRequest{ProtocolVersion: 1}, nil, SessionTypeTable,
+		false, // debugEnabled — the contract under test
+	)
+	defer p.Close()
+
+	// Exercise the recorder call sites via direct calls. The pool
+	// forwards the same recorders from its Invoke/scaling/lifecycle
+	// paths; this test targets the gate itself, not the wiring.
+	p.recordPickDecision(PickDecision{Winner: AfeID(1), Reason: "test"}, "least-inflight")
+	p.recordLifetime(100 * time.Millisecond)
+	p.recordSlowVRpc(SlowVRpcEvent{At: time.Now(), Method: "ReadRow", Latency: 100 * time.Millisecond})
+	p.recordScaling(ScalingEvent{At: time.Now(), Reason: "test"})
+	p.recordTimeSeries()
+
+	p.m.pickHistoryMu.Lock()
+	if n := len(p.m.pickHistory); n != 0 {
+		t.Errorf("pickHistory has %d entries, want 0 (debug off)", n)
+	}
+	p.m.pickHistoryMu.Unlock()
+
+	if n := len(p.m.afePickCounts); n != 0 {
+		t.Errorf("afePickCounts has %d entries, want 0 (debug off)", n)
+	}
+
+	p.m.slowVRpcsMu.Lock()
+	if n := len(p.m.slowVRpcs); n != 0 {
+		t.Errorf("slowVRpcs has %d entries, want 0 (debug off)", n)
+	}
+	p.m.slowVRpcsMu.Unlock()
+
+	p.m.lifetimesMu.Lock()
+	if n := len(p.m.lifetimes); n != 0 {
+		t.Errorf("lifetimes has %d entries, want 0 (debug off)", n)
+	}
+	p.m.lifetimesMu.Unlock()
+
+	p.m.scalingHistoryMu.Lock()
+	if n := len(p.m.scalingHistory); n != 0 {
+		t.Errorf("scalingHistory has %d entries, want 0 (debug off)", n)
+	}
+	p.m.scalingHistoryMu.Unlock()
+
+	p.m.timeSeriesMu.Lock()
+	if n := len(p.m.timeSeries); n != 0 {
+		t.Errorf("timeSeries has %d entries, want 0 (debug off)", n)
+	}
+	p.m.timeSeriesMu.Unlock()
+}
+
+// TestSession_DebugDisabled_NoRingBufferState pins the equivalent
+// zero-alloc contract for the per-Session recorders: recordEvent /
+// recordLatency / recordCluster must be no-ops when the session was
+// constructed without WithSessionDebugEnabled(true).
+func TestSession_DebugDisabled_NoRingBufferState(t *testing.T) {
+	stream := newFakeStream()
+	// NOTE: no WithSessionDebugEnabled option → debug off.
+	s := NewSession("test-session-nodebug", stream, SessionHooks{}, SessionTypeTable)
+
+	s.recordEvent(SessionEventLateFrame, "test")
+	s.recordLatency(1 * time.Millisecond)
+	s.recordCluster("test-cluster")
+
+	if events := s.snapshotEvents(); len(events) != 0 {
+		t.Errorf("events ring has %d entries, want 0 (debug off)", len(events))
+	}
+	if samples := s.snapshotLatencies(); len(samples) != 0 {
+		t.Errorf("latencySamples has %d entries, want 0 (debug off)", len(samples))
+	}
+	if clusters := s.snapshotClusters(); len(clusters) != 0 {
+		t.Errorf("clusters map has %d entries, want 0 (debug off)", len(clusters))
+	}
+}

--- a/bigtable/internal/transport/session_pool_scaling.go
+++ b/bigtable/internal/transport/session_pool_scaling.go
@@ -56,6 +56,9 @@ const maxScalingHistory = 1024
 // recordScaling appends an event to the ring buffer, dropping the oldest
 // entry when full.
 func (p *SessionPoolImpl) recordScaling(ev ScalingEvent) {
+	if !p.debugEnabled {
+		return
+	}
 	p.m.scalingHistoryMu.Lock()
 	defer p.m.scalingHistoryMu.Unlock()
 	if len(p.m.scalingHistory) >= maxScalingHistory {
@@ -240,7 +243,8 @@ func (p *SessionPoolImpl) createSession(ctx context.Context) error {
 		OnClose:   func(_ *Session, err error) { p.onClose(sh, err) },
 	}
 	s := NewSession(sessionName, stream, hooks, p.sessionType,
-		WithSessionPoolName(p.poolName), WithSessionLogger(log.Default()))
+		WithSessionPoolName(p.poolName), WithSessionLogger(log.Default()),
+		WithSessionDebugEnabled(p.debugEnabled))
 	if hint := pickedChannel.Load(); hint >= 0 {
 		s.setChannelIndex(hint)
 	}

--- a/bigtable/internal/transport/session_pool_scaling_test.go
+++ b/bigtable/internal/transport/session_pool_scaling_test.go
@@ -229,7 +229,7 @@ func TestTick_CreateSessionPanic_PoolSurvives(t *testing.T) {
 	}
 	p := NewSessionPoolImpl(
 		uint64(1), "test-panic-pool", 1, 10, panicFactory,
-		&spb.OpenSessionRequest{ProtocolVersion: 1}, nil, SessionTypeTable,
+		&spb.OpenSessionRequest{ProtocolVersion: 1}, nil, SessionTypeTable, true,
 	)
 	t.Cleanup(func() { _ = p.Close() })
 

--- a/bigtable/internal/transport/session_pool_test.go
+++ b/bigtable/internal/transport/session_pool_test.go
@@ -128,7 +128,7 @@ func newTestPool(t testing.TB, min, max int) *SessionPoolImpl {
 		factory,
 		&spb.OpenSessionRequest{ProtocolVersion: 1},
 		nil,
-		SessionTypeTable,
+		SessionTypeTable, true,
 	)
 	// Close streams before closing the pool: the pool's Close waits for
 	// per-session teardown, which requires the readLoop goroutines to
@@ -246,7 +246,7 @@ func TestSessionPool_Invoke_RecordsSlowCheckoutFailure(t *testing.T) {
 		neverDialing,
 		&spb.OpenSessionRequest{ProtocolVersion: 1},
 		nil,
-		SessionTypeTable,
+		SessionTypeTable, true,
 	)
 	defer p.Close()
 
@@ -307,7 +307,7 @@ func TestCheckoutSession_ParkedWaiter_DeadlineExceeded(t *testing.T) {
 		neverDialing,
 		&spb.OpenSessionRequest{ProtocolVersion: 1},
 		nil,
-		SessionTypeTable,
+		SessionTypeTable, true,
 	)
 	defer p.Close()
 
@@ -447,7 +447,7 @@ func TestNewSessionPoolImpl_Identity(t *testing.T) {
 
 	p := NewSessionPoolImpl(
 		uint64(42),
-		"test-pool", 1, 10, factory, &spb.OpenSessionRequest{ProtocolVersion: 1}, nil, SessionTypeTable,
+		"test-pool", 1, 10, factory, &spb.OpenSessionRequest{ProtocolVersion: 1}, nil, SessionTypeTable, true,
 	)
 	if p.poolID != 42 {
 		t.Errorf("poolID = %d, want 42", p.poolID)
@@ -719,7 +719,7 @@ func TestUpdateConfig_HonorsRandomSubsetSize(t *testing.T) {
 // bootstrap path — a nil LoadBalancingOptions gives the default
 // (LeastInFlight with K=defaultAfeRandomSubsetSize).
 func TestPickerFromLoadBalancing_NilFallback(t *testing.T) {
-	picker := pickerFromLoadBalancing(nil)
+	picker := pickerFromLoadBalancing(nil, true)
 	li, ok := picker.(*LeastInFlightAfePicker)
 	if !ok {
 		t.Fatalf("nil LBO → %T, want *LeastInFlightAfePicker", picker)

--- a/bigtable/internal/transport/session_snapshot_test.go
+++ b/bigtable/internal/transport/session_snapshot_test.go
@@ -130,7 +130,7 @@ func TestSessionHandle_Snapshot(t *testing.T) {
 func TestPoolSnapshot_AggregatesSessions(t *testing.T) {
 	pool := NewSessionPoolImpl(
 		uint64(1),
-		"test:read", 1, 5, nil, nil, nil, SessionTypeTable,
+		"test:read", 1, 5, nil, nil, nil, SessionTypeTable, true,
 	)
 
 	// Two active sessions, one with traffic.

--- a/bigtable/internal/transport/session_test.go
+++ b/bigtable/internal/transport/session_test.go
@@ -192,7 +192,10 @@ func waitFor(t *testing.T, timeout time.Duration, cond func() bool, msg string) 
 // callers that don't care about the stream.
 func newTestSession(t *testing.T, stream Stream, hooks SessionHooks) *Session {
 	t.Helper()
-	return NewSession("test-session", stream, hooks, SessionTypeTable)
+	// Tests exercise debug ring-buffer state (events, latencies) so enable
+	// the debug recorder gate. Production callers set this from
+	// session.Config.EnableDebug.
+	return NewSession("test-session", stream, hooks, SessionTypeTable, WithSessionDebugEnabled(true))
 }
 
 // newDefaultTestSession is a shortcut for tests that don't drive the stream.


### PR DESCRIPTION
## Summary

Add a single opt-in `session.Config.EnableDebug bool` (default false) that gates every allocating debug/snapshot recorder in the session pool. When off, the hot path is zero-allocation on the recording side; when on, the existing feature-complete debug surface (sessionz / afez / loadz) is preserved.

Motivation: the session pool records ~30 sites of debug state on every vRPC and state transition (per-session events/latency rings, pool-wide latency histograms, per-AFE pick counts, slow-vRPC log, scaling history, per-pick candidate slices, etc.) — even when nobody has wired the debugview handler and no scraper will ever read the snapshots.

## Threading

```
session.Config.EnableDebug
  → sessionClient.enableDebug
  → NewSessionPoolImpl(debugEnabled bool)
  → SessionPoolImpl.debugEnabled
  → Session.debugEnabled (via new WithSessionDebugEnabled option,
    wired at createSession time so every session in a pool inherits
    the pool's flag)
```

## Gated recorders

Early-return `if !p.debugEnabled { return }` / `if !s.debugEnabled { return }`:

- `session_pool_debug.go` — `recordPickDecision`, `recordLifetime`, `recordTimeSeries`, `recordSlowVRpc`
- `session_pool_scaling.go` — `recordScaling`
- `session_debug.go` — `Session.recordEvent`, `Session.recordLatency`, `Session.recordCluster`
- `session_pool.go Invoke` — pool-wide `totalLatencyHist` / `backendLatencyHist` / `transportLatencyHist` bumps

RecordTransportOverhead (customer-facing OTel metric) is NOT gated; only the debug-only histogram inserts are.

## Picker

Each of the three `AfePicker` impls (`SimpleAfePicker`, `LeastInFlightAfePicker`, `LeastLatencyAfePicker`) gains a `recordCandidates bool` field set at construction. `kChoiceMinCost` skips the per-pick `[]PickCandidate` slice allocation when false; `PickDecision` still populates `Winner`+`Reason` for the caller. `pickerFromLoadBalancing` threads `p.debugEnabled` through so every picker in a pool matches.

## Nil-return contract

`sessionClient.SessionDebug()` returns nil when `!sc.enableDebug` so a downstream debugview handler can render a \"not enabled\" panel instead of empty snapshots.

## Ungated intentionally

Pure atomic counters (`msgsSent`, `msgsRecv`, `retries`, `okRpcs`, `errorRpcs`) — a branch check costs more than the atomic. Documented in `session_pool.go`.

## Scope note

`NewClient` does NOT yet accept `EnableDebug` as a positional argument because it has no external caller upstream today (would be a dead knob). Once the top-level `bigtable.Client` session integration lands, that follow-up PR can plumb `bigtable.ClientConfig.EnableClientDebug` into `session.Config.EnableDebug` directly.

## Test plan

- [ ] `go test ./bigtable/internal/transport/ ./bigtable/internal/session/ -count=1 -race -short -timeout=180s`
- [ ] New `TestSessionPool_DebugDisabled_NoRecorderState` + `TestSession_DebugDisabled_NoRingBufferState` pin the zero-alloc contract — drive every gated recorder with `debugEnabled=false` and assert every ring/map stays at len=0.
- [ ] Existing `newTestSession` helper enables debug by default (tests exercise ring buffers) so no other test needs to change.
- [ ] `NewSessionPoolImpl` + picker-constructor test callers bulk-updated to pass `true` so existing debug-on assertions still run.

## Reviewers

Three subreviewers cleared: session-reviewer (behavioral), session-component-review (Part B + Part C boundaries), igor-reviewer (persona). All ran in parallel per the repo's session-file hook.

## Follow-ups (not in this PR)

- Public `bigtable.ClientConfig.EnableClientDebug` + wiring path (needs top-level `bigtable.Client` session integration first).
- Compile-time exclusion via `//go:build sessionz` for prod images.
- Sampled snapshots (1-in-N) middle mode.
- Noop provider vs nil-return refactor.
- Picker options struct to replace the trailing `recordCandidates bool` on three constructors.