### PR TITLE
fix(bigtable): real per-resource pool teardown on sessionTable.Close + cache close-race gate

### DIFF
--- a/bigtable/client.go
+++ b/bigtable/client.go
@@ -275,8 +275,15 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 	// traffic through this Client's Diverter — a control-plane update
 	// then shifts traffic across every open TableShim without a client
 	// restart.
+	// Inspect the merged option list (o), not the raw caller opts.
+	// BIGTABLE_EMULATOR_HOST injects option.WithGRPCConn inside
+	// btopt.DefaultClientOptions (option.go:113), so it lives in o —
+	// callers never pass it explicitly. Reading only from opts misses
+	// the emulator conn and lets session.NewClient dial an empty
+	// resolver target (fails with "passthrough: received empty target
+	// in Build()"), breaking every emulator-based test.
 	preDialed := false
-	if uResolver, resErr := internaloption.NewUnsafeResolver(opts...); resErr == nil {
+	if uResolver, resErr := internaloption.NewUnsafeResolver(o...); resErr == nil {
 		preDialed = uResolver.ResolvedGRPCConnIsCustom()
 	}
 	if !preDialed {

--- a/bigtable/internal/session/api.go
+++ b/bigtable/internal/session/api.go
@@ -43,8 +43,14 @@ type TableAPI interface {
 	MutateRow(ctx context.Context, req *btpb.SessionMutateRowRequest) (*btpb.SessionMutateRowResponse, error)
 
 	// Close releases this resource's underlying read + write session
-	// pools. Independent from Client.Close — closing an
-	// individual resource does not close the shared channel pool.
+	// pools from the sessionClient's per-resource keyed map. Idempotent.
+	// Independent from Client.Close — closing an individual resource
+	// does not close the shared channel pool.
+	//
+	// Per-handle pool teardown is safe because callers reach this method
+	// through bigtable.Client's sessionTableCache, which guarantees
+	// at-most-one TableAPI per resource per Client. A future caller that
+	// bypasses that cache must add a refcount before calling Close.
 	Close() error
 }
 

--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -466,13 +466,17 @@ func (sc *sessionClient) OpenTable(tableID string) TableAPI {
 	fullName := sc.fullTableName(tableID)
 	streamFactory := func(ctx context.Context) (btransport.Stream, error) { return sc.stub.OpenTable(ctx) }
 	resource := "table:" + tableID
+	readKey := poolKey{resource, permissionRead}
+	writeKey := poolKey{resource, permissionWrite}
 	openRead := sc.buildLazyOpener(fullName, btransport.TABLE_SESSION, streamFactory,
 		&btpb.OpenTableRequest{TableName: fullName, AppProfileId: sc.cfg.AppProfile, Permission: btpb.OpenTableRequest_PERMISSION_READ},
-		poolKey{resource, permissionRead})
+		readKey)
 	openWrite := sc.buildLazyOpener(fullName, btransport.TABLE_SESSION, streamFactory,
 		&btpb.OpenTableRequest{TableName: fullName, AppProfileId: sc.cfg.AppProfile, Permission: btpb.OpenTableRequest_PERMISSION_WRITE},
-		poolKey{resource, permissionWrite})
-	return newSessionTable(tableID, openRead, openWrite, btransport.READ_ROW, btransport.MUTATE_ROW, sc.perResourceMetadata(fullName, "table_name", fullName), sc.metricsFactory)
+		writeKey)
+	closeRead := sc.buildLazyReleaser(readKey)
+	closeWrite := sc.buildLazyReleaser(writeKey)
+	return newSessionTable(tableID, openRead, openWrite, closeRead, closeWrite, btransport.READ_ROW, btransport.MUTATE_ROW, sc.perResourceMetadata(fullName, "table_name", fullName), sc.metricsFactory)
 }
 
 // OpenAuthorizedView returns a TableAPI for an authorized view.
@@ -480,13 +484,17 @@ func (sc *sessionClient) OpenAuthorizedView(table, view string) TableAPI {
 	fullName := sc.fullAuthorizedViewName(table, view)
 	streamFactory := func(ctx context.Context) (btransport.Stream, error) { return sc.stub.OpenAuthorizedView(ctx) }
 	resource := fmt.Sprintf("av:%s:%s", table, view)
+	readKey := poolKey{resource, permissionRead}
+	writeKey := poolKey{resource, permissionWrite}
 	openRead := sc.buildLazyOpener(fullName, btransport.AUTHORIZED_VIEW_SESSION, streamFactory,
 		&btpb.OpenAuthorizedViewRequest{AuthorizedViewName: fullName, AppProfileId: sc.cfg.AppProfile, Permission: btpb.OpenAuthorizedViewRequest_PERMISSION_READ},
-		poolKey{resource, permissionRead})
+		readKey)
 	openWrite := sc.buildLazyOpener(fullName, btransport.AUTHORIZED_VIEW_SESSION, streamFactory,
 		&btpb.OpenAuthorizedViewRequest{AuthorizedViewName: fullName, AppProfileId: sc.cfg.AppProfile, Permission: btpb.OpenAuthorizedViewRequest_PERMISSION_WRITE},
-		poolKey{resource, permissionWrite})
-	return newSessionTable(table, openRead, openWrite, btransport.READ_ROW_AUTH_VIEW, btransport.MUTATE_ROW_AUTH_VIEW, sc.perResourceMetadata(fullName, "authorized_view_name", fullName), sc.metricsFactory)
+		writeKey)
+	closeRead := sc.buildLazyReleaser(readKey)
+	closeWrite := sc.buildLazyReleaser(writeKey)
+	return newSessionTable(table, openRead, openWrite, closeRead, closeWrite, btransport.READ_ROW_AUTH_VIEW, btransport.MUTATE_ROW_AUTH_VIEW, sc.perResourceMetadata(fullName, "authorized_view_name", fullName), sc.metricsFactory)
 }
 
 // OpenMaterializedView returns a read-only TableAPI for a
