### PR TITLE
test(bigquery/storage/managedwriter): remove stale genproto refs

### DIFF
--- a/bigquery/storage/managedwriter/appendresult_test.go
+++ b/bigquery/storage/managedwriter/appendresult_test.go
@@ -22,7 +22,6 @@ import (
 
 	"cloud.google.com/go/bigquery/storage/apiv1/storagepb"
 	"github.com/google/go-cmp/cmp"
-	"google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/descriptorpb"
@@ -64,7 +63,7 @@ func TestPendingWrite(t *testing.T) {
 	}
 
 	// Mark completed, verify result.
-	pending.markDone(&storage.AppendRowsResponse{}, nil)
+	pending.markDone(&storagepb.AppendRowsResponse{}, nil)
 	if gotOff := pending.result.offset(ctx); gotOff != NoStreamOffset {
 		t.Errorf("mismatch on completed AppendResult without offset: got %d want %d", gotOff, NoStreamOffset)
 	}

--- a/bigquery/storage/managedwriter/connection_test.go
+++ b/bigquery/storage/managedwriter/connection_test.go
@@ -24,7 +24,6 @@ import (
 
 	"cloud.google.com/go/bigquery/storage/apiv1/storagepb"
 	"github.com/googleapis/gax-go/v2"
-	"google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1"
 	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -214,7 +213,7 @@ func TestConnectionPool_OpenCallOptionPropagation(t *testing.T) {
 	pool := &connectionPool{
 		ctx:    ctx,
 		cancel: cancel,
-		open: createOpenF(func(ctx context.Context, opts ...gax.CallOption) (storage.BigQueryWrite_AppendRowsClient, error) {
+		open: createOpenF(func(ctx context.Context, opts ...gax.CallOption) (storagepb.BigQueryWrite_AppendRowsClient, error) {
 			if len(opts) == 0 {
 				t.Fatalf("no options were propagated")
 			}


### PR DESCRIPTION
This PR corrects some historical usages of genproto message locations in tests.