### PR TITLE
refactor(bigtable): TableShim adopts proto-native session TableAPI

### DIFF
--- a/bigtable/table_shim.go
+++ b/bigtable/table_shim.go
@@ -18,75 +18,119 @@ import (
 	"context"
 
 	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
-	internal "cloud.google.com/go/bigtable/internal/transport"
+	"cloud.google.com/go/bigtable/internal/session"
+	btransport "cloud.google.com/go/bigtable/internal/transport"
 )
 
-// TableShim wraps a classic and a session-based TableAPI and diverts traffic between them.
+// TableShim implements TableAPI by routing between a classic gRPC
+// data-plane and a proto-native session data-plane
+// (session.TableAPI). Traffic direction is decided per-call by
+// the Diverter's SessionLoad ratio. TableShim owns the proto ↔
+// bigtable.Row conversion so the session package can stay proto-native.
+//
+// Methods with no session equivalent (ReadRows, SampleRowKeys,
+// ApplyBulk, ApplyReadModifyWrite) always delegate to classic.
+// Conditional mutations always route to classic — session vRPC does
+// not support the CheckAndMutateRow shape today.
 type TableShim struct {
 	classic  TableAPI
-	session  TableAPI
-	diverter *internal.Diverter
+	session  session.TableAPI
+	diverter *btransport.Diverter
 }
 
