### PR TITLE
fix(multiple): correct module go version declaration

### DIFF
--- a/analytics/CHANGES.md
+++ b/analytics/CHANGES.md
@@ -493,3 +493,4 @@
 
 This is the first tag to carve out analytics as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/container/CHANGES.md
+++ b/container/CHANGES.md
@@ -722,3 +722,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out container as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+

--- a/dlp/CHANGES.md
+++ b/dlp/CHANGES.md
@@ -433,3 +433,4 @@ Stabilize GA surface.
 
 This is the first tag to carve out dlp as its own module. See
 [Add a module to a multi-module repository](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository).
+


### PR DESCRIPTION
This PR doesn't do anything interesting in itself, but is being used to mark modules for an incremental release so that they advertise the correct go version 1.25.0 in their module definitions.  The actual change was handled via chore-level PRs which don't normally trigger releases.