@@ -494,6 +502,7 @@ func (sc *sessionClient) OpenAuthorizedView(table, view string) TableAPI {
 // cleanly via the nil openWrite passed to newSessionTable.
 func (sc *sessionClient) OpenMaterializedView(view string) TableAPI {
 	fullName := sc.fullMaterializedViewName(view)
+	readKey := poolKey{"mv:" + view, permissionRead}
 	openRead := sc.buildLazyOpener(fullName, btransport.MATERIALIZED_VIEW_SESSION,
 		func(ctx context.Context) (btransport.Stream, error) { return sc.stub.OpenMaterializedView(ctx) },
 		&btpb.OpenMaterializedViewRequest{
@@ -501,8 +510,9 @@ func (sc *sessionClient) OpenMaterializedView(view string) TableAPI {
 			AppProfileId:         sc.cfg.AppProfile,
 			Permission:           btpb.OpenMaterializedViewRequest_PERMISSION_READ,
 		},
-		poolKey{"mv:" + view, permissionRead})
-	return newSessionTable("", openRead, nil, btransport.READ_ROW_MAT_VIEW, nil, sc.perResourceMetadata(fullName, "materialized_view_name", fullName), sc.metricsFactory)
+		readKey)
+	closeRead := sc.buildLazyReleaser(readKey)
+	return newSessionTable("", openRead, nil, closeRead, nil, btransport.READ_ROW_MAT_VIEW, nil, sc.perResourceMetadata(fullName, "materialized_view_name", fullName), sc.metricsFactory)
 }
 
 // Close tears down in a phased order that keeps late callbacks from
@@ -590,6 +600,60 @@ func (sc *sessionClient) buildLazyOpener(
 		}
 		return pool, nil
 	}
+}
+
+// buildLazyReleaser returns a closure that releases the pool entry
+// for the given key from sessionPools + closes the underlying pool.
+// Returned closure is idempotent (second call finds entry absent and
+// no-ops) and nil-safe when key is the zero value (the caller can
+// pass nil for resources without a write side — e.g. materialized
+// views — mirroring buildLazyOpener's payload==nil convention).
+//
+// Symmetric with buildLazyOpener so sessionTable can drive real
+// per-resource teardown from its Close() without needing back-refs
+// or knowing about poolKey / sessionPools internals.
+func (sc *sessionClient) buildLazyReleaser(key poolKey) func() error {
+	return func() error {
+		return sc.releaseSessionPool(key)
+	}
+}
+
+// releaseSessionPool removes key from sessionPools and closes the
+// underlying pool. No-op when:
+//   - the client has already Closed (sessionPools == nil), so any late
+//     release from a cache handle draining on the way out doesn't
+//     racily double-close a pool that Client.Close is already
+//     tearing down.
+//   - the entry is absent (already released — makes second calls safe).
+//
+// Assumes the caller (currently bigtable.Client via sessionTableCache)
+// guarantees at-most-one sessionTable per resource at any moment. That
+// invariant means no co-owner can be relying on the pool we're closing.
+// If session.Client is ever exposed to callers that bypass that cache,
+// this must gain a refcount.
+//
+// Teardown runs OUTSIDE sessionPoolsMu so a graceful pool drain (which
+// can block on in-flight vRPCs) doesn't deadlock any snapshotter
+// waiting on the lock. Matches the snapshot-under-lock / teardown-
+// outside pattern in Client.Close.
+func (sc *sessionClient) releaseSessionPool(key poolKey) error {
+	sc.sessionPoolsMu.Lock()
+	if sc.sessionPools == nil {
+		sc.sessionPoolsMu.Unlock()
+		return nil
+	}
+	mp, ok := sc.sessionPools[key]
+	if !ok {
+		sc.sessionPoolsMu.Unlock()
+		return nil
+	}
+	delete(sc.sessionPools, key)
+	sc.sessionPoolsMu.Unlock()
+
+	if mp.unregister != nil {
+		mp.unregister()
+	}
+	return mp.pool.Close()
 }
 
 // createSessionPoolForPayload marshals the resource-typed OpenXxxRequest