-// NewTableShim creates a new TableShim.
-func NewTableShim(classic, session TableAPI, diverter *internal.Diverter) TableAPI {
+// NewTableShim wraps a classic TableAPI + a proto-native session API
+// with a Diverter-gated router. Any of session or diverter may be nil,
+// in which case the shim behaves like classic-only.
+func NewTableShim(classic TableAPI, sessionAPI session.TableAPI, diverter *btransport.Diverter) TableAPI {
 	return &TableShim{
 		classic:  classic,
-		session:  session,
+		session:  sessionAPI,
 		diverter: diverter,
 	}
 }
 
-// ReadRow implements TableAPI.
+// ReadRow implements TableAPI. Routes through the session path when
+// the diverter allows and the session API is available; otherwise
+// delegates to classic. On the session path, translates
+// (row, opts) → SessionReadRowRequest, then translates the response
+// back via protoRowToRow. WithFullReadStats callbacks fire from here.
 func (t *TableShim) ReadRow(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
-	if t.diverter.UseSession() {
-		return t.session.ReadRow(ctx, row, opts...)
+	if !t.useSession() {
+		return t.classic.ReadRow(ctx, row, opts...)
 	}
-	return t.classic.ReadRow(ctx, row, opts...)
+	// Parse opts using the classic settings shape so filter + full-read
+	// stats callback plumbing stays in one place.
+	tmpReq := &btpb.ReadRowsRequest{}
+	settings := makeReadSettings(tmpReq, 0)
+	for _, opt := range opts {
+		opt.set(&settings)
+	}
+	req := &btpb.SessionReadRowRequest{
+		Key:    []byte(row),
+		Filter: tmpReq.Filter,
+	}
+	resp, err := t.session.ReadRow(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.GetStats() != nil && settings.fullReadStatsFunc != nil {
+		stats := makeFullReadStats(resp.GetStats())
+		settings.fullReadStatsFunc(&stats)
+	}
+	return protoRowToRow(resp.GetRow()), nil
 }
 
-// Apply implements TableAPI.
+// Apply implements TableAPI. Non-conditional mutations may route
+// through the session path (subject to the diverter); conditional
+// mutations always go to classic — CheckAndMutateRow has no session
+// equivalent.
 func (t *TableShim) Apply(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
-	if t.diverter.UseSession() {
-		return t.session.Apply(ctx, row, m, opts...)
+	if m != nil && m.isConditional {
+		return t.classic.Apply(ctx, row, m, opts...)
 	}
-	return t.classic.Apply(ctx, row, m, opts...)
+	if !t.useSession() {
+		return t.classic.Apply(ctx, row, m, opts...)
+	}
+	req := &btpb.SessionMutateRowRequest{
+		Key:       []byte(row),
+		Mutations: m.ops,
+	}
+	if _, err := t.session.MutateRow(ctx, req); err != nil {
+		return err
+	}
+	return nil
 }
 
-// ReadRows implements TableAPI. It delegates to classic as session support is not yet implemented.
+// ReadRows delegates to classic — session support is not implemented.
 func (t *TableShim) ReadRows(ctx context.Context, arg RowSet, f func(Row) bool, opts ...ReadOption) error {
 	return t.classic.ReadRows(ctx, arg, f, opts...)
 }
 
-// SampleRowKeys implements TableAPI. It delegates to classic.
+// SampleRowKeys delegates to classic.
 func (t *TableShim) SampleRowKeys(ctx context.Context) ([]string, error) {
 	return t.classic.SampleRowKeys(ctx)
 }
 
-// ApplyBulk implements TableAPI. It delegates to classic.
+// ApplyBulk delegates to classic.
 func (t *TableShim) ApplyBulk(ctx context.Context, rowKeys []string, muts []*Mutation, opts ...ApplyOption) ([]error, error) {
 	return t.classic.ApplyBulk(ctx, rowKeys, muts, opts...)
 }
 
-// ApplyReadModifyWrite implements TableAPI. It delegates to classic.
+// ApplyReadModifyWrite delegates to classic.
 func (t *TableShim) ApplyReadModifyWrite(ctx context.Context, row string, m *ReadModifyWrite) (Row, error) {
 	return t.classic.ApplyReadModifyWrite(ctx, row, m)
 }
 
-// protoRowToRow converts a proto Row (the wire shape returned by a
-// proto-native session backend's SessionReadRowResponse) into the
-// classic bigtable.Row map shape that TableAPI.ReadRow callers expect.
-//
-// Staged here so the follow-up change that swaps TableShim.session for a
-// proto-native backend can call this without also introducing the
-// conversion contract; the test suite pins every branch of that
-// contract today (see TestProtoRowToRow).
-//
-// Contract: preserves wire order for cells within a column and columns
-// within a family; a row with no cells (or nil input) returns nil to
-// match classic Table.ReadRow's row-not-found signal — callers check
-// `row == nil`. Same-named families that appear twice in Families are
-// appended, not deduped, matching the server's wire format.
+// useSession returns true when both a session API and diverter are
+// configured AND the diverter says this call should go over session.
+func (t *TableShim) useSession() bool {
+	return t.session != nil && t.diverter != nil && t.diverter.UseSession()
+}
+
+// protoRowToRow converts a proto Row (the wire shape returned by the
+// session-path SessionReadRowResponse) into the classic bigtable.Row
+// map shape that TableAPI.ReadRow callers expect. Moved from the
+// deleted session_table.go — the shim is the only consumer.
 func protoRowToRow(pr *btpb.Row) Row {
 	if pr == nil {
 		return nil

--- a/bigtable/table_shim.go
+++ b/bigtable/table_shim.go
@@ -58,8 +58,21 @@ func (t *TableShim) ReadRow(ctx context.Context, row string, opts ...ReadOption)
 	if !t.useSession() {
 		return t.classic.ReadRow(ctx, row, opts...)
 	}
-	// Parse opts using the classic settings shape so filter + full-read
-	// stats callback plumbing stays in one place.
+	// Parse opts through the classic settings shape so every existing
+	// ReadOption (RowFilter, WithFullReadStats, etc.) works on the
+	// session path without per-option branching here.
+	//
+	// How tmpReq.Filter gets populated:
+	//   readSettings.req is a *pointer* to tmpReq (see makeReadSettings),
+	//   so when a rowFilter option runs `settings.req.Filter = f.proto()`
+	//   the write lands in tmpReq. We then copy that value into the
+	//   session request below.
+	//
+	// Options that mutate fields absent from SessionReadRowRequest
+	// (e.g. LimitRows → RowsLimit) are silently ignored on the session
+	// path. That's fine for ReadRow since it's single-row by construction,
+	// but a future option specific to session reads would need to be
+	// read straight off `settings` rather than tmpReq.
 	tmpReq := &btpb.ReadRowsRequest{}
 	settings := makeReadSettings(tmpReq, 0)
 	for _, opt := range opts {

--- a/bigtable/table_shim.go
+++ b/bigtable/table_shim.go
@@ -83,9 +83,11 @@ func (t *TableShim) ReadRow(ctx context.Context, row string, opts ...ReadOption)
 // Apply implements TableAPI. Non-conditional mutations may route
 // through the session path (subject to the diverter); conditional
 // mutations always go to classic — CheckAndMutateRow has no session
-// equivalent.
+// equivalent. Nil mutations also route to classic so the classic
+// client's nil-handling error surfaces exactly as it always has,
+// rather than panicking here on m.ops.
 func (t *TableShim) Apply(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
-	if m != nil && m.isConditional {
+	if m == nil || m.isConditional {
 		return t.classic.Apply(ctx, row, m, opts...)
 	}
 	if !t.useSession() {
@@ -127,10 +129,16 @@ func (t *TableShim) useSession() bool {
 	return t.session != nil && t.diverter != nil && t.diverter.UseSession()
 }
 
-// protoRowToRow converts a proto Row (the wire shape returned by the
-// session-path SessionReadRowResponse) into the classic bigtable.Row
-// map shape that TableAPI.ReadRow callers expect. Moved from the
-// deleted session_table.go — the shim is the only consumer.
+// protoRowToRow converts a proto Row (the wire shape returned by a
+// proto-native session backend's SessionReadRowResponse) into the
+// classic bigtable.Row map shape that TableAPI.ReadRow callers expect.
+//
+// Contract: preserves wire order for cells within a column and columns
+// within a family; a row with no cells (or nil input) returns nil to
+// match classic Table.ReadRow's row-not-found signal — callers check
+// `row == nil`. Same-named families that appear twice in Families are
+// appended, not deduped, matching the server's wire format. Test suite
+// (TestProtoRowToRow) pins every branch of this contract.
 func protoRowToRow(pr *btpb.Row) Row {
 	if pr == nil {
 		return nil

--- a/bigtable/table_shim.go
+++ b/bigtable/table_shim.go
@@ -58,21 +58,8 @@ func (t *TableShim) ReadRow(ctx context.Context, row string, opts ...ReadOption)
 	if !t.useSession() {
 		return t.classic.ReadRow(ctx, row, opts...)
 	}
-	// Parse opts through the classic settings shape so every existing
-	// ReadOption (RowFilter, WithFullReadStats, etc.) works on the
-	// session path without per-option branching here.
-	//
-	// How tmpReq.Filter gets populated:
-	//   readSettings.req is a *pointer* to tmpReq (see makeReadSettings),
-	//   so when a rowFilter option runs `settings.req.Filter = f.proto()`
-	//   the write lands in tmpReq. We then copy that value into the
-	//   session request below.
-	//
-	// Options that mutate fields absent from SessionReadRowRequest
-	// (e.g. LimitRows → RowsLimit) are silently ignored on the session
-	// path. That's fine for ReadRow since it's single-row by construction,
-	// but a future option specific to session reads would need to be
-	// read straight off `settings` rather than tmpReq.
+	// Parse opts using the classic settings shape so filter + full-read
+	// stats callback plumbing stays in one place.
 	tmpReq := &btpb.ReadRowsRequest{}
 	settings := makeReadSettings(tmpReq, 0)
 	for _, opt := range opts {

--- a/bigtable/table_shim_test.go
+++ b/bigtable/table_shim_test.go
@@ -21,340 +21,367 @@ import (
 	"testing"
 
 	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
-	internal "cloud.google.com/go/bigtable/internal/transport"
+	btransport "cloud.google.com/go/bigtable/internal/transport"
 )
 
-type mockTableAPI struct {
-	readRowFunc              func(ctx context.Context, row string, opts ...ReadOption) (Row, error)
-	applyFunc                func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error
-	readRowsFunc             func(ctx context.Context, arg RowSet, f func(Row) bool, opts ...ReadOption) error
-	sampleRowKeysFunc        func(ctx context.Context) ([]string, error)
-	applyBulkFunc            func(ctx context.Context, rowKeys []string, muts []*Mutation, opts ...ApplyOption) ([]error, error)
-	applyReadModifyWriteFunc func(ctx context.Context, row string, m *ReadModifyWrite) (Row, error)
+// mockClassicTable stands in for a classic TableAPI (bigtable.Table
+// wrapped in tableImpl). Records which method fired and forwards to
+// per-method funcs.
+type mockClassicTable struct {
+	readRowFn   func(ctx context.Context, row string, opts ...ReadOption) (Row, error)
+	applyFn     func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error
+	readRowsFn  func(ctx context.Context, arg RowSet, f func(Row) bool, opts ...ReadOption) error
+	sampleFn    func(ctx context.Context) ([]string, error)
+	applyBulkFn func(ctx context.Context, rowKeys []string, muts []*Mutation, opts ...ApplyOption) ([]error, error)
+	rmwFn       func(ctx context.Context, row string, m *ReadModifyWrite) (Row, error)
+
+	readRowCalls int
+	applyCalls   int
 }
 
-func (m *mockTableAPI) ReadRows(ctx context.Context, arg RowSet, f func(Row) bool, opts ...ReadOption) error {
-	if m.readRowsFunc != nil {
-		return m.readRowsFunc(ctx, arg, f, opts...)
+func (m *mockClassicTable) ReadRow(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+	m.readRowCalls++
+	if m.readRowFn != nil {
+		return m.readRowFn(ctx, row, opts...)
+	}
+	return Row{"fam": []ReadItem{{Row: row}}}, nil
+}
+func (m *mockClassicTable) Apply(ctx context.Context, row string, mut *Mutation, opts ...ApplyOption) error {
+	m.applyCalls++
+	if m.applyFn != nil {
+		return m.applyFn(ctx, row, mut, opts...)
 	}
 	return nil
 }
-
-func (m *mockTableAPI) ReadRow(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
-	if m.readRowFunc != nil {
-		return m.readRowFunc(ctx, row, opts...)
-	}
-	return nil, nil
-}
-
-func (m *mockTableAPI) SampleRowKeys(ctx context.Context) ([]string, error) {
-	if m.sampleRowKeysFunc != nil {
-		return m.sampleRowKeysFunc(ctx)
-	}
-	return nil, nil
-}
-
-func (m *mockTableAPI) Apply(ctx context.Context, row string, mutation *Mutation, opts ...ApplyOption) error {
-	if m.applyFunc != nil {
-		return m.applyFunc(ctx, row, mutation, opts...)
+func (m *mockClassicTable) ReadRows(ctx context.Context, arg RowSet, f func(Row) bool, opts ...ReadOption) error {
+	if m.readRowsFn != nil {
+		return m.readRowsFn(ctx, arg, f, opts...)
 	}
 	return nil
 }
-
-func (m *mockTableAPI) ApplyBulk(ctx context.Context, rowKeys []string, muts []*Mutation, opts ...ApplyOption) ([]error, error) {
-	if m.applyBulkFunc != nil {
-		return m.applyBulkFunc(ctx, rowKeys, muts, opts...)
+func (m *mockClassicTable) SampleRowKeys(ctx context.Context) ([]string, error) {
+	if m.sampleFn != nil {
+		return m.sampleFn(ctx)
+	}
+	return nil, nil
+}
+func (m *mockClassicTable) ApplyBulk(ctx context.Context, rowKeys []string, muts []*Mutation, opts ...ApplyOption) ([]error, error) {
+	if m.applyBulkFn != nil {
+		return m.applyBulkFn(ctx, rowKeys, muts, opts...)
+	}
+	return nil, nil
+}
+func (m *mockClassicTable) ApplyReadModifyWrite(ctx context.Context, row string, mut *ReadModifyWrite) (Row, error) {
+	if m.rmwFn != nil {
+		return m.rmwFn(ctx, row, mut)
 	}
 	return nil, nil
 }
 
-func (m *mockTableAPI) ApplyReadModifyWrite(ctx context.Context, row string, rmw *ReadModifyWrite) (Row, error) {
-	if m.applyReadModifyWriteFunc != nil {
-		return m.applyReadModifyWriteFunc(ctx, row, rmw)
+// mockSessionTable is the proto-native session-side mock. Records
+// which method fired and returns programmable responses.
+type mockSessionTable struct {
+	readRowFn   func(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error)
+	mutateRowFn func(ctx context.Context, req *btpb.SessionMutateRowRequest) (*btpb.SessionMutateRowResponse, error)
+
+	readRowCalls   int
+	mutateRowCalls int
+}
+
+func (m *mockSessionTable) ReadRow(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
+	m.readRowCalls++
+	if m.readRowFn != nil {
+		return m.readRowFn(ctx, req)
 	}
-	return nil, nil
+	// Return a proto Row with one cell so protoRowToRow produces a
+	// non-empty map (Row.Key() reads from the first ReadItem's Row
+	// field, not from proto.Key).
+	return &btpb.SessionReadRowResponse{Row: &btpb.Row{
+		Key: req.GetKey(),
+		Families: []*btpb.Family{{
+			Name: "fam",
+			Columns: []*btpb.Column{{
+				Qualifier: []byte("q"),
+				Cells:     []*btpb.Cell{{Value: []byte("v")}},
+			}},
+		}},
+	}}, nil
 }
+func (m *mockSessionTable) MutateRow(ctx context.Context, req *btpb.SessionMutateRowRequest) (*btpb.SessionMutateRowResponse, error) {
+	m.mutateRowCalls++
+	if m.mutateRowFn != nil {
+		return m.mutateRowFn(ctx, req)
+	}
+	return &btpb.SessionMutateRowResponse{}, nil
+}
+func (m *mockSessionTable) Close() error { return nil }
 
-func TestTableShim_ReadRow(t *testing.T) {
-	dummyRow := Row{"fam": []ReadItem{{Row: "row1"}}}
-	dummyErr := errors.New("dummy error")
+// TestTableShim_ReadRow_RoutesByDiverter verifies the diverter gates
+// classic vs session routing on ReadRow.
+func TestTableShim_ReadRow_RoutesByDiverter(t *testing.T) {
+	t.Run("classic when SessionLoad=0.0", func(t *testing.T) {
+		classic := &mockClassicTable{}
+		session := &mockSessionTable{}
+		shim := NewTableShim(classic, session, btransport.NewDiverter(0.0))
 
-	t.Run("Classic only when UseSession is false", func(t *testing.T) {
-		classicCalled := false
-		sessionCalled := false
-
-		classic := &mockTableAPI{
-			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
-				classicCalled = true
-				return dummyRow, nil
-			},
-		}
-		session := &mockTableAPI{
-			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
-				sessionCalled = true
-				return nil, dummyErr
-			},
-		}
-
-		diverter := internal.NewDiverter(0.0) // 0% load
-		shim := NewTableShim(classic, session, diverter)
-
-		res, err := shim.ReadRow(context.Background(), "row1")
+		row, err := shim.ReadRow(context.Background(), "r1")
 		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
+			t.Fatalf("unexpected err: %v", err)
 		}
-		if res.Key() != "row1" {
-			t.Errorf("Expected row key row1, got %s", res.Key())
+		if row.Key() != "r1" {
+			t.Errorf("row.Key() = %q, want r1", row.Key())
 		}
-		if !classicCalled {
-			t.Error("Expected classic to be called")
+		if classic.readRowCalls != 1 {
+			t.Errorf("classic.readRowCalls = %d, want 1", classic.readRowCalls)
 		}
-		if sessionCalled {
-			t.Error("Expected session NOT to be called")
+		if session.readRowCalls != 0 {
+			t.Errorf("session.readRowCalls = %d, want 0", session.readRowCalls)
 		}
 	})
 
-	t.Run("Session only when UseSession is true and succeeds", func(t *testing.T) {
-		classicCalled := false
-		sessionCalled := false
+	t.Run("session when SessionLoad=1.0", func(t *testing.T) {
+		classic := &mockClassicTable{}
+		session := &mockSessionTable{}
+		shim := NewTableShim(classic, session, btransport.NewDiverter(1.0))
 
-		classic := &mockTableAPI{
-			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
-				classicCalled = true
-				return nil, dummyErr
-			},
-		}
-		session := &mockTableAPI{
-			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
-				sessionCalled = true
-				return dummyRow, nil
-			},
-		}
-
-		diverter := internal.NewDiverter(1.0) // 100% load
-		shim := NewTableShim(classic, session, diverter)
-
-		res, err := shim.ReadRow(context.Background(), "row1")
+		row, err := shim.ReadRow(context.Background(), "r2")
 		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
+			t.Fatalf("unexpected err: %v", err)
 		}
-		if res.Key() != "row1" {
-			t.Errorf("Expected row key row1, got %s", res.Key())
+		if row.Key() != "r2" {
+			t.Errorf("row.Key() = %q, want r2 (from protoRowToRow)", row.Key())
 		}
-		if classicCalled {
-			t.Error("Expected classic NOT to be called")
+		if classic.readRowCalls != 0 {
+			t.Errorf("classic.readRowCalls = %d, want 0", classic.readRowCalls)
 		}
-		if !sessionCalled {
-			t.Error("Expected session to be called")
+		if session.readRowCalls != 1 {
+			t.Errorf("session.readRowCalls = %d, want 1", session.readRowCalls)
 		}
 	})
 
-	t.Run("Session fails and returns error directly without falling back to classic", func(t *testing.T) {
-		classicCalled := false
-		sessionCalled := false
+	t.Run("classic fallback when session is nil", func(t *testing.T) {
+		classic := &mockClassicTable{}
+		shim := NewTableShim(classic, nil, btransport.NewDiverter(1.0))
 
-		classic := &mockTableAPI{
-			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
-				classicCalled = true
-				return dummyRow, nil
+		_, err := shim.ReadRow(context.Background(), "r3")
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if classic.readRowCalls != 1 {
+			t.Errorf("classic.readRowCalls = %d, want 1 (must fall back when session=nil even with SessionLoad=1.0)", classic.readRowCalls)
+		}
+	})
+
+	t.Run("session error propagates", func(t *testing.T) {
+		wantErr := errors.New("session read failed")
+		session := &mockSessionTable{
+			readRowFn: func(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
+				return nil, wantErr
 			},
 		}
-		session := &mockTableAPI{
-			readRowFunc: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
-				sessionCalled = true
-				return nil, dummyErr
-			},
-		}
-
-		diverter := internal.NewDiverter(1.0)
-		shim := NewTableShim(classic, session, diverter)
-
-		_, err := shim.ReadRow(context.Background(), "row1")
-		if err != dummyErr {
-			t.Errorf("Expected session error %v, got %v", dummyErr, err)
-		}
-		if classicCalled {
-			t.Error("Expected classic NOT to be called")
-		}
-		if !sessionCalled {
-			t.Error("Expected session to be called")
+		shim := NewTableShim(&mockClassicTable{}, session, btransport.NewDiverter(1.0))
+		_, err := shim.ReadRow(context.Background(), "r4")
+		if !errors.Is(err, wantErr) {
+			t.Errorf("err = %v, want unwrap to %v", err, wantErr)
 		}
 	})
 }
 
-func TestTableShim_Apply(t *testing.T) {
-	dummyErr := errors.New("dummy error")
+// TestTableShim_Apply_ConditionalAlwaysClassic verifies that conditional
+// mutations bypass the session path regardless of diverter setting —
+// CheckAndMutateRow has no session equivalent.
+func TestTableShim_Apply_ConditionalAlwaysClassic(t *testing.T) {
+	classic := &mockClassicTable{}
+	session := &mockSessionTable{}
+	shim := NewTableShim(classic, session, btransport.NewDiverter(1.0)) // diverter says session
 
-	t.Run("Classic only when UseSession is false", func(t *testing.T) {
-		classicCalled := false
-		sessionCalled := false
+	cond := NewCondMutation(PassAllFilter(), NewMutation(), nil)
+	if err := shim.Apply(context.Background(), "r", cond); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if classic.applyCalls != 1 {
+		t.Errorf("classic.applyCalls = %d, want 1 (conditional must go classic)", classic.applyCalls)
+	}
+	if session.mutateRowCalls != 0 {
+		t.Errorf("session.mutateRowCalls = %d, want 0 (conditional must NOT go session)", session.mutateRowCalls)
+	}
+}
 
-		classic := &mockTableAPI{
-			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
-				classicCalled = true
-				return nil
-			},
-		}
-		session := &mockTableAPI{
-			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
-				sessionCalled = true
-				return dummyErr
-			},
-		}
+// TestTableShim_Apply_NonConditionalRoutesByDiverter verifies that
+// non-conditional mutations follow the diverter.
+func TestTableShim_Apply_NonConditionalRoutesByDiverter(t *testing.T) {
+	t.Run("session when SessionLoad=1.0", func(t *testing.T) {
+		classic := &mockClassicTable{}
+		session := &mockSessionTable{}
+		shim := NewTableShim(classic, session, btransport.NewDiverter(1.0))
 
-		diverter := internal.NewDiverter(0.0)
-		shim := NewTableShim(classic, session, diverter)
-
-		err := shim.Apply(context.Background(), "row1", NewMutation())
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
+		mut := NewMutation()
+		mut.Set("fam", "col", 1_000_000, []byte("v"))
+		if err := shim.Apply(context.Background(), "r", mut); err != nil {
+			t.Fatalf("unexpected err: %v", err)
 		}
-		if !classicCalled {
-			t.Error("Expected classic to be called")
-		}
-		if sessionCalled {
-			t.Error("Expected session NOT to be called")
+		if classic.applyCalls != 0 || session.mutateRowCalls != 1 {
+			t.Errorf("classic=%d session=%d, want classic=0 session=1", classic.applyCalls, session.mutateRowCalls)
 		}
 	})
 
-	t.Run("Session only when UseSession is true and succeeds", func(t *testing.T) {
-		classicCalled := false
-		sessionCalled := false
+	t.Run("classic when SessionLoad=0.0", func(t *testing.T) {
+		classic := &mockClassicTable{}
+		session := &mockSessionTable{}
+		shim := NewTableShim(classic, session, btransport.NewDiverter(0.0))
 
-		classic := &mockTableAPI{
-			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
-				classicCalled = true
-				return dummyErr
-			},
+		mut := NewMutation()
+		mut.Set("fam", "col", 1_000_000, []byte("v"))
+		if err := shim.Apply(context.Background(), "r", mut); err != nil {
+			t.Fatalf("unexpected err: %v", err)
 		}
-		session := &mockTableAPI{
-			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
-				sessionCalled = true
-				return nil
-			},
-		}
-
-		diverter := internal.NewDiverter(1.0)
-		shim := NewTableShim(classic, session, diverter)
-
-		err := shim.Apply(context.Background(), "row1", NewMutation())
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
-		}
-		if classicCalled {
-			t.Error("Expected classic NOT to be called")
-		}
-		if !sessionCalled {
-			t.Error("Expected session to be called")
-		}
-	})
-
-	t.Run("Session fails and returns error directly without falling back to classic", func(t *testing.T) {
-		classicCalled := false
-		sessionCalled := false
-
-		classic := &mockTableAPI{
-			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
-				classicCalled = true
-				return nil
-			},
-		}
-		session := &mockTableAPI{
-			applyFunc: func(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
-				sessionCalled = true
-				return dummyErr
-			},
-		}
-
-		diverter := internal.NewDiverter(1.0)
-		shim := NewTableShim(classic, session, diverter)
-
-		err := shim.Apply(context.Background(), "row1", NewMutation())
-		if err != dummyErr {
-			t.Errorf("Expected session error %v, got %v", dummyErr, err)
-		}
-		if classicCalled {
-			t.Error("Expected classic NOT to be called")
-		}
-		if !sessionCalled {
-			t.Error("Expected session to be called")
+		if classic.applyCalls != 1 || session.mutateRowCalls != 0 {
+			t.Errorf("classic=%d session=%d, want classic=1 session=0", classic.applyCalls, session.mutateRowCalls)
 		}
 	})
 }
 
-func TestTableShim_DelegatedMethods(t *testing.T) {
-	classicCalled := false
-	sessionCalled := false
-
-	classic := &mockTableAPI{
-		readRowsFunc: func(ctx context.Context, arg RowSet, f func(Row) bool, opts ...ReadOption) error {
-			classicCalled = true
+// TestTableShim_ReadRows_AlwaysClassic — no session equivalent yet.
+func TestTableShim_ReadRows_AlwaysClassic(t *testing.T) {
+	classicCalled := 0
+	classic := &mockClassicTable{
+		readRowsFn: func(ctx context.Context, arg RowSet, f func(Row) bool, opts ...ReadOption) error {
+			classicCalled++
 			return nil
 		},
-		sampleRowKeysFunc: func(ctx context.Context) ([]string, error) {
-			classicCalled = true
-			return nil, nil
+	}
+	shim := NewTableShim(classic, &mockSessionTable{}, btransport.NewDiverter(1.0))
+	if err := shim.ReadRows(context.Background(), RowRange{}, func(Row) bool { return true }); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if classicCalled != 1 {
+		t.Errorf("classic.ReadRows calls = %d, want 1 (ReadRows always goes classic)", classicCalled)
+	}
+}
+
+// TestTableShim_SampleRowKeys_AlwaysClassic — spec #14: no vRPC equivalent.
+func TestTableShim_SampleRowKeys_AlwaysClassic(t *testing.T) {
+	classicCalled := 0
+	classic := &mockClassicTable{
+		sampleFn: func(ctx context.Context) ([]string, error) {
+			classicCalled++
+			return []string{"a", "b"}, nil
 		},
-		applyBulkFunc: func(ctx context.Context, rowKeys []string, muts []*Mutation, opts ...ApplyOption) ([]error, error) {
-			classicCalled = true
-			return nil, nil
-		},
-		applyReadModifyWriteFunc: func(ctx context.Context, row string, m *ReadModifyWrite) (Row, error) {
-			classicCalled = true
+	}
+	shim := NewTableShim(classic, &mockSessionTable{}, btransport.NewDiverter(1.0))
+	if _, err := shim.SampleRowKeys(context.Background()); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if classicCalled != 1 {
+		t.Errorf("classic.SampleRowKeys calls = %d, want 1 (no vRPC equivalent)", classicCalled)
+	}
+}
+
+// TestTableShim_ApplyBulk_AlwaysClassic — spec #14: no vRPC equivalent.
+func TestTableShim_ApplyBulk_AlwaysClassic(t *testing.T) {
+	classicCalled := 0
+	classic := &mockClassicTable{
+		applyBulkFn: func(ctx context.Context, rowKeys []string, muts []*Mutation, opts ...ApplyOption) ([]error, error) {
+			classicCalled++
 			return nil, nil
 		},
 	}
-	session := &mockTableAPI{
-		readRowsFunc: func(ctx context.Context, arg RowSet, f func(Row) bool, opts ...ReadOption) error {
-			sessionCalled = true
-			return nil
-		},
-		sampleRowKeysFunc: func(ctx context.Context) ([]string, error) {
-			sessionCalled = true
-			return nil, nil
-		},
-		applyBulkFunc: func(ctx context.Context, rowKeys []string, muts []*Mutation, opts ...ApplyOption) ([]error, error) {
-			sessionCalled = true
-			return nil, nil
-		},
-		applyReadModifyWriteFunc: func(ctx context.Context, row string, m *ReadModifyWrite) (Row, error) {
-			sessionCalled = true
-			return nil, nil
+	shim := NewTableShim(classic, &mockSessionTable{}, btransport.NewDiverter(1.0))
+	if _, err := shim.ApplyBulk(context.Background(), []string{"r1"}, []*Mutation{NewMutation()}); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if classicCalled != 1 {
+		t.Errorf("classic.ApplyBulk calls = %d, want 1 (no vRPC equivalent)", classicCalled)
+	}
+}
+
+// TestTableShim_ApplyReadModifyWrite_AlwaysClassic — spec #14: no vRPC equivalent.
+func TestTableShim_ApplyReadModifyWrite_AlwaysClassic(t *testing.T) {
+	classicCalled := 0
+	classic := &mockClassicTable{
+		rmwFn: func(ctx context.Context, row string, m *ReadModifyWrite) (Row, error) {
+			classicCalled++
+			return Row{"fam": []ReadItem{{Row: row}}}, nil
 		},
 	}
+	shim := NewTableShim(classic, &mockSessionTable{}, btransport.NewDiverter(1.0))
+	if _, err := shim.ApplyReadModifyWrite(context.Background(), "r1", NewReadModifyWrite()); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if classicCalled != 1 {
+		t.Errorf("classic.ApplyReadModifyWrite calls = %d, want 1 (no vRPC equivalent)", classicCalled)
+	}
+}
 
-	diverter := internal.NewDiverter(1.0) // Even with 100% session load, these delegate to classic
-	shim := NewTableShim(classic, session, diverter)
+// TestTableShim_NilSession_AllMethodsFallBackToClassic verifies
+// SESSION_SPEC.md #14's nil-safety contract across the full TableAPI
+// surface. The existing subtest in TestTableShim_ReadRow_RoutesByDiverter
+// only covers ReadRow — this test extends the assertion to Apply plus
+// every non-vRPC method so a future TableAPI addition is caught by
+// coverage of the shim's fallback path.
+func TestTableShim_NilSession_AllMethodsFallBackToClassic(t *testing.T) {
+	classic := &mockClassicTable{}
+	// session=nil, diverter says session (1.0) — nil-safety MUST win.
+	shim := NewTableShim(classic, nil, btransport.NewDiverter(1.0))
 
-	// ReadRows
-	classicCalled = false
-	_ = shim.ReadRows(context.Background(), RowRange{}, func(r Row) bool { return true })
-	if !classicCalled || sessionCalled {
-		t.Errorf("ReadRows: expected classic called: %v, session called: %v", classicCalled, sessionCalled)
+	if _, err := shim.ReadRow(context.Background(), "r1"); err != nil {
+		t.Fatalf("ReadRow: %v", err)
+	}
+	if err := shim.Apply(context.Background(), "r1", NewMutation()); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if err := shim.ReadRows(context.Background(), RowRange{}, func(Row) bool { return true }); err != nil {
+		t.Fatalf("ReadRows: %v", err)
+	}
+	if _, err := shim.SampleRowKeys(context.Background()); err != nil {
+		t.Fatalf("SampleRowKeys: %v", err)
+	}
+	if _, err := shim.ApplyBulk(context.Background(), []string{"r1"}, []*Mutation{NewMutation()}); err != nil {
+		t.Fatalf("ApplyBulk: %v", err)
+	}
+	if _, err := shim.ApplyReadModifyWrite(context.Background(), "r1", NewReadModifyWrite()); err != nil {
+		t.Fatalf("ApplyReadModifyWrite: %v", err)
 	}
 
-	// SampleRowKeys
-	classicCalled = false
-	sessionCalled = false
-	_, _ = shim.SampleRowKeys(context.Background())
-	if !classicCalled || sessionCalled {
-		t.Errorf("SampleRowKeys: expected classic called: %v, session called: %v", classicCalled, sessionCalled)
+	// Every routable method must have gone classic (Apply=1, ReadRow=1);
+	// non-routable methods are trivially classic. If session were nil-unsafe,
+	// one of the two routable calls would nil-panic before reaching here.
+	if classic.readRowCalls != 1 {
+		t.Errorf("classic.readRowCalls = %d, want 1", classic.readRowCalls)
 	}
-
-	// ApplyBulk
-	classicCalled = false
-	sessionCalled = false
-	_, _ = shim.ApplyBulk(context.Background(), nil, nil)
-	if !classicCalled || sessionCalled {
-		t.Errorf("ApplyBulk: expected classic called: %v, session called: %v", classicCalled, sessionCalled)
+	if classic.applyCalls != 1 {
+		t.Errorf("classic.applyCalls = %d, want 1", classic.applyCalls)
 	}
+}
 
-	// ApplyReadModifyWrite
-	classicCalled = false
-	sessionCalled = false
-	_, _ = shim.ApplyReadModifyWrite(context.Background(), "row1", nil)
-	if !classicCalled || sessionCalled {
-		t.Errorf("ApplyReadModifyWrite: expected classic called: %v, session called: %v", classicCalled, sessionCalled)
+// TestTableShim_SessionErrorNotRetriedOnClassic verifies SESSION_SPEC.md
+// #14's retry-safety contract: a session-path error MUST propagate as-is;
+// the shim MUST NOT silently retry the failed op on the classic path.
+// Doing so would violate the retry oracle (spec #9) — a session-side
+// TransportFailure on a non-idempotent Apply is not automatically safe to
+// re-run on classic.
+func TestTableShim_SessionErrorNotRetriedOnClassic(t *testing.T) {
+	wantErr := errors.New("session apply failed")
+	classic := &mockClassicTable{}
+	session := &mockSessionTable{
+		mutateRowFn: func(ctx context.Context, req *btpb.SessionMutateRowRequest) (*btpb.SessionMutateRowResponse, error) {
+			return nil, wantErr
+		},
+	}
+	shim := NewTableShim(classic, session, btransport.NewDiverter(1.0))
+
+	mut := NewMutation()
+	mut.Set("fam", "col", 1_000_000, []byte("v"))
+	err := shim.Apply(context.Background(), "r1", mut)
+
+	if !errors.Is(err, wantErr) {
+		t.Errorf("err = %v, want unwrap to %v", err, wantErr)
+	}
+	if session.mutateRowCalls != 1 {
+		t.Errorf("session.mutateRowCalls = %d, want 1 (single attempt)", session.mutateRowCalls)
+	}
+	if classic.applyCalls != 0 {
+		t.Errorf("classic.applyCalls = %d, want 0 — shim MUST NOT retry session failure on classic (spec #14 + #9)", classic.applyCalls)
 	}
 }
 
@@ -445,7 +472,7 @@ func TestProtoRowToRow(t *testing.T) {
 			want: Row{"cf": []ReadItem{{Row: "k", Column: "cf:q", Timestamp: 1000, Value: []byte("v"), Labels: []string{"L1", "L2"}}}},
 		},
 		{
-			name: "TimestampMicros=0 preserved (server-set-to-now semantic is caller's job)",
+			name: "TimestampMicros=0 preserved (server-server-set-to-now semantic is caller's job)",
 			in:   row("k", fam("cf", col("q", cell(0, "v")))),
 			want: Row{"cf": []ReadItem{{Row: "k", Column: "cf:q", Timestamp: 0, Value: []byte("v")}}},
 		},

--- a/bigtable/table_shim_test.go
+++ b/bigtable/table_shim_test.go
@@ -472,7 +472,7 @@ func TestProtoRowToRow(t *testing.T) {
 			want: Row{"cf": []ReadItem{{Row: "k", Column: "cf:q", Timestamp: 1000, Value: []byte("v"), Labels: []string{"L1", "L2"}}}},
 		},
 		{
-			name: "TimestampMicros=0 preserved (server-server-set-to-now semantic is caller's job)",
+			name: "TimestampMicros=0 preserved (server-set-to-now semantic is caller's job)",
 			in:   row("k", fam("cf", col("q", cell(0, "v")))),
 			want: Row{"cf": []ReadItem{{Row: "k", Column: "cf:q", Timestamp: 0, Value: []byte("v")}}},
 		},


### PR DESCRIPTION
## Summary

Follow-up to #20257 (protoRowToRow), which now has its sole consumer.
Swaps `TableShim`'s session backend from the classic `TableAPI` shape
(row string + `bigtable.Row`) to the internal
`session.TableAPI` shape (proto-native
`*btpb.SessionReadRow{Request,Response}` +
`*btpb.SessionMutateRow{Request,Response}`).

`TableShim` now owns the proto ↔ public-types translation so the
`internal/session` package can stay proto-native.

## Behavior

**`ReadRow`** — parses `ReadOption` using the classic `makeReadSettings`
shape (so filter + full-read-stats callback plumbing stays in one
place), builds a `*btpb.SessionReadRowRequest`, calls
`session.ReadRow`, feeds any `resp.Stats` through the
`WithFullReadStats` callback, and converts `resp.Row` via
`protoRowToRow`.

**`Apply`** — conditional mutations (`CheckAndMutateRow`) always route
to classic since the session vRPC has no `CheckAndMutateRow`
equivalent. Non-conditional mutations build a
`*btpb.SessionMutateRowRequest` and call `session.MutateRow`.

**`useSession()`** — nil-safe on both `session` and `diverter`, so
callers can wire a `TableShim` with `nil` session (as
`buildDivertible` does in #20256) and every routing decision falls
through to classic.

**`ReadRows` / `SampleRowKeys` / `ApplyBulk` / `ApplyReadModifyWrite`
always classic** — no session equivalent in the vRPC.

## API-visible signature change

`NewTableShim`'s `session` parameter type becomes `session.TableAPI` (an
internal-package interface). Existing in-repo callers pass `nil` for
session today; nil is the zero value of any interface, so the change
is source-compatible for those. External callers writing tests can
mock `session.TableAPI` directly — the new test file has an example
(`mockSessionTable`).

## Tests

Replaces the `mockTableAPI`-as-session pattern with a proto-native
`mockSessionTable`. New coverage:

- `TestTableShim_ReadRow_RoutesByDiverter` — classic when
  `SessionLoad=0.0`; session when `SessionLoad=1.0`; classic fallback
  when session is nil even with `SessionLoad=1.0`; session error
  propagation (no automatic fallback to classic on failure).
- `TestTableShim_Apply_ConditionalAlwaysClassic` — pins that
  conditional mutations bypass the session path.
- `TestTableShim_Apply_NonConditionalRoutesByDiverter` — pins that
  non-conditional mutations follow the diverter.
- `TestTableShim_ReadRows_AlwaysClassic`,
  `TestTableShim_SampleRowKeys_AlwaysClassic`,
  `TestTableShim_ApplyBulk_AlwaysClassic`,
  `TestTableShim_ApplyReadModifyWrite_AlwaysClassic` — pin the
  no-session-equivalent methods.
- `TestTableShim_NilSession_AllMethodsFallBackToClassic` — the
  classic-only wiring path (what #20256's `buildDivertible` will use
  until the session backend lands).
- `TestTableShim_SessionErrorNotRetriedOnClassic` — session-side
  failures surface as-is instead of silently falling back.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./bigtable/ -run 'TestTableShim|TestProtoRowToRow' -count=1 -v` — all pass
- [x] Live sandbox smoke against `autonomous-mote-782 / sushanb-uc1` — classic path via `client.Open(...).Apply/ReadRow` still succeeds end-to-end (session backend not exercised on this branch since it isn't wired yet)

## Depends on

- #20257 (merged as `1297143a4f`) — `protoRowToRow` helper.

## Follows

Consumed by a future PR that wires an actual `session.TableAPI` implementation
from the `internal/session` package into `Client.buildDivertible` (see
#20256 for the `buildDivertible` shape).