### PR TITLE
feat(bigtable): add protoRowToRow conversion helper for TableShim

### DIFF
--- a/bigtable/table_shim.go
+++ b/bigtable/table_shim.go
@@ -17,6 +17,7 @@ package bigtable
 import (
 	"context"
 
+	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
 	internal "cloud.google.com/go/bigtable/internal/transport"
 )
 
@@ -70,4 +71,52 @@ func (t *TableShim) ApplyBulk(ctx context.Context, rowKeys []string, muts []*Mut
 // ApplyReadModifyWrite implements TableAPI. It delegates to classic.
 func (t *TableShim) ApplyReadModifyWrite(ctx context.Context, row string, m *ReadModifyWrite) (Row, error) {
 	return t.classic.ApplyReadModifyWrite(ctx, row, m)
+}
+
+// protoRowToRow converts a proto Row (the wire shape returned by a
+// proto-native session backend's SessionReadRowResponse) into the
+// classic bigtable.Row map shape that TableAPI.ReadRow callers expect.
+//
+// Staged here so the follow-up change that swaps TableShim.session for a
+// proto-native backend can call this without also introducing the
+// conversion contract; the test suite pins every branch of that
+// contract today (see TestProtoRowToRow).
+//
+// Contract: preserves wire order for cells within a column and columns
+// within a family; a row with no cells (or nil input) returns nil to
+// match classic Table.ReadRow's row-not-found signal — callers check
+// `row == nil`. Same-named families that appear twice in Families are
+// appended, not deduped, matching the server's wire format.
+func protoRowToRow(pr *btpb.Row) Row {
+	if pr == nil {
+		return nil
+	}
+	rowMap := make(Row)
+	rowKey := string(pr.Key)
+	for _, fam := range pr.Families {
+		familyName := fam.Name
+		for _, col := range fam.Columns {
+			columnName := familyName + ":" + string(col.Qualifier)
+			var items []ReadItem
+			for _, cell := range col.Cells {
+				items = append(items, ReadItem{
+					Row:       rowKey,
+					Column:    columnName,
+					Timestamp: Timestamp(cell.TimestampMicros),
+					Value:     cell.Value,
+					Labels:    cell.Labels,
+				})
+			}
+			if len(items) > 0 {
+				rowMap[familyName] = append(rowMap[familyName], items...)
+			}
+		}
+	}
+	// Match classic Table.ReadRow: a row with no cells is a not-found
+	// signal; callers check `row == nil`. Server should send pr=nil for
+	// not-found, but defensively collapse the empty-but-non-nil case too.
+	if len(rowMap) == 0 {
+		return nil
+	}
+	return rowMap
 }

--- a/bigtable/table_shim_test.go
+++ b/bigtable/table_shim_test.go
@@ -17,8 +17,10 @@ package bigtable
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
+	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
 	internal "cloud.google.com/go/bigtable/internal/transport"
 )
 