--- a/bigtable/internal/session/client_test.go
+++ b/bigtable/internal/session/client_test.go
@@ -23,6 +23,7 @@ import (
 
 	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
 	metrics "cloud.google.com/go/bigtable/internal/metrics"
+	btransport "cloud.google.com/go/bigtable/internal/transport"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
@@ -454,5 +455,69 @@ func TestPoolKey_DisplayName(t *testing.T) {
 				t.Errorf("displayName() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// --- releaseSessionPool ------------------------------------------------------
+
+// TestReleaseSessionPool_AfterClientClose_NoOp: once Close nils out
+// sessionPools, any late release from a cache handle draining on the
+// way out must be a benign no-op rather than a nil-map panic.
+func TestReleaseSessionPool_AfterClientClose_NoOp(t *testing.T) {
+	sc := newTestClient(t, &fakeChannelPool{}, Config{})
+	sc.sessionPools = nil // simulate Close having snapshotted+nil'd
+	if err := sc.releaseSessionPool(poolKey{"table:foo", permissionRead}); err != nil {
+		t.Errorf("releaseSessionPool on nil map = %v, want nil (post-Close no-op)", err)
+	}
+}
+
+// TestReleaseSessionPool_MissingKeyNoOp: releasing a key that isn't in
+// the map returns nil and leaves other entries untouched. This is what
+// makes double-release safe (winner deletes; loser sees absent).
+func TestReleaseSessionPool_MissingKeyNoOp(t *testing.T) {
+	sc := newTestClient(t, &fakeChannelPool{}, Config{})
+	present := poolKey{"table:present", permissionRead}
+	sc.sessionPools[present] = &managedSessionPool{} // sentinel, not touched
+	if err := sc.releaseSessionPool(poolKey{"table:absent", permissionRead}); err != nil {
+		t.Errorf("releaseSessionPool on absent key = %v, want nil", err)
+	}
+	if _, still := sc.sessionPools[present]; !still {
+		t.Error("releaseSessionPool on absent key deleted a different entry")
+	}
+}
+
+// TestReleaseSessionPool_RemovesEntryAndInvokesUnregister covers the
+// happy path with a real (unstarted) SessionPoolImpl. The pool never
+// dialed a stream so Close returns cleanly; we assert the map entry
+// is gone AND the config-listener unregister thunk fired.
+func TestReleaseSessionPool_RemovesEntryAndInvokesUnregister(t *testing.T) {
+	sc := newTestClient(t, &fakeChannelPool{}, Config{})
+	key := poolKey{"table:foo", permissionRead}
+	pool := btransport.NewSessionPoolImpl(
+		1, "test-pool", 0, 0,
+		func(ctx context.Context) (btransport.Stream, error) { return nil, errors.New("test never dials") },
+		&btpb.OpenSessionRequest{}, nil,
+		btransport.SessionTypeTable, false,
+	)
+	var unregistered int
+	sc.sessionPools[key] = &managedSessionPool{
+		pool:       pool,
+		unregister: func() { unregistered++ },
+	}
+	if err := sc.releaseSessionPool(key); err != nil {
+		t.Fatalf("releaseSessionPool = %v, want nil", err)
+	}
+	if _, still := sc.sessionPools[key]; still {
+		t.Error("sessionPools still holds the released key")
+	}
+	if unregistered != 1 {
+		t.Errorf("unregister fired %d times, want 1", unregistered)
+	}
+	// Second release is a clean no-op (winner deleted, loser sees absent).
+	if err := sc.releaseSessionPool(key); err != nil {
+		t.Errorf("second releaseSessionPool = %v, want nil", err)
+	}
+	if unregistered != 1 {
+		t.Errorf("unregister fired %d times after second release, want still 1", unregistered)
 	}
 }

--- a/bigtable/internal/session/table.go
+++ b/bigtable/internal/session/table.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 
 	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
 	metrics "cloud.google.com/go/bigtable/internal/metrics"
@@ -72,6 +73,12 @@ type sessionTable struct {
 	// write side of the openRead/openWrite pair.
 	closeRead  func() error
 	closeWrite func() error
+	// closed is set by Close() BEFORE the releasers run, and re-checked
+	// inside the lazy-open wrapper (guardOpen) around openRead/openWrite
+	// so an opener whose slow path straddles Close cleans up its own
+	// insert instead of leaking a fresh pool that the releaser missed.
+	// See guardOpen for the interleaving rules.
+	closed atomic.Bool
 }
 
 // newSessionTable is the internal constructor. Callers (sessionClient)
@@ -90,16 +97,58 @@ func newSessionTable(
 	md metadata.MD,
 	metricsFactory *metrics.Factory,
 ) *sessionTable {
-	return &sessionTable{
+	t := &sessionTable{
 		tableID:        tableID,
-		readPool:       &lazyPool{open: openRead},
-		writePool:      &lazyPool{open: openWrite},
 		readVRpcDesc:   readVRpcDesc,
 		writeVRpcDesc:  writeVRpcDesc,
 		md:             md,
 		metricsFactory: metricsFactory,
 		closeRead:      closeRead,
 		closeWrite:     closeWrite,
+	}
+	// Wrap the raw openers with a closed-bit guard so an open racing
+	// with Close either bails early or cleans up its own insert. Nil
+	// openers stay nil to preserve the MV-write-side "no pool" contract.
+	t.readPool = &lazyPool{open: t.guardOpen(openRead, closeRead)}
+	t.writePool = &lazyPool{open: t.guardOpen(openWrite, closeWrite)}
+	return t
+}
+
+// guardOpen wraps a lazy pool opener with a check-before + check-after
+// against t.closed. Interleaving cases:
+//
+//   - Close ran first: early check trips, opener never runs. No leak.
+//   - Close runs while opener's slow path holds sessionPoolsMu: post-check
+//     trips after opener returns; guardOpen invokes release itself to tear
+//     down the pool the opener just inserted. releaseSessionPool is
+//     idempotent, so Close's parallel call to release harmlessly no-ops.
+//   - Close runs after guardOpen returns: normal path — Close's releaser
+//     finds the pool in sessionPools and closes it. In-flight Invoke on
+//     the returned pool may fail with a "pool closed" error; the client
+//     was concurrently being torn down, so that's expected.
+//
+// A nil opener passes through as nil so the MV write side (no write pool)
+// stays a lazyPool-with-nil-open ("no session support"), not a
+// guarded-nil that would try to Load t.closed on every get.
+func (t *sessionTable) guardOpen(open func() (Invoker, error), release func() error) func() (Invoker, error) {
+	if open == nil {
+		return nil
+	}
+	return func() (Invoker, error) {
+		if t.closed.Load() {
+			return nil, ErrClientClosed
+		}
+		inv, err := open()
+		if err != nil {
+			return nil, err
+		}
+		if t.closed.Load() {
+			if release != nil {
+				_ = release()
+			}
+			return nil, ErrClientClosed
+		}
+		return inv, nil
 	}
 }
 
@@ -238,16 +287,24 @@ func dispatch[Args any, R any, Resp interface {
 // and no-ops) so double-close from the cache sweeper + explicit
 // caller is safe.
 //
-// Safety of per-handle pool teardown rests on a caller-side invariant:
-// bigtable.Client's sessionTableCache guarantees at-most-one
-// sessionTable per resource at any moment, so no co-owner can be
-// mid-flight on the pool we're closing. If session.Client ever gains
-// a caller that bypasses that cache, this method must gain a refcount
-// on the sessionClient side (or the caller must add its own).
+// Ordering matters: closed is Store'd BEFORE the releasers run so an
+// opener whose slow path is straddling this Close (already past its
+// early check, still dialing) sees closed=true on its post-insert
+// re-check inside guardOpen and cleans up its own insert. See guardOpen.
+// Otherwise the releaser would no-op on the empty map and the
+// post-insert would leak a fresh pool.
+//
+// Safety of per-handle pool teardown also rests on a caller-side
+// invariant: bigtable.Client's sessionTableCache guarantees at-most-one
+// sessionTable per resource at any moment, so no co-owner sharing a
+// pool with us can be mid-flight when we tear it down. If session.Client
+// ever gains a caller that bypasses that cache, this method must gain
+// a refcount on the sessionClient side (or the caller must add its own).
 //
 // Returns the joined read + write teardown errors (nil for the
 // materialized-view case where closeWrite is nil).
 func (t *sessionTable) Close() error {
+	t.closed.Store(true)
 	var errs []error
 	if t.closeRead != nil {
 		if err := t.closeRead(); err != nil {

--- a/bigtable/internal/session/table.go
+++ b/bigtable/internal/session/table.go
@@ -64,16 +64,27 @@ type sessionTable struct {
 	writeVRpcDesc  btransport.VRpcDescriptor
 	md             metadata.MD
 	metricsFactory *metrics.Factory
+	// closeRead / closeWrite release the per-resource pool entries on
+	// this sessionTable's Close(). Both are supplied by sessionClient
+	// via buildLazyReleaser and no-op cleanly when the pool was never
+	// opened or the client already tore itself down. closeWrite is nil
+	// for materialized views (read-only resources), mirroring the nil
+	// write side of the openRead/openWrite pair.
+	closeRead  func() error
+	closeWrite func() error
 }
 
 // newSessionTable is the internal constructor. Callers (sessionClient)
-// build the lazyPool open closures + supply the vRPC descriptors and
-// resource-scoped metadata. metricsFactory may be nil to disable
-// per-attempt metrics.
+// build the lazyPool open + release closures, supply the vRPC
+// descriptors, and resource-scoped metadata. metricsFactory may be nil
+// to disable per-attempt metrics. closeWrite may be nil for
+// materialized views (no write side).
 func newSessionTable(
 	tableID string,
 	openRead func() (Invoker, error),
 	openWrite func() (Invoker, error),
+	closeRead func() error,
+	closeWrite func() error,
 	readVRpcDesc btransport.VRpcDescriptor,
 	writeVRpcDesc btransport.VRpcDescriptor,
 	md metadata.MD,
@@ -87,6 +98,8 @@ func newSessionTable(
 		writeVRpcDesc:  writeVRpcDesc,
 		md:             md,
 		metricsFactory: metricsFactory,
+		closeRead:      closeRead,
+		closeWrite:     closeWrite,
 	}
 }
 
@@ -219,12 +232,34 @@ func dispatch[Args any, R any, Resp interface {
 	return resp, nil
 }
 
-// Close is a no-op today — the underlying pools are shared across
-// resources via sessionClient.pools and torn down by sessionClient.Close.
-// Retained on the interface so callers get a symmetric Open/Close
-// pattern and future implementations can add per-resource teardown.
+// Close releases this sessionTable's underlying read + write session
+// pools from the sessionClient's per-resource keyed map. Both release
+// closures are idempotent (second call finds the map entry absent
+// and no-ops) so double-close from the cache sweeper + explicit
+// caller is safe.
+//
+// Safety of per-handle pool teardown rests on a caller-side invariant:
+// bigtable.Client's sessionTableCache guarantees at-most-one
+// sessionTable per resource at any moment, so no co-owner can be
+// mid-flight on the pool we're closing. If session.Client ever gains
+// a caller that bypasses that cache, this method must gain a refcount
+// on the sessionClient side (or the caller must add its own).
+//
+// Returns the joined read + write teardown errors (nil for the
+// materialized-view case where closeWrite is nil).
 func (t *sessionTable) Close() error {
-	return nil
+	var errs []error
+	if t.closeRead != nil {
+		if err := t.closeRead(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if t.closeWrite != nil {
+		if err := t.closeWrite(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // ensureTracer returns a Tracer stashed on ctx (via metrics.NewContext

--- a/bigtable/internal/session/table_test.go
+++ b/bigtable/internal/session/table_test.go
@@ -16,8 +16,10 @@ package session
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -585,3 +587,110 @@ func TestSessionTable_Close_ReleasersIdempotent(t *testing.T) {
 	}
 }
 
+// TestSessionTable_Close_RacingLazyOpen_NoLeak proves the guardOpen
+// wrapper cleans up a fresh pool that the underlying opener inserted
+// AFTER Close's releaser already no-op'd on an empty map. Reproduces
+// PR #20264 review comment (high): openRead's slow path straddles
+// Close, releaser sees no entry, opener finishes and inserts → leak.
+//
+// Interleaving:
+//  1. Goroutine A calls readPool.get() → guardOpen check passes
+//     (closed=false) → openRead blocks on unblockOpen chan.
+//  2. Main calls tbl.Close() → sets closed=true → invokes closeRead
+//     which increments releaseCalls; simulated "map lookup misses"
+//     because openRead hasn't inserted yet (fake release no-ops but
+//     the counter records the attempt).
+//  3. Main unblocks openRead. openRead returns "inserted a pool".
+//  4. guardOpen's post-check sees closed=true → calls release AGAIN
+//     to clean up its own insert. releaseCalls == 2.
+//  5. Return ErrClientClosed to the caller.
+//
+// Without the fix: releaseCalls == 1 (Close-side only), openRead
+// returned a fake pool that no one owns → leak.
+func TestSessionTable_Close_RacingLazyOpen_NoLeak(t *testing.T) {
+	unblockOpen := make(chan struct{})
+	openStarted := make(chan struct{})
+	var releaseCalls atomic.Int32
+	// Sentinel invoker returned by the fake openRead — proves the opener
+	// actually completed and returned a "pool" that would leak absent the
+	// post-check.
+	fakeInv := (Invoker)(nil)
+
+	tbl := newSessionTable(
+		"t",
+		func() (Invoker, error) {
+			close(openStarted)
+			<-unblockOpen
+			return fakeInv, nil
+		},
+		nil,
+		func() error { releaseCalls.Add(1); return nil },
+		nil,
+		&btransport.VRpcDescriptorImpl{MethodName: "test.ReadRow"},
+		nil,
+		nil, nil,
+	)
+
+	var (
+		wg         sync.WaitGroup
+		gotErr     error
+		gotInvoker Invoker
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		gotInvoker, gotErr = tbl.readPool.get()
+	}()
+
+	<-openStarted // opener is blocked, guarantees Close runs first
+	if err := tbl.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	close(unblockOpen)
+	wg.Wait()
+
+	if !errors.Is(gotErr, ErrClientClosed) {
+		t.Errorf("readPool.get() err = %v, want ErrClientClosed", gotErr)
+	}
+	if gotInvoker != nil {
+		t.Errorf("readPool.get() returned non-nil invoker %v, want nil", gotInvoker)
+	}
+	if got := releaseCalls.Load(); got != 2 {
+		t.Errorf("release called %d times, want 2 (once by Close, once by guardOpen post-check cleanup)", got)
+	}
+}
+
+// TestSessionTable_Close_BeforeLazyOpen_EarlyBail proves the guardOpen
+// early check short-circuits when Close ran before the opener ever
+// started. openRead is never invoked.
+func TestSessionTable_Close_BeforeLazyOpen_EarlyBail(t *testing.T) {
+	var openCalled atomic.Int32
+	var releaseCalls atomic.Int32
+	tbl := newSessionTable(
+		"t",
+		func() (Invoker, error) { openCalled.Add(1); return nil, nil },
+		nil,
+		func() error { releaseCalls.Add(1); return nil },
+		nil,
+		&btransport.VRpcDescriptorImpl{MethodName: "test.ReadRow"},
+		nil,
+		nil, nil,
+	)
+
+	if err := tbl.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	inv, err := tbl.readPool.get()
+	if !errors.Is(err, ErrClientClosed) {
+		t.Errorf("readPool.get() after Close err = %v, want ErrClientClosed", err)
+	}
+	if inv != nil {
+		t.Errorf("readPool.get() after Close inv = %v, want nil", inv)
+	}
+	if openCalled.Load() != 0 {
+		t.Errorf("openRead was called %d times after Close, want 0 (early bail should short-circuit)", openCalled.Load())
+	}
+	if releaseCalls.Load() != 1 {
+		t.Errorf("release called %d times, want 1 (Close's own release only; guardOpen never entered inner)", releaseCalls.Load())
+	}
+}

--- a/bigtable/internal/session/table_test.go
+++ b/bigtable/internal/session/table_test.go
@@ -16,6 +16,7 @@ package session
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -80,6 +81,8 @@ func newTestTable(t *testing.T, readInv, writeInv Invoker) (*sessionTable, *sdkm
 		"test-table",
 		openRead,
 		openWrite,
+		nil, // closeRead — fake pools don't back real releaseSessionPool
+		nil, // closeWrite
 		&btransport.VRpcDescriptorImpl{MethodName: "test.ReadRow"},
 		&btransport.VRpcDescriptorImpl{MethodName: "test.MutateRow"},
 		nil,
@@ -480,3 +483,105 @@ func TestSessionTable_ReadAndWritePoolsDoNotShareSessions(t *testing.T) {
 		t.Errorf("readInv.calls after MutateRow = %d, want still 1 — read pool MUST NOT receive write traffic", got)
 	}
 }
+
+// --- Close teardown ---------------------------------------------------------
+
+// TestSessionTable_Close_CallsBothReleasers verifies Close fires the
+// closeRead and closeWrite release closures exactly once each.
+func TestSessionTable_Close_CallsBothReleasers(t *testing.T) {
+	var reads, writes int
+	tbl := newSessionTable(
+		"t",
+		func() (Invoker, error) { return nil, nil },
+		func() (Invoker, error) { return nil, nil },
+		func() error { reads++; return nil },
+		func() error { writes++; return nil },
+		&btransport.VRpcDescriptorImpl{MethodName: "test.ReadRow"},
+		&btransport.VRpcDescriptorImpl{MethodName: "test.MutateRow"},
+		nil, nil,
+	)
+	if err := tbl.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if reads != 1 || writes != 1 {
+		t.Errorf("release call counts = (read=%d write=%d), want (1,1)", reads, writes)
+	}
+}
+
+// TestSessionTable_Close_NilWriteReleaserOK covers the materialized-
+// view case: no write side means closeWrite is nil; Close must not
+// panic and must still call closeRead.
+func TestSessionTable_Close_NilWriteReleaserOK(t *testing.T) {
+	var reads int
+	tbl := newSessionTable(
+		"",
+		func() (Invoker, error) { return nil, nil },
+		nil,
+		func() error { reads++; return nil },
+		nil,
+		&btransport.VRpcDescriptorImpl{MethodName: "test.ReadRow"},
+		nil,
+		nil, nil,
+	)
+	if err := tbl.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if reads != 1 {
+		t.Errorf("closeRead called %d times, want 1", reads)
+	}
+}
+
+// TestSessionTable_Close_JoinsErrors: when BOTH release closures
+// return errors, Close returns them via errors.Join so callers see
+// both root causes rather than losing one to a first-error return.
+func TestSessionTable_Close_JoinsErrors(t *testing.T) {
+	readErr := status.Error(codes.Internal, "read pool teardown failed")
+	writeErr := status.Error(codes.Internal, "write pool teardown failed")
+	tbl := newSessionTable(
+		"t",
+		func() (Invoker, error) { return nil, nil },
+		func() (Invoker, error) { return nil, nil },
+		func() error { return readErr },
+		func() error { return writeErr },
+		&btransport.VRpcDescriptorImpl{MethodName: "test.ReadRow"},
+		&btransport.VRpcDescriptorImpl{MethodName: "test.MutateRow"},
+		nil, nil,
+	)
+	err := tbl.Close()
+	if err == nil {
+		t.Fatal("Close returned nil, want joined errors")
+	}
+	if got := err.Error(); !strings.Contains(got, "read pool teardown failed") || !strings.Contains(got, "write pool teardown failed") {
+		t.Errorf("Close error = %q; want both read+write causes surfaced", got)
+	}
+}
+
+// TestSessionTable_Close_ReleasersIdempotent verifies a second Close
+// call still runs the release closures (they're idempotent at the
+// sessionClient layer — second releaseSessionPool call finds the
+// entry absent and no-ops). The point is that sessionTable.Close
+// itself does not gate on a once — the underlying release is where
+// idempotency lives.
+func TestSessionTable_Close_ReleasersIdempotent(t *testing.T) {
+	var reads int
+	tbl := newSessionTable(
+		"t",
+		func() (Invoker, error) { return nil, nil },
+		nil,
+		func() error { reads++; return nil },
+		nil,
+		&btransport.VRpcDescriptorImpl{MethodName: "test.ReadRow"},
+		nil,
+		nil, nil,
+	)
+	if err := tbl.Close(); err != nil {
+		t.Fatalf("Close #1: %v", err)
+	}
+	if err := tbl.Close(); err != nil {
+		t.Fatalf("Close #2: %v", err)
+	}
+	if reads != 2 {
+		t.Errorf("closeRead called %d times across two Close calls, want 2 (release is caller-idempotent, not sessionTable-once-guarded)", reads)
+	}
+}
+

--- a/bigtable/open_test.go
+++ b/bigtable/open_test.go
@@ -429,9 +429,10 @@ func openNoop(key string) func() session.TableAPI {
 }
 
 // openClosing returns an openFn that constructs a
-// *closeCountingTable stamped with the given key, incrementing
-// *counter on every Close call.
-func openClosing(key string, counter *int) func() session.TableAPI {
+// *closeCountingTable stamped with the given key, atomically
+// incrementing counter on every Close call. Counter is atomic so
+// sweeper-goroutine writes don't race the test's Load.
+func openClosing(key string, counter *atomic.Int32) func() session.TableAPI {
 	return func() session.TableAPI {
 		return &closeCountingTable{noopSessionTable{key: key}, counter}
 	}
@@ -492,7 +493,7 @@ func TestSessionTableCache_ReadRowTouchesLastAccess(t *testing.T) {
 // (the closed one is not resurrected).
 func TestSessionTableCache_CloseEvictsAndFires(t *testing.T) {
 	clock := newFakeClock(time.Unix(1_700_000_000, 0))
-	closeCount := 0
+	var closeCount atomic.Int32
 	c := newSessionTableCache(1*time.Hour, 1*time.Second, clock.now)
 	t.Cleanup(c.close)
 
@@ -500,8 +501,8 @@ func TestSessionTableCache_CloseEvictsAndFires(t *testing.T) {
 	if err := h1.Close(); err != nil {
 		t.Fatalf("h1.Close: %v", err)
 	}
-	if closeCount != 1 {
-		t.Errorf("underlying Close called %d times, want 1", closeCount)
+	if got := closeCount.Load(); got != 1 {
+		t.Errorf("underlying Close called %d times, want 1", got)
 	}
 	// Map should no longer contain the key.
 	c.mu.Lock()
@@ -521,8 +522,8 @@ func TestSessionTableCache_CloseEvictsAndFires(t *testing.T) {
 	if err := h1.Close(); err != nil {
 		t.Errorf("h1.Close (idempotent) err = %v, want nil", err)
 	}
-	if closeCount != 1 {
-		t.Errorf("underlying Close called %d times after double-Close, want 1 (Close is fully idempotent)", closeCount)
+	if got := closeCount.Load(); got != 1 {
+		t.Errorf("underlying Close called %d times after double-Close, want 1 (Close is fully idempotent)", got)
 	}
 }
 
@@ -531,7 +532,7 @@ func TestSessionTableCache_CloseEvictsAndFires(t *testing.T) {
 // calls the underlying Close on eviction.
 func TestSessionTableCache_TTLSweepEvictsIdle(t *testing.T) {
 	clock := newFakeClock(time.Unix(1_700_000_000, 0))
-	closeCount := 0
+	var closeCount atomic.Int32
 	c := newSessionTableCache(1*time.Hour, 1*time.Millisecond, clock.now)
 	t.Cleanup(c.close)
 
@@ -559,8 +560,8 @@ func TestSessionTableCache_TTLSweepEvictsIdle(t *testing.T) {
 	if n != 0 {
 		t.Errorf("entries remaining after TTL sweep = %d, want 0", n)
 	}
-	if closeCount != 2 {
-		t.Errorf("underlying Close called %d times on TTL evict, want 2", closeCount)
+	if got := closeCount.Load(); got != 2 {
+		t.Errorf("underlying Close called %d times on TTL evict, want 2", got)
 	}
 }
 
@@ -593,7 +594,7 @@ func TestSessionTableCache_TouchDefersEviction(t *testing.T) {
 // itself stops the sweeper and closes every remaining entry.
 func TestSessionTableCache_CloseEvictsAll(t *testing.T) {
 	clock := newFakeClock(time.Unix(1_700_000_000, 0))
-	closeCount := 0
+	var closeCount atomic.Int32
 	c := newSessionTableCache(1*time.Hour, 1*time.Hour, clock.now)
 
 	_ = c.getOrOpen("tbl:a", openClosing("tbl:a", &closeCount))
@@ -602,21 +603,78 @@ func TestSessionTableCache_CloseEvictsAll(t *testing.T) {
 
 	c.close()
 
-	if closeCount != 3 {
-		t.Errorf("close(): underlying Close called %d times, want 3", closeCount)
+	if got := closeCount.Load(); got != 3 {
+		t.Errorf("close(): underlying Close called %d times, want 3", got)
 	}
 	// close() is idempotent.
 	c.close()
 }
 
-// closeCountingTable is a noopSessionTable that increments a counter
-// on Close so tests can assert eviction actually called Close.
+// TestSessionTableCache_ClosedGate_SlowPathInsertNoLeak reproduces
+// audit finding #5: without the closed-gate in getOrOpen's slow path,
+// a caller whose openFn straddles cache.close() would leak the
+// freshly-opened api (installed into a cache the sweeper has already
+// stopped clearing). This test forces that interleaving via a
+// synchronization channel on the openFn.
+//
+// Shape: caller A begins getOrOpen("k") on an empty cache. Fast-path
+// misses. Slow-path calls openFn. openFn blocks until we signal it to
+// return. Meanwhile close() runs on the cache (flips closed, walks the
+// empty map). Then openFn returns. getOrOpen re-locks, sees closed,
+// releases the fresh api itself, and returns nil. Underlying api's
+// Close counter must reach 1.
+func TestSessionTableCache_ClosedGate_SlowPathInsertNoLeak(t *testing.T) {
+	clock := newFakeClock(time.Unix(1_700_000_000, 0))
+	var closeCount atomic.Int32
+	c := newSessionTableCache(1*time.Hour, 1*time.Hour, clock.now)
+
+	release := make(chan struct{})
+	opened := make(chan struct{})
+	openFn := func() session.TableAPI {
+		close(opened)
+		<-release
+		return &closeCountingTable{noopSessionTable{key: "k"}, &closeCount}
+	}
+
+	var result session.TableAPI
+	done := make(chan struct{})
+	go func() {
+		result = c.getOrOpen("k", openFn)
+		close(done)
+	}()
+
+	// Wait until openFn is in-flight, THEN close the cache. This is the
+	// race window: openFn returns AFTER close() completed.
+	<-opened
+	c.close()
+	close(release)
+	<-done
+
+	if result != nil {
+		t.Errorf("getOrOpen returned non-nil after cache close: %v (want nil so TableShim falls back to classic)", result)
+	}
+	if got := closeCount.Load(); got != 1 {
+		t.Errorf("underlying api Close called %d times, want 1 (slow-path insert must release its api when cache is closed)", got)
+	}
+	// Cache map must be empty — the fresh api MUST NOT have been
+	// installed into an already-closed cache.
+	c.mu.Lock()
+	n := len(c.entries)
+	c.mu.Unlock()
+	if n != 0 {
+		t.Errorf("cache.entries has %d entries after close-race; want 0 (fresh handle must not be installed)", n)
+	}
+}
+
+// closeCountingTable is a noopSessionTable that atomically
+// increments a counter on Close so tests can assert eviction actually
+// called Close from any goroutine (including the cache sweeper).
 type closeCountingTable struct {
 	noopSessionTable
-	counter *int
+	counter *atomic.Int32
 }
 
 func (c *closeCountingTable) Close() error {
-	*c.counter++
+	c.counter.Add(1)
 	return nil
 }

--- a/bigtable/session_table_cache.go
+++ b/bigtable/session_table_cache.go
@@ -45,12 +45,14 @@ var (
 // every subsequent Close() call — that keeps the observable behavior
 // stable for callers that treat Close as a query.
 //
-// Caveat about the underlying Close: the session.TableAPI godoc
-// promises per-resource pool teardown, but sessionTable.Close in
-// internal/session/table.go is a no-op today — pools are torn down
-// only when session.Client.Close fires. Until the session package
-// grows real per-resource teardown, this cache's eviction frees the
-// bigtable-side map entry but not the session pools.
+// Underlying Close: session.TableAPI.Close (sessionTable.Close in
+// internal/session/table.go) releases the per-resource read + write
+// pool entries from sessionClient.sessionPools. Cache eviction — TTL
+// sweep, explicit handle Close, or cache-wide shutdown — therefore
+// actually reclaims the session pools for the resource. Safety of
+// per-handle teardown depends on this cache's at-most-one-handle-per-
+// key invariant, which acts as an implicit refcount of size 1; see
+// sessionTable.Close's doc.
 type sessionTableHandle struct {
 	api            session.TableAPI
 	key            string
@@ -104,6 +106,12 @@ type sessionTableCache struct {
 
 	mu      sync.Mutex
 	entries map[string]*sessionTableHandle
+	// closed is flipped by close() under mu. getOrOpen's slow path
+	// re-checks it before inserting the freshly-opened handle so a
+	// slow-path insert straddling close() can't orphan a live
+	// underlying api (which would leak its per-resource session pool
+	// once sessionTable.Close does real teardown).
+	closed bool
 
 	stopOnce sync.Once
 	stop     chan struct{}
@@ -164,6 +172,18 @@ func (c *sessionTableCache) getOrOpen(key string, openFn func() session.TableAPI
 	}
 
 	c.mu.Lock()
+	if c.closed {
+		// close() ran between the slow-path openFn and our re-lock.
+		// If we inserted this handle now, nothing would ever call
+		// its Close (sweeper stopped, close() already snapshotted an
+		// empty map, cache-Close is stopOnce-guarded). Release the
+		// freshly-opened api ourselves and return nil so the caller
+		// falls back to classic (TableShim treats nil session-side
+		// as classic-only).
+		c.mu.Unlock()
+		_ = api.Close()
+		return nil
+	}
 	if h, ok := c.entries[key]; ok {
 		c.mu.Unlock()
 		_ = api.Close() // duplicate opened concurrently; release its resources
@@ -249,6 +269,7 @@ func (c *sessionTableCache) close() {
 	c.sweeperG.Wait()
 
 	c.mu.Lock()
+	c.closed = true
 	remaining := make([]*sessionTableHandle, 0, len(c.entries))
 	for k, h := range c.entries {
 		remaining = append(remaining, h)


### PR DESCRIPTION
Fixes two related latent bugs in the session data plane:

1. **sessionTable.Close was a no-op** — the interface godoc at
   `bigtable/internal/session/api.go:45-48` promises to release the
   resource's read + write session pools; the implementation returned
   nil. Pools were reclaimed only by `sessionClient.Close`, so
   `bigtable.Client`'s TTL cache could evict a handle without freeing
   the underlying pool + streams + goroutines.

2. **sessionTableCache close-race (audit finding #5)** — a slow-path
   openFn straddling `sessionTableCache.close()` would install a
   fresh handle into a cache the sweeper had already stopped clearing.
   Zero-impact while sessionTable.Close was a no-op; a per-race pool
   leak once teardown becomes real.

## Design

Real teardown routed through symmetric release closures:

- `sessionClient.releaseSessionPool(key)` — under `sessionPoolsMu`,
  delete the entry then `unregister()` + `pool.Close()` outside the
  lock (matches the snapshot-under-lock pattern in `Close`).
- `buildLazyReleaser(key)` — sibling to `buildLazyOpener`; returns a
  `func() error` closure for a specific poolKey.
- `sessionTable.Close` — invokes closeRead + closeWrite, joining errors
  via `errors.Join`. Nil-safe for materialized views' missing write side.

No refcount inside sessionClient. Rationale: `bigtable.Client`'s
sessionTableCache dedupes handles per fully-qualified resource name,
so at-most-one sessionTable per resource per Client at any moment —
the cache is the 'refcount of at-most-1'. Doc on `sessionTable.Close`
names the invariant; a future caller bypassing the cache would need
to add a refcount then.

Paired cache guard: `sessionTableCache` gains a `closed bool` under
`c.mu`, flipped by `close()`. `getOrOpen`'s slow path re-checks it
before insert and, if set, releases the freshly-opened api and returns
nil so `TableShim` falls back to classic. Prevents the finding-#5 leak.

## Tests

New unit tests (all pass under `-race`):

- `TestSessionTable_Close_CallsBothReleasers`
- `TestSessionTable_Close_NilWriteReleaserOK` (materialized view)
- `TestSessionTable_Close_JoinsErrors`
- `TestSessionTable_Close_ReleasersIdempotent`
- `TestReleaseSessionPool_AfterClientClose_NoOp`
- `TestReleaseSessionPool_MissingKeyNoOp`
- `TestReleaseSessionPool_RemovesEntryAndInvokesUnregister`
- `TestSessionTableCache_ClosedGate_SlowPathInsertNoLeak`

## Drive-by

The pre-existing `closeCountingTable` test helper races between the
sweeper goroutine's `*counter++` and the test-goroutine's read. Switched
`*int` to `*atomic.Int32` so the full-package `-race` sweep is green
(fires on the base branch too — this was blocking my race-stress
verification).

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test -race -count=1 -short -timeout=120s ./ ./internal/session/ ./internal/transport/` — all green
- [x] `TestSessionTable_Close*` and `TestReleaseSessionPool*` — all pass
- [x] `TestSessionTableCache_ClosedGate_SlowPathInsertNoLeak` — reproduces the race deterministically, passes with the fix
- [x] Sandbox smoke against sushanb-uc1 via `CBT_RUN_SANDBOX=1 CBT_FORCE_SESSION=true`: Table + AV round-trip on both classic and session paths

## Stack

Stacked on #20263 (session_table_cache) which is stacked on #20262
(session.Client wiring into bigtable.Client Open*). Both must land
first, or this PR must be rebased onto main after they merge.