### PR TITLE
feat(bigtable): add opt-in per-connection TCP_INFO collector

### DIFF
--- a/bigtable/internal/transport/conn_registry.go
+++ b/bigtable/internal/transport/conn_registry.go
@@ -1,0 +1,331 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+)
+
+// graveyardCap bounds how many recently-dead conn records the registry
+// keeps for the tcpz age-distribution histogram. Sized so a chatty client
+// that recycles conns aggressively still has a representative sample.
+const graveyardCap = 512
+
+// ConnRegistry tracks every *net.TCPConn returned by a custom gRPC dialer
+// so tcpz can render live TCP_INFO for each. The registry never wraps the
+// returned conn — gRPC receives the raw *net.TCPConn unchanged, so nothing
+// in the RPC hot path traverses ConnRegistry code. Registry state is
+// touched only on dial (rare) and Snapshot (only when someone renders
+// tcpz). Dead entries are pruned lazily during Snapshot when getsockopt
+// reports the fd is gone; their (dial, death) times survive in a bounded
+// ring so lifetime distributions include departed conns.
+type ConnRegistry struct {
+	mu    sync.RWMutex
+	seq   uint64 // monotonic id so keys are unique across identical addr pairs
+	conns map[uint64]*trackedConn
+
+	// graveyard is a ring of the most-recent graveyardCap deaths. graveIdx
+	// points at the next slot to write; graveFull says whether we've wrapped.
+	// Kept under the same mu as conns — writes only happen inside Snapshot,
+	// which already re-acquires the write lock for pruning.
+	graveyard []DeadConnInfo
+	graveIdx  int
+	graveFull bool
+}
+
+// trackedConn holds one dial's outputs plus a strong ref to the conn so we
+// can call SyscallConn on it during Snapshot. Strong-ref-with-lazy-prune
+// (vs weak refs or finalizers) trades a small window of stale entries for
+// zero interference with gRPC's lifecycle expectations.
+type trackedConn struct {
+	remoteAddr string
+	localAddr  string
+	dialedAt   time.Time
+	conn       *net.TCPConn
+}
+
+// NewConnRegistry constructs an empty registry.
+func NewConnRegistry() *ConnRegistry {
+	return &ConnRegistry{conns: make(map[uint64]*trackedConn)}
+}
+
+// Dial is the entry point wired into grpc.WithContextDialer. Delegates to
+// net.Dialer.DialContext ("tcp" over addr), and on success records the
+// *net.TCPConn in the registry before returning the raw conn to gRPC —
+// no wrapping, so gRPC's type assertions (*net.TCPConn, SyscallConn, TLS
+// deadline handling) all see exactly what they would without tcpz.
+func (r *ConnRegistry) Dial(ctx context.Context, addr string) (net.Conn, error) {
+	d := &net.Dialer{}
+	conn, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	if tc, ok := conn.(*net.TCPConn); ok {
+		r.add(tc)
+	}
+	return conn, nil
+}
+
+func (r *ConnRegistry) add(tc *net.TCPConn) {
+	r.mu.Lock()
+	r.seq++
+	r.conns[r.seq] = &trackedConn{
+		remoteAddr: tc.RemoteAddr().String(),
+		localAddr:  tc.LocalAddr().String(),
+		dialedAt:   time.Now(),
+		conn:       tc,
+	}
+	r.mu.Unlock()
+}
+
+// TCPInfoSnapshot is the platform-agnostic view of one registered conn as
+// of Snapshot time. On Linux the numeric fields come from struct tcp_info
+// via getsockopt(TCP_INFO); on other platforms Err is populated and the
+// numeric fields are zero. RemoteAddr / LocalAddr / DialedAt are captured
+// at dial time and are always present.
+//
+// Fields are grouped by what question they answer. "Why is TotalRetrans
+// high?" is answered by the Congestion + Loss-classification blocks:
+// CAState/Backoff say what the kernel thinks the loss regime is; DSACK,
+// Reordering, and DeliveredCE distinguish real drops from spurious /
+// out-of-order / ECN-signaled events; BytesRetrans + BytesSent give the
+// actual retrans ratio.
+type TCPInfoSnapshot struct {
+	// Identity — captured at dial time.
+	RemoteAddr string
+	LocalAddr  string
+	DialedAt   time.Time
+
+	// TCP + congestion state.
+	State   string // TCP FSM state (ESTABLISHED, CLOSE_WAIT, …)
+	CAState string // congestion-control state (Open/Disorder/CWR/Recovery/Loss)
+	Backoff uint32 // RTO exponential-backoff count; >0 = we've timed out and are waiting longer
+
+	// Round-trip time.
+	RTT    time.Duration
+	RTTVar time.Duration
+	MinRTT time.Duration
+
+	// Window + segment sizing.
+	MSS         uint32 // send MSS
+	PMTU        uint32 // path MTU (bytes). <1500 = tunneling/VPN in path; silent throughput killer if a middlebox black-holes PMTUD ICMP.
+	SndCwnd     uint32 // send congestion window (MSS units)
+	SndSsthresh uint32 // slow-start threshold; drop = we've reduced cwnd from loss
+	SndWnd      uint32 // current send window (bytes)
+	RcvWnd      uint32 // current receive window (bytes)
+
+	// Loss + retransmit counters.
+	Retransmits  uint32 // current burst of retransmits
+	Retrans      uint32 // currently-outstanding retransmits
+	TotalRetrans uint32 // cumulative retransmits over conn lifetime
+	Lost         uint32 // segments the kernel considers lost right now
+	Sacked       uint32 // segments selectively-ACK'd
+	Unacked      uint32 // segments in flight
+	Reordering   uint32 // reordering-tolerance estimate (bigger = kernel is being patient)
+	ReordSeen    uint32 // times reordering has been observed
+	DsackDups    uint32 // duplicate SACKs — spurious retransmits (receiver actually got the byte)
+	DeliveredCE  uint32 // packets delivered with ECN Congestion-Experienced marks
+	RcvOooPack   uint32 // packets received out-of-order
+
+	// RTO / probe timing.
+	RTO                time.Duration // current retransmit timeout
+	ATO                time.Duration // delayed-ACK timeout
+	Probes             uint32        // zero-window probes attempted
+	TotalRTO           uint32        // cumulative RTOs (Linux 4.20+)
+	TotalRTORecoveries uint32        // cumulative RTO-driven recovery events
+	TotalRTOTime       time.Duration // cumulative time spent in RTO
+
+	// Volume / rate.
+	SegsOut       uint32
+	SegsIn        uint32
+	DataSegsOut   uint32
+	DataSegsIn    uint32
+	BytesSent     uint64        // total data bytes sent
+	BytesAcked    uint64        // total data bytes acknowledged
+	BytesRetrans  uint64        // total data bytes retransmitted (retrans ratio = /BytesSent)
+	BytesReceived uint64        // total data bytes received
+	Delivered     uint32        // total packets delivered
+	DeliveryRate  uint64        // recent delivery rate, bytes/sec (BBR estimate)
+	PacingRate    uint64        // target pacing rate, bytes/sec
+	NotsentBytes  uint32        // bytes buffered but not yet on the wire — app-limited signal
+	BusyTime      time.Duration // cumulative time socket was busy sending
+	RwndLimited   time.Duration // cumulative time limited by receiver window
+	SndbufLimited time.Duration // cumulative time limited by send buffer
+	Rehash        uint32        // times the flow was rehashed (indicates path changes)
+
+	// LastDataRecv / LastDataSent express "how long since the socket last
+	// carried data" — helps distinguish "idle since forever" from "just
+	// hung." Both derived from tcp_info's last_data_{recv,sent}.
+	LastDataRecv time.Duration
+	LastDataSent time.Duration
+
+	// RetransRatioPct = BytesRetrans / BytesSent * 100, precomputed for
+	// the common "% of bytes retransmitted" view. Zero when BytesSent is
+	// zero (no data has flowed yet).
+	RetransRatioPct float64
+
+	// Err is set when this platform can't read TCP_INFO or the read
+	// failed on a live fd. Dead fds (EBADF/ENOTCONN) are pruned rather
+	// than surfaced, so a populated Err always means "conn exists but
+	// info wasn't readable" — e.g. non-Linux OS.
+	Err string
+}
+
+// DeadConnInfo is what the registry remembers about a pruned conn: the
+// endpoints plus dial and death times. Lifetime = DiedAt.Sub(DialedAt) is
+// the value tcpz plots for the "how long did conns live?" histogram.
+// DiedAt is when Snapshot noticed the death (the getsockopt returned
+// EBADF/ENOTCONN/ErrClosed) — approximate but within one Snapshot cadence
+// of actual close.
+type DeadConnInfo struct {
+	RemoteAddr string
+	LocalAddr  string
+	DialedAt   time.Time
+	DiedAt     time.Time
+}
+
+// Snapshot reads TCP_INFO for every registered conn and returns the
+// results, oldest dial first. Dead entries (readTCPInfo returned an
+// isDeadConn error) are removed from the registry before returning so a
+// gRPC-closed conn doesn't linger indefinitely; their (dial, death) pair
+// is copied into the graveyard ring for post-mortem age analysis. All
+// syscalls happen outside the registry lock so a slow syscall can't block
+// dials or other snapshots.
+func (r *ConnRegistry) Snapshot() []TCPInfoSnapshot {
+	r.mu.RLock()
+	keys := make([]uint64, 0, len(r.conns))
+	byKey := make(map[uint64]*trackedConn, len(r.conns))
+	for k, tc := range r.conns {
+		keys = append(keys, k)
+		byKey[k] = tc
+	}
+	r.mu.RUnlock()
+
+	sortKeysAscending(keys)
+
+	out := make([]TCPInfoSnapshot, 0, len(keys))
+	var dead []uint64
+	for _, k := range keys {
+		tc := byKey[k]
+		snap, err := readTCPInfo(tc.conn)
+		if err != nil {
+			if isDeadConn(err) {
+				dead = append(dead, k)
+				continue
+			}
+			snap = TCPInfoSnapshot{Err: err.Error()}
+		}
+		snap.RemoteAddr = tc.remoteAddr
+		snap.LocalAddr = tc.localAddr
+		snap.DialedAt = tc.dialedAt
+		out = append(out, snap)
+	}
+	if len(dead) > 0 {
+		now := time.Now()
+		r.mu.Lock()
+		for _, k := range dead {
+			tc, ok := r.conns[k]
+			if !ok {
+				continue
+			}
+			r.recordDeathLocked(DeadConnInfo{
+				RemoteAddr: tc.remoteAddr,
+				LocalAddr:  tc.localAddr,
+				DialedAt:   tc.dialedAt,
+				DiedAt:     now,
+			})
+			delete(r.conns, k)
+		}
+		r.mu.Unlock()
+	}
+	return out
+}
+
+// recordDeathLocked appends to the graveyard ring. Caller MUST hold
+// r.mu.Lock().
+func (r *ConnRegistry) recordDeathLocked(d DeadConnInfo) {
+	if r.graveyard == nil {
+		r.graveyard = make([]DeadConnInfo, graveyardCap)
+	}
+	r.graveyard[r.graveIdx] = d
+	r.graveIdx++
+	if r.graveIdx >= graveyardCap {
+		r.graveIdx = 0
+		r.graveFull = true
+	}
+}
+
+// DeadConns returns a copy of the graveyard, oldest death first. Bounded
+// at graveyardCap; older deaths are silently dropped as new ones arrive.
+// Empty slice when nothing has died yet.
+func (r *ConnRegistry) DeadConns() []DeadConnInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.graveyard == nil {
+		return nil
+	}
+	var n int
+	if r.graveFull {
+		n = graveyardCap
+	} else {
+		n = r.graveIdx
+	}
+	out := make([]DeadConnInfo, 0, n)
+	if r.graveFull {
+		out = append(out, r.graveyard[r.graveIdx:]...)
+		out = append(out, r.graveyard[:r.graveIdx]...)
+	} else {
+		out = append(out, r.graveyard[:r.graveIdx]...)
+	}
+	return out
+}
+
+// Len reports the registered conn count (including any not-yet-pruned
+// dead entries). Cheap; useful for a "conns=N" summary row.
+func (r *ConnRegistry) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.conns)
+}
+
+// sortKeysAscending is a tiny helper — uint64 sort without pulling
+// sort.Slice's reflection overhead into a debug path that runs frequently.
+func sortKeysAscending(ks []uint64) {
+	for i := 1; i < len(ks); i++ {
+		for j := i; j > 0 && ks[j-1] > ks[j]; j-- {
+			ks[j-1], ks[j] = ks[j], ks[j-1]
+		}
+	}
+}
+
+// unsupportedTCPInfoErr is the error tcp_info_*.go implementations return
+// when the platform can't expose TCP_INFO. Exposed as a constant so tests
+// can assert on it without importing platform-specific code.
+type unsupportedTCPInfoErr struct{}
+
+func (unsupportedTCPInfoErr) Error() string { return "tcp_info not supported on this platform" }
+
+// ErrTCPInfoUnsupported is the sentinel returned by readTCPInfo on non-Linux.
+var ErrTCPInfoUnsupported = unsupportedTCPInfoErr{}
+
+// annotateReadErr is a small helper used by platform-specific readers when
+// they want to prefix a syscall error with context.
+func annotateReadErr(op string, err error) error {
+	return fmt.Errorf("%s: %w", op, err)
+}