@@ -353,5 +355,118 @@ func TestTableShim_DelegatedMethods(t *testing.T) {
 	_, _ = shim.ApplyReadModifyWrite(context.Background(), "row1", nil)
 	if !classicCalled || sessionCalled {
 		t.Errorf("ApplyReadModifyWrite: expected classic called: %v, session called: %v", classicCalled, sessionCalled)
+	}
+}
+
+// TestProtoRowToRow pins the wire-shape → Row-map conversion contract
+// against every branch in protoRowToRow, including the "no cells → nil"
+// contract that matches classic Table.ReadRow (row-not-found is nil, not
+// empty map — callers rely on `row == nil` for the not-found check).
+func TestProtoRowToRow(t *testing.T) {
+	cell := func(ts int64, v string, labels ...string) *btpb.Cell {
+		return &btpb.Cell{TimestampMicros: ts, Value: []byte(v), Labels: labels}
+	}
+	col := func(q string, cells ...*btpb.Cell) *btpb.Column {
+		return &btpb.Column{Qualifier: []byte(q), Cells: cells}
+	}
+	fam := func(name string, cols ...*btpb.Column) *btpb.Family {
+		return &btpb.Family{Name: name, Columns: cols}
+	}
+	row := func(key string, fams ...*btpb.Family) *btpb.Row {
+		return &btpb.Row{Key: []byte(key), Families: fams}
+	}
+
+	cases := []struct {
+		name string
+		in   *btpb.Row
+		want Row
+	}{
+		{
+			name: "nil input returns nil",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "empty Families returns nil (matches classic not-found)",
+			in:   row("k"),
+			want: nil,
+		},
+		{
+			name: "family with no columns returns nil",
+			in:   row("k", fam("cf")),
+			want: nil,
+		},
+		{
+			name: "column with zero cells is skipped (family drops out entirely)",
+			in:   row("k", fam("cf", col("q"))),
+			want: nil,
+		},
+		{
+			name: "single family/column/cell — happy path",
+			in:   row("k", fam("cf", col("q", cell(1000, "v")))),
+			want: Row{"cf": []ReadItem{{Row: "k", Column: "cf:q", Timestamp: 1000, Value: []byte("v")}}},
+		},
+		{
+			name: "multiple cells per column preserves order (versioning)",
+			in:   row("k", fam("cf", col("q", cell(3000, "v3"), cell(2000, "v2"), cell(1000, "v1")))),
+			want: Row{"cf": []ReadItem{
+				{Row: "k", Column: "cf:q", Timestamp: 3000, Value: []byte("v3")},
+				{Row: "k", Column: "cf:q", Timestamp: 2000, Value: []byte("v2")},
+				{Row: "k", Column: "cf:q", Timestamp: 1000, Value: []byte("v1")},
+			}},
+		},
+		{
+			name: "multiple columns per family concatenate into same map key in wire order",
+			in:   row("k", fam("cf", col("qA", cell(1, "vA")), col("qB", cell(2, "vB")))),
+			want: Row{"cf": []ReadItem{
+				{Row: "k", Column: "cf:qA", Timestamp: 1, Value: []byte("vA")},
+				{Row: "k", Column: "cf:qB", Timestamp: 2, Value: []byte("vB")},
+			}},
+		},
+		{
+			name: "multiple families land as separate map keys",
+			in:   row("k", fam("cfA", col("q", cell(1, "vA"))), fam("cfB", col("q", cell(2, "vB")))),
+			want: Row{
+				"cfA": []ReadItem{{Row: "k", Column: "cfA:q", Timestamp: 1, Value: []byte("vA")}},
+				"cfB": []ReadItem{{Row: "k", Column: "cfB:q", Timestamp: 2, Value: []byte("vB")}},
+			},
+		},
+		{
+			name: "same family name appearing twice in Families is appended (wire-preserving, no dedup)",
+			in:   row("k", fam("cf", col("qA", cell(1, "vA"))), fam("cf", col("qB", cell(2, "vB")))),
+			want: Row{"cf": []ReadItem{
+				{Row: "k", Column: "cf:qA", Timestamp: 1, Value: []byte("vA")},
+				{Row: "k", Column: "cf:qB", Timestamp: 2, Value: []byte("vB")},
+			}},
+		},
+		{
+			name: "Labels propagate through to ReadItem",
+			in:   row("k", fam("cf", col("q", cell(1000, "v", "L1", "L2")))),
+			want: Row{"cf": []ReadItem{{Row: "k", Column: "cf:q", Timestamp: 1000, Value: []byte("v"), Labels: []string{"L1", "L2"}}}},
+		},
+		{
+			name: "TimestampMicros=0 preserved (server-set-to-now semantic is caller's job)",
+			in:   row("k", fam("cf", col("q", cell(0, "v")))),
+			want: Row{"cf": []ReadItem{{Row: "k", Column: "cf:q", Timestamp: 0, Value: []byte("v")}}},
+		},
+		{
+			name: "empty qualifier produces column name \"cf:\"",
+			in:   row("k", fam("cf", col("", cell(1000, "v")))),
+			want: Row{"cf": []ReadItem{{Row: "k", Column: "cf:", Timestamp: 1000, Value: []byte("v")}}},
+		},
+		{
+			name: "empty Value ([]byte{}) preserved",
+			in:   row("k", fam("cf", col("q", cell(1000, "")))),
+			want: Row{"cf": []ReadItem{{Row: "k", Column: "cf:q", Timestamp: 1000, Value: []byte("")}}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := protoRowToRow(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("protoRowToRow(%+v)\n got  = %#v\n want = %#v", tc.in, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Adds an unexported `protoRowToRow(*btpb.Row) Row` helper to
`table_shim.go` plus a 13-case `TestProtoRowToRow` that pins the
wire-shape → `Row`-map conversion contract.

Staged for the follow-up change that swaps `TableShim.session` for a
proto-native session backend whose `SessionReadRowResponse` carries a
`*btpb.Row` rather than the already-converted `bigtable.Row`. Keeping
the converter + its tests in a separate patch means the follow-up
introduces exactly one new call site — the conversion itself is already
reviewed and pinned by tests.

## Contract pinned by the test cases

| Case | Expected |
|---|---|
| nil input | nil |
| empty `Families` | nil (matches classic not-found) |
| family with no columns | nil |
| column with zero cells | family drops out entirely → nil |
| single family/column/cell | happy path → correct `Row` |
| multiple cells per column | preserves wire order (versioning) |
| multiple columns per family | concatenate into same map key in wire order |
| multiple families | separate map keys |
| same family name twice in `Families` | appended, not deduped |
| Labels | propagate through to `ReadItem` |
| `TimestampMicros = 0` | preserved |
| empty qualifier | column name is \"cf:\" |
| empty `Value` (`[]byte{}`) | preserved |

The nil-on-empty behavior matches classic `Table.ReadRow`'s row-not-found
signal — callers rely on `row == nil` for the not-found check, so
returning an empty-but-non-nil `Row` would be a subtle contract break.

## Files

- `bigtable/table_shim.go` — `protoRowToRow` helper (+49 LOC, unused in this patch)
- `bigtable/table_shim_test.go` — `TestProtoRowToRow` (+115 LOC, 13 subtests)

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./bigtable/ -run 'TestProtoRowToRow|TestTableShim' -count=1 -v` — 13/13 subtests pass