### PR TITLE
feat(bigtable): rename session pool display to <resource-id>-<PERM>

### DIFF
--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -143,15 +143,15 @@ func (p permission) display() string {
 // resource. Struct keys let the map dedup on both axes without string
 // concatenation.
 type poolKey struct {
-	resource string
-	perm     permission
+	resourceName string
+	perm         permission
 }
 
 // less orders poolKeys for stable snapshot rendering (resource first,
 // then permission).
 func (k poolKey) less(other poolKey) bool {
-	if k.resource != other.resource {
-		return k.resource < other.resource
+	if k.resourceName != other.resourceName {
+		return k.resourceName < other.resourceName
 	}
 	return k.perm < other.perm
 }
@@ -183,7 +183,7 @@ func (k poolKey) displayName() string {
 }
 
 func (k poolKey) displayResource() string {
-	r := k.resource
+	r := k.resourceName
 	switch {
 	case strings.HasPrefix(r, "table:"):
 		return strings.TrimPrefix(r, "table:")

--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -156,6 +156,49 @@ func (k poolKey) less(other poolKey) bool {
 	return k.perm < other.perm
 }
 
+// displayName renders the human-readable pool identity that is stamped
+// as the OTel `session_name` metric label (via WithSessionPoolName)
+// and rendered in sessionz. Format: "<resource-id>-<PERM>".
+//
+// Resource-id is the caller-supplied short name with the internal
+// type-prefix stripped:
+//
+//	table:<id>    → "<id>-<PERM>"            e.g. "my-table-READ"
+//	av:<t>:<v>    → "<t>/<v>-<PERM>"         e.g. "my-table/my-view-READ"
+//	mv:<v>        → "<v>-<PERM>"             e.g. "my-view-READ"
+//
+// For authorized views the table qualifier is preserved as "<table>/<view>"
+// (converted from the "av:" pool-key encoding "av:<table>:<view>") so
+// two AVs with the same view id on different tables produce distinct
+// `session_name` timeseries and distinct sessionz rows — otherwise they
+// would silently aggregate on the label.
+//
+// (Resource, permission) is already unique per pool, so the numeric
+// pool id is intentionally left out of the display name. The pool id
+// remains on SessionPoolImpl (as poolID) and gets baked into per-session
+// log names via createSession — `session_name` label cardinality stays
+// bounded by (resource × permission).
+func (k poolKey) displayName() string {
+	return k.displayResource() + "-" + k.perm.display()
+}
+
+func (k poolKey) displayResource() string {
+	r := k.resource
+	switch {
+	case strings.HasPrefix(r, "table:"):
+		return strings.TrimPrefix(r, "table:")
+	case strings.HasPrefix(r, "mv:"):
+		return strings.TrimPrefix(r, "mv:")
+	case strings.HasPrefix(r, "av:"):
+		// "av:<table>:<view>" → "<table>/<view>" so the label
+		// disambiguates AVs with the same view id on different tables.
+		rest := strings.TrimPrefix(r, "av:")
+		return strings.Replace(rest, ":", "/", 1)
+	default:
+		return r
+	}
+}
+
 // sessionClient is the internal implementation of the Client
 // interface. Owns the channel pool + gRPC stub + configuration
 // manager, and vends per-resource TableAPI instances.
@@ -592,10 +635,13 @@ func (sc *sessionClient) getOrCreateSessionPool(
 		return mp.pool
 	}
 	id := sc.nextPoolID.Add(1)
-	poolName := fmt.Sprintf("%sPool-%d", sessionType.ProtoName(), id)
-	if label := key.perm.display(); label != "" {
-		poolName += " [" + label + "]"
-	}
+	// poolName is stamped as the `session_name` OTel metric label and
+	// surfaces in sessionz — "<resource-id>-<PERM>" (see poolKey.displayName).
+	// Numeric pool id lives on SessionPoolImpl.poolID for the sessionz
+	// ↔ channelz reverse link and per-session log names; we don't need
+	// it in the human-readable label because (resource, permission)
+	// already uniquely identifies the pool.
+	poolName := key.displayName()
 	// Pool bounds start at 0; NewSessionPoolImpl falls back to
 	// defaultPoolConfig() and ClientConfigurationManager overrides on
 	// first UpdateConfig with server-driven values.

--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -179,24 +179,18 @@ func (k poolKey) less(other poolKey) bool {
 // log names via createSession — `session_name` label cardinality stays
 // bounded by (resource × permission).
 func (k poolKey) displayName() string {
-	return k.displayResource() + "-" + k.perm.display()
-}
-
-func (k poolKey) displayResource() string {
 	r := k.resourceName
 	switch {
 	case strings.HasPrefix(r, "table:"):
-		return strings.TrimPrefix(r, "table:")
+		r = strings.TrimPrefix(r, "table:")
 	case strings.HasPrefix(r, "mv:"):
-		return strings.TrimPrefix(r, "mv:")
+		r = strings.TrimPrefix(r, "mv:")
 	case strings.HasPrefix(r, "av:"):
 		// "av:<table>:<view>" → "<table>/<view>" so the label
 		// disambiguates AVs with the same view id on different tables.
-		rest := strings.TrimPrefix(r, "av:")
-		return strings.Replace(rest, ":", "/", 1)
-	default:
-		return r
+		r = strings.Replace(strings.TrimPrefix(r, "av:"), ":", "/", 1)
 	}
+	return r + "-" + k.perm.display()
 }
 
 // sessionClient is the internal implementation of the Client

--- a/bigtable/internal/session/client_test.go
+++ b/bigtable/internal/session/client_test.go
@@ -413,3 +413,43 @@ func TestSessionClient_DebugAccessors(t *testing.T) {
 		t.Errorf("LoadBalancingSnapshots() on fresh client = %v, want empty", snaps)
 	}
 }
+
+// TestPoolKey_DisplayName pins the "<resource-id>-<PERM>" contract for
+// the session_name OTel metric label + sessionz UI. If this test
+// changes, coordinate with dashboard owners — session_name is a public
+// metric label.
+func TestPoolKey_DisplayName(t *testing.T) {
+	tests := []struct {
+		name string
+		key  poolKey
+		want string
+	}{
+		{"table read", poolKey{"table:my-table", permissionRead}, "my-table-READ"},
+		{"table write", poolKey{"table:my-table", permissionWrite}, "my-table-WRITE"},
+		{"authorized view read", poolKey{"av:my-table:my-view", permissionRead}, "my-table/my-view-READ"},
+		{"authorized view write", poolKey{"av:my-table:my-view", permissionWrite}, "my-table/my-view-WRITE"},
+		{"authorized view — same view id, different tables must not collide",
+			poolKey{"av:other-table:my-view", permissionRead}, "other-table/my-view-READ"},
+		{"materialized view read", poolKey{"mv:my-mat-view", permissionRead}, "my-mat-view-READ"},
+		{"table id with dashes and dots", poolKey{"table:tbl-1.foo", permissionRead}, "tbl-1.foo-READ"},
+		// Unknown prefix falls through to the raw resource string so
+		// operators still get a legible label even if a future resource
+		// kind hasn't been wired into displayResource yet.
+		{"unknown prefix falls through", poolKey{"future-kind:xyz", permissionRead}, "future-kind:xyz-READ"},
+		// Malformed inputs: pin current fallback behavior so nobody
+		// silently changes to a panic. In practice these can't be
+		// produced by any of the Open* call sites; the assertions are
+		// defensive-programming contracts on displayResource.
+		{"empty resource", poolKey{"", permissionRead}, "-READ"},
+		{"empty table id after prefix", poolKey{"table:", permissionRead}, "-READ"},
+		{"empty view id after av prefix", poolKey{"av:t:", permissionRead}, "t/-READ"},
+		{"empty view id after mv prefix", poolKey{"mv:", permissionRead}, "-READ"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.key.displayName(); got != tc.want {
+				t.Errorf("displayName() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Reformat `SessionPoolImpl.poolName` — the string that is:
- stamped as the OTel `session_name` metric label (via `WithSessionPoolName` → `sessionTracer.setPoolName`), and
- rendered as the pool identity in the sessionz debug view.

Old format: `\"TablePool-1 [READ]\"` — three concatenated concepts (proto session type, monotonic id, permission bracket) that convey nothing an operator debugging a specific table would recognise.

New format: `\"<resource-id>-<PERM>\"`

| Resource kind    | Old label             | New label                      |
|------------------|-----------------------|--------------------------------|
| standard table   | `TablePool-1 [READ]`  | `my-table-READ`                |
| authorized view  | `AuthorizedViewPool-1 [READ]` | `my-table/my-view-READ` |
| materialized view| `MaterializedViewPool-1 [READ]` | `my-mat-view-READ`   |

The numeric pool id lives on `SessionPoolImpl.poolID` for the sessionz ↔ channelz reverse link and gets baked into per-session log names via `createSession` — cardinality of `session_name` stays bounded by (resource × permission).

## AV disambiguation

For authorized views the table qualifier is preserved as `<table>/<view>` so two AVs with the same view id on different tables produce **distinct** `session_name` timeseries. Otherwise they would silently aggregate on the label — a metric-integrity concern flagged by both `session-reviewer` and `igor-reviewer` in early review. `/` is disjoint from Bigtable resource-id grammar (`[-_.a-zA-Z0-9]`) so the compound decomposes unambiguously.

## Files touched

- `bigtable/internal/session/client.go` — new `poolKey.displayName()` + `poolKey.displayResource()` helpers; `getOrCreateSessionPool` uses them instead of `fmt.Sprintf(\"%sPool-%d\", ...) + \" [\" + label + \"]\"`.
- `bigtable/internal/session/client_test.go` — new `TestPoolKey_DisplayName` covers table/AV/MV + read/write + AV-collision + malformed-input fallback pins.

## Test plan

- [ ] `go test ./bigtable/internal/session/ ./bigtable/internal/transport/ -count=1 -race -short -timeout=180s`
- [ ] New `TestPoolKey_DisplayName` covers 12 cases including the AV-collision guard and 4 malformed-input fallback pins.

## Reviewers

Three subreviewers cleared: `session-reviewer` (METRICS #3 pool-scoped bounded cardinality + sole-writer discipline preserved), `session-component-review` (Part B / Part C boundaries unchanged), `igor-reviewer` (metric-integrity framing correct; naming + fallback pins fine).

## Follow-ups (not in this PR)

- Same change on sessionz-debug (working branch); will port after this lands.
- Java parity check: match Java `SessionPoolInfo.name` format if it diverges.