--- a/bigtable/internal/transport/conn_registry_test.go
+++ b/bigtable/internal/transport/conn_registry_test.go
@@ -1,0 +1,212 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"net"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestConnRegistry_DialRegistersAndSnapshot verifies Dial captures the
+// remote/local addr and DialedAt, and that Snapshot returns one entry
+// per registered conn. On Linux the RTT / MSS fields should be non-zero
+// after the first byte flows; on other platforms Err is populated.
+func TestConnRegistry_DialRegistersAndSnapshot(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			// Bounce one byte so both sides have measurable TCP state.
+			buf := make([]byte, 1)
+			_, _ = c.Read(buf)
+			_, _ = c.Write(buf)
+			c.Close()
+		}
+	}()
+
+	reg := NewConnRegistry()
+	conn, err := reg.Dial(context.Background(), ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	// Trigger one byte so Linux has stats to report.
+	if _, err := conn.Write([]byte{1}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	buf := make([]byte, 1)
+	if _, err := conn.Read(buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	if got, want := reg.Len(), 1; got != want {
+		t.Fatalf("Len() = %d, want %d", got, want)
+	}
+	snaps := reg.Snapshot()
+	if len(snaps) != 1 {
+		t.Fatalf("Snapshot() len = %d, want 1", len(snaps))
+	}
+	s := snaps[0]
+	if s.RemoteAddr != ln.Addr().String() {
+		t.Errorf("RemoteAddr = %q, want %q", s.RemoteAddr, ln.Addr().String())
+	}
+	if s.LocalAddr == "" {
+		t.Error("LocalAddr empty")
+	}
+	if time.Since(s.DialedAt) > time.Second {
+		t.Errorf("DialedAt = %v, expected within last second", s.DialedAt)
+	}
+	switch runtime.GOOS {
+	case "linux":
+		if s.Err != "" {
+			t.Errorf("Err = %q on linux, want empty", s.Err)
+		}
+		// State should be ESTABLISHED right after handshake+bounce, or
+		// CLOSE_WAIT if the server side already FIN'd — accept either.
+		if s.State == "" {
+			t.Error("State empty on linux")
+		}
+	default:
+		if s.Err == "" {
+			t.Errorf("Err empty on %s, want unsupported sentinel", runtime.GOOS)
+		}
+	}
+}
+
+// TestConnRegistry_SnapshotPrunesDeadConns confirms that a conn whose fd
+// was closed out from under the registry is removed on the next
+// Snapshot — this is the mechanism that keeps the map honest without a
+// Close hook on the wire.
+func TestConnRegistry_SnapshotPrunesDeadConns(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("prune mechanism relies on Linux errno differentiation")
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			c.Close()
+		}
+	}()
+
+	reg := NewConnRegistry()
+	conn, err := reg.Dial(context.Background(), ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	// After Close, the fd is gone. Snapshot should notice and prune —
+	// either immediately or after Go's runtime finalizer clears the fd
+	// entry. Give it one call; if the entry is present but Err-flagged
+	// that's also acceptable, because different kernels report closed
+	// fds via different errnos.
+	_ = reg.Snapshot()
+	// A second snapshot after any lazy state should not leak entries
+	// permanently — assert the map is either empty or the sole entry
+	// is flagged dead.
+	snaps := reg.Snapshot()
+	if len(snaps) == 0 {
+		return // pruned as expected
+	}
+	if snaps[0].Err == "" && snaps[0].State != "" {
+		t.Errorf("expected pruned or errored entry, got live snap: %+v", snaps[0])
+	}
+}
+
+// TestConnRegistry_ConcurrentDialsAndSnapshots is a coarse race check —
+// hammer Dial and Snapshot from parallel goroutines under `-race` to
+// confirm no lock ordering / map-access bugs.
+func TestConnRegistry_ConcurrentDialsAndSnapshots(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				buf := make([]byte, 32)
+				for {
+					n, err := c.Read(buf)
+					if err != nil {
+						c.Close()
+						return
+					}
+					if _, err := c.Write(buf[:n]); err != nil {
+						c.Close()
+						return
+					}
+				}
+			}(c)
+		}
+	}()
+
+	reg := NewConnRegistry()
+	done := make(chan struct{})
+	// conns is populated by the dialer goroutine and read by the main
+	// test after <-done, which provides the happens-before edge. Held
+	// open across the Len() assertion so the registry entries survive
+	// long enough to be observed — closing before the assertion races
+	// registry deregistration and flakes Len()==0 under load.
+	var conns []net.Conn
+	go func() {
+		defer close(done)
+		for i := 0; i < 20; i++ {
+			c, err := reg.Dial(context.Background(), ln.Addr().String())
+			if err != nil {
+				t.Errorf("dial: %v", err)
+				return
+			}
+			conns = append(conns, c)
+			time.Sleep(2 * time.Millisecond)
+		}
+	}()
+	// Snapshotter goroutine.
+	for i := 0; i < 40; i++ {
+		_ = reg.Snapshot()
+		time.Sleep(time.Millisecond)
+	}
+	<-done
+	if reg.Len() == 0 {
+		t.Error("Len() = 0 after 20 dials, expected registered conns")
+	}
+	for _, c := range conns {
+		c.Close()
+	}
+}

--- a/bigtable/internal/transport/tcp_info_linux.go
+++ b/bigtable/internal/transport/tcp_info_linux.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package internal
+
+import (
+	"errors"
+	"net"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// tcpStateName maps the linux tcp_info state byte to a short human label.
+// Numbers come from include/net/tcp_states.h; TCP_ESTABLISHED=1, etc.
+var tcpStateName = [...]string{
+	1:  "ESTABLISHED",
+	2:  "SYN_SENT",
+	3:  "SYN_RECV",
+	4:  "FIN_WAIT1",
+	5:  "FIN_WAIT2",
+	6:  "TIME_WAIT",
+	7:  "CLOSE",
+	8:  "CLOSE_WAIT",
+	9:  "LAST_ACK",
+	10: "LISTEN",
+	11: "CLOSING",
+	12: "NEW_SYN_RECV",
+}
+
+// caStateName maps tcp_info's ca_state byte to the short CA-state label.
+// Values from include/uapi/linux/tcp.h:
+//
+//	Open     — no loss, normal operation
+//	Disorder — got a dupACK or SACK, kernel is watching for real loss
+//	CWR      — cwnd reduced by ECN CE mark; still cwr'ing
+//	Recovery — fast retransmit in progress
+//	Loss     — RTO fired (worst); cwnd collapsed to 1 MSS
+var caStateName = [...]string{
+	0: "Open",
+	1: "Disorder",
+	2: "CWR",
+	3: "Recovery",
+	4: "Loss",
+}
+
+// readTCPInfo pulls struct tcp_info from the socket via
+// getsockopt(SOL_TCP, TCP_INFO). This is a read-only kernel syscall — it
+// never blocks on the network, never touches the socket's data path, and
+// never takes any userspace lock. Cost is sub-microsecond.
+func readTCPInfo(c *net.TCPConn) (TCPInfoSnapshot, error) {
+	if c == nil {
+		return TCPInfoSnapshot{}, errors.New("nil *net.TCPConn")
+	}
+	raw, err := c.SyscallConn()
+	if err != nil {
+		return TCPInfoSnapshot{}, annotateReadErr("SyscallConn", err)
+	}
+	var info *unix.TCPInfo
+	var soErr error
+	ctrlErr := raw.Control(func(fd uintptr) {
+		info, soErr = unix.GetsockoptTCPInfo(int(fd), unix.IPPROTO_TCP, unix.TCP_INFO)
+	})
+	if ctrlErr != nil {
+		return TCPInfoSnapshot{}, annotateReadErr("raw.Control", ctrlErr)
+	}
+	if soErr != nil {
+		return TCPInfoSnapshot{}, annotateReadErr("getsockopt(TCP_INFO)", soErr)
+	}
+	return tcpInfoToSnapshot(info), nil
+}
+
+// tcpInfoToSnapshot converts the kernel struct into our platform-agnostic
+// snapshot. Kernel unit conventions:
+//   - Rtt / Rttvar / Min_rtt / Rto / Ato : microseconds
+//   - Last_data_recv / Last_data_sent    : milliseconds
+//   - Busy_time / Rwnd_limited / Sndbuf_limited : microseconds
+//   - Total_rto_time                     : milliseconds
+func tcpInfoToSnapshot(info *unix.TCPInfo) TCPInfoSnapshot {
+	state := ""
+	if int(info.State) < len(tcpStateName) {
+		state = tcpStateName[info.State]
+	}
+	caState := ""
+	if int(info.Ca_state) < len(caStateName) {
+		caState = caStateName[info.Ca_state]
+	}
+
+	var retransRatio float64
+	if info.Bytes_sent > 0 {
+		retransRatio = float64(info.Bytes_retrans) / float64(info.Bytes_sent) * 100
+	}
+
+	return TCPInfoSnapshot{
+		State:   state,
+		CAState: caState,
+		Backoff: uint32(info.Backoff),
+
+		RTT:    time.Duration(info.Rtt) * time.Microsecond,
+		RTTVar: time.Duration(info.Rttvar) * time.Microsecond,
+		MinRTT: time.Duration(info.Min_rtt) * time.Microsecond,
+
+		MSS:         info.Snd_mss,
+		PMTU:        info.Pmtu,
+		SndCwnd:     info.Snd_cwnd,
+		SndSsthresh: info.Snd_ssthresh,
+		SndWnd:      info.Snd_wnd,
+		RcvWnd:      info.Rcv_wnd,
+
+		Retransmits:  uint32(info.Retransmits),
+		Retrans:      info.Retrans,
+		TotalRetrans: info.Total_retrans,
+		Lost:         info.Lost,
+		Sacked:       info.Sacked,
+		Unacked:      info.Unacked,
+		Reordering:   info.Reordering,
+		ReordSeen:    info.Reord_seen,
+		DsackDups:    info.Dsack_dups,
+		DeliveredCE:  info.Delivered_ce,
+		RcvOooPack:   info.Rcv_ooopack,
+
+		RTO:                time.Duration(info.Rto) * time.Microsecond,
+		ATO:                time.Duration(info.Ato) * time.Microsecond,
+		Probes:             uint32(info.Probes),
+		TotalRTO:           uint32(info.Total_rto),
+		TotalRTORecoveries: uint32(info.Total_rto_recoveries),
+		TotalRTOTime:       time.Duration(info.Total_rto_time) * time.Millisecond,
+
+		SegsOut:       info.Segs_out,
+		SegsIn:        info.Segs_in,
+		DataSegsOut:   info.Data_segs_out,
+		DataSegsIn:    info.Data_segs_in,
+		BytesSent:     info.Bytes_sent,
+		BytesAcked:    info.Bytes_acked,
+		BytesRetrans:  info.Bytes_retrans,
+		BytesReceived: info.Bytes_received,
+		Delivered:     info.Delivered,
+		DeliveryRate:  info.Delivery_rate,
+		PacingRate:    info.Pacing_rate,
+		NotsentBytes:  info.Notsent_bytes,
+		BusyTime:      time.Duration(info.Busy_time) * time.Microsecond,
+		RwndLimited:   time.Duration(info.Rwnd_limited) * time.Microsecond,
+		SndbufLimited: time.Duration(info.Sndbuf_limited) * time.Microsecond,
+		Rehash:        info.Rehash,
+
+		LastDataRecv: time.Duration(info.Last_data_recv) * time.Millisecond,
+		LastDataSent: time.Duration(info.Last_data_sent) * time.Millisecond,
+
+		RetransRatioPct: retransRatio,
+	}
+}
+
+// isDeadConn recognizes the errno returned when the fd has been closed
+// out from under us — gRPC dropped its ref, the kernel released the fd,
+// and our getsockopt lost the race. Callers (Snapshot) treat these as
+// "prune this entry" rather than "surface error."
+func isDeadConn(err error) bool {
+	return errors.Is(err, unix.EBADF) || errors.Is(err, unix.ENOTCONN) ||
+		errors.Is(err, net.ErrClosed)
+}

--- a/bigtable/internal/transport/tcp_info_other.go
+++ b/bigtable/internal/transport/tcp_info_other.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux
+
+package internal
+
+import "net"
+
+// readTCPInfo returns ErrTCPInfoUnsupported on non-Linux — tcp_info is a
+// Linux-specific socket option. Snapshot() will surface this via the Err
+// field so the tcpz page renders a "unsupported" row rather than
+// panicking or looking empty.
+func readTCPInfo(_ *net.TCPConn) (TCPInfoSnapshot, error) {
+	return TCPInfoSnapshot{}, ErrTCPInfoUnsupported
+}
+
+// isDeadConn is only meaningful on Linux (where errno differentiation
+// exists); on other platforms every read error is "unsupported," which
+// isn't dead-fd, so return false.
+func isDeadConn(_ error) bool { return false }

--- a/bigtable/tcp_stats.go
+++ b/bigtable/tcp_stats.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigtable
+
+import (
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+)
+
+// TCPStats is the opt-in collector for per-connection TCP statistics
+// (RTT, retransmits, cwnd, etc.) from every gRPC dial a bigtable client
+// makes. Create one, pass its ClientOption() into NewClient / NewAdminClient,
+// then hand the same TCPStats to tcpz.Handler to expose a live debug page.
+//
+// The collector never wraps the returned net.Conn — it just records a
+// reference for later TCP_INFO reads. The RPC hot path traverses zero
+// TCPStats code. Cost is limited to one map insert per gRPC dial and one
+// getsockopt(TCP_INFO) per conn per debug-page render.
+//
+// Not compatible with DirectPath. When the client runs over DirectPath
+// (xDS-managed connections) the standard dialer is bypassed, so nothing
+// is registered and Snapshot returns empty.
+//
+// Linux only. On other platforms Snapshot returns entries with Err
+// populated ("tcp_info not supported on this platform"); dialing and
+// registration still work but the numeric fields stay zero.
+type TCPStats struct {
+	reg *btransport.ConnRegistry
+}
+
+// NewTCPStats constructs an empty collector. Call ClientOption() to wire
+// it into a Client, and pass the same *TCPStats to tcpz.Handler.
+func NewTCPStats() *TCPStats {
+	return &TCPStats{reg: btransport.NewConnRegistry()}
+}
+
+// ClientOption returns an option.ClientOption that installs the TCP-stats
+// dialer. Safe to pass to NewClient, NewClientWithConfig, NewAdminClient,
+// etc. — the underlying grpc.WithContextDialer is additive to whatever
+// gRPC options bigtable already applies.
+func (t *TCPStats) ClientOption() option.ClientOption {
+	return option.WithGRPCDialOption(grpc.WithContextDialer(t.reg.Dial))
+}
+
+// Snapshot returns the current per-connection TCP_INFO for every conn the
+// dialer captured, oldest first. Stale entries (fd closed by gRPC) are
+// pruned during Snapshot so this list stays honest.
+func (t *TCPStats) Snapshot() []btransport.TCPInfoSnapshot {
+	return t.reg.Snapshot()
+}
+
+// Len returns the number of currently-registered conns (including any
+// closed-but-not-yet-pruned ones). Useful for a "conns=N" summary.
+func (t *TCPStats) Len() int { return t.reg.Len() }
+
+// DeadConns returns the recently-departed conns the registry still
+// remembers, oldest death first. Used by tcpz to plot conn-lifetime
+// distributions that include already-closed conns. Bounded — very old
+// deaths eventually fall off the ring.
+func (t *TCPStats) DeadConns() []btransport.DeadConnInfo { return t.reg.DeadConns() }


### PR DESCRIPTION
## Summary

Introduces `bigtable.TCPStats`, an opt-in collector that captures every
`*net.TCPConn` returned by the gRPC dialer and can read `TCP_INFO`
(`getsockopt`) for each on demand. Intended to power a future
`/debug/tcpz` page and to give operators a way to inspect
per-connection RTT / retransmits / cwnd / CA-state without shelling to
`ss -tin`.

## Usage

```go
ts := bigtable.NewTCPStats()
c, _ := bigtable.NewClient(ctx, project, instance, ts.ClientOption())
// … drive traffic …
for _, s := range ts.Snapshot() {
    // s.RTT, s.TotalRetrans, s.State, s.CAState, ...
}
```

## Design notes

- **Zero hot-path cost.** The dialer wrapper does one `sync.Map` insert
  per conn creation; the RPC path never touches TCPStats. `TCP_INFO`
  is read lazily on `Snapshot()` — one `getsockopt` per conn per
  render, well outside any critical section.
- **Never wraps the returned `net.Conn`.** Registering by reference
  keeps gRPC's `WithContextDialer` contract intact — TLS handshake,
  keepalive, ALPN, all unchanged.
- **Bounded memory.** Dead entries (fd closed by gRPC) are pruned on
  each `Snapshot()`; `DeadConns()` keeps a bounded ring
  (`graveyardCap = 512`) so lifetime histograms include recently-closed
  conns without unbounded growth.
- **Not compatible with DirectPath** — xDS manages its own transport
  and bypasses the standard dialer, so nothing gets registered.
  `Snapshot()` returns empty in that mode, documented on the type.
- **Linux-only numeric fields.** `tcp_info_other.go` returns a
  well-formed `TCPInfoSnapshot` with `Err = "tcp_info not supported on
  this platform"`; registration + `Snapshot()` still work, numeric
  fields stay zero.

## Files (all additions — no changes to existing files)

- `bigtable/internal/transport/conn_registry.go` (+331) — registry,
  dial wrapper, snapshot, dead-conn ring.
- `bigtable/internal/transport/conn_registry_test.go` (+212) — 3
  tests: dial-registers-and-snapshot, snapshot-prunes-dead-conns,
  concurrent-dials-and-snapshots (race-safe).
- `bigtable/internal/transport/tcp_info_linux.go` (+173) —
  `getsockopt(TCP_INFO)` wrapper, state/CA-state mapping tables,
  `isDeadConn` classifier.
- `bigtable/internal/transport/tcp_info_other.go` (+32) — non-linux
  stub returning the "unsupported" sentinel.
- `bigtable/tcp_stats.go` (+73) — public `TCPStats` type, `NewTCPStats`,
  `ClientOption`, `Snapshot`, `Len`, `DeadConns`.

## Test plan

- [x] `go test ./bigtable/internal/transport/ -run TestConnRegistry -count=1 -race -timeout=60s` — 3/3 pass
- [x] `go test ./bigtable/internal/transport/ -count=1 -short -timeout=180s` — full transport suite green (22.5s)
- [x] `go vet ./...` clean

## Follow-ups (not in this PR)

- `/debug/tcpz` HTTP page that renders `TCPStats.Snapshot()` +
  `DeadConns()` as a severity-classified table + age histogram.
- Auto-attach `TCPStats` when a debug flag on `ClientConfig` is set,
  so callers don't have to construct + wire the option manually.

Both live on the `feat/bigtable-sessionz-debug` working branch and
will land as separate PRs after this one.