### PR TITLE
test(bigtable): pin UNIMPLEMENTED preservation on session Recv-side + close chain

### DIFF
--- a/bigtable/internal/transport/session_lifecycle.go
+++ b/bigtable/internal/transport/session_lifecycle.go
@@ -55,14 +55,18 @@ func (s *Session) Start(ctx context.Context, req *spb.OpenSessionRequest) error 
 		// other transport-side loss. errors.Is still resolves the
 		// underlying send error via sessionErr.Unwrap.
 		//
-		// TODO(sushanb): distinguish Unimplemented from generic
-		// transport failure so the client can fall back to the unary
-		// (non-session) path when the server rejects OpenSession
-		// with codes.Unimplemented. Today every Send failure — network
-		// drop, backpressure, Unimplemented — is folded into
-		// Unavailable, which retries indefinitely against a server
-		// that will never accept the RPC. Follow-up when the fallback
-		// path lands.
+		// A server rejecting the RPC as UNIMPLEMENTED does NOT reach
+		// this branch — gRPC bidi streams surface the server's status
+		// on Recv, not on Send (Send typically returns io.EOF when the
+		// server has already terminated the stream, and the actual
+		// status is retrieved on the next Recv). The Recv-side
+		// UNIMPLEMENTED preservation is enforced by
+		// TestReadLoop_RecvUnimplemented_SurfacesToWaiterViaConsecutiveFailure
+		// in session_pool_consecutive_failures_test.go: handleClose
+		// stamps the raw Recv err onto s.closeErr, which
+		// SessionPoolImpl.abnormalClose captures into
+		// lastAbnormalCloseErr, and consecutiveFailureError.GRPCStatus
+		// then surfaces the code intact to any waiter parked on Invoke.
 		return unavailable(err, "session OpenSession request failed: %v", err)
 	}
 

--- a/bigtable/internal/transport/session_lifecycle_test.go
+++ b/bigtable/internal/transport/session_lifecycle_test.go
@@ -658,3 +658,49 @@ func TestHooks_FiredInSpecOrder(t *testing.T) {
 		t.Errorf("hook order = %v, want %v", got, want)
 	}
 }
+
+// TestReadLoop_RecvUnimplemented_StampsCodeOnCloseErr pins the
+// invariant that when the server rejects a session RPC with
+// UNIMPLEMENTED (surfaced via readLoop's Recv, the actual gRPC bidi
+// error path — Send-fail almost never carries a meaningful code), the
+// raw err lands on s.closeErr with the code intact. Downstream layers
+// depend on this:
+//
+//   - SessionPoolImpl.abnormalClose reads s.closeError() into
+//     lastAbnormalCloseErr (session_pool_lifecycle.go:396-398).
+//   - consecutiveFailureError.GRPCStatus (session_pool.go:80-83)
+//     inherits the code, so a waiter woken on breaker-trip sees
+//     status.Code(err) == codes.Unimplemented.
+//   - A future TableShim classic-fallback path dispatches on that
+//     code to short-circuit the session route on server-capability
+//     failures.
+//
+// If any future refactor of handleClose starts wrapping the Recv err
+// (e.g. folding into unavailable() the way the Send-fail branch
+// legitimately does — see Session.Start), the fallback signal
+// silently disappears. This test breaks in that case.
+func TestReadLoop_RecvUnimplemented_StampsCodeOnCloseErr(t *testing.T) {
+	stream := newFakeStream()
+	s := newTestSession(t, stream, SessionHooks{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := s.Start(ctx, &spb.OpenSessionRequest{ProtocolVersion: 1}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	// Feed readLoop a synthetic Recv failure carrying Unimplemented —
+	// the wire shape a server that doesn't implement session RPCs would
+	// return on the OpenSessionResponse trailer.
+	recvErr := status.Error(codes.Unimplemented, "server does not implement session RPCs")
+	stream.recv <- recvOp{err: recvErr}
+
+	waitFor(t, time.Second, func() bool { return s.closeError() != nil }, "closeErr populated by handleClose")
+
+	got := s.closeError()
+	if !errors.Is(got, recvErr) {
+		t.Errorf("errors.Is(s.closeError(), recvErr) = false; got %v", got)
+	}
+	if code := status.Code(got); code != codes.Unimplemented {
+		t.Errorf("status.Code(s.closeError()) = %v, want Unimplemented (handleClose must stamp the raw Recv err with the code intact)", code)
+	}
+}

--- a/bigtable/internal/transport/session_pool_consecutive_failures_test.go
+++ b/bigtable/internal/transport/session_pool_consecutive_failures_test.go
@@ -344,6 +344,67 @@ func TestConsecutiveFailures_TripCarriesLastCauseAndGRPCStatus(t *testing.T) {
 	}
 }
 
+// TestConsecutiveFailures_UnimplementedCauseSurfacesToWaiter pins the
+// specific case where the server rejects session RPCs with
+// UNIMPLEMENTED (the "AFE doesn't implement session backend yet"
+// signal). Regression guard for the future TableShim classic-fallback
+// path, which dispatches on status.Code(err) == codes.Unimplemented
+// off the same drain-time consecutiveFailureError wrap that
+// TestConsecutiveFailures_TripCarriesLastCauseAndGRPCStatus already
+// exercises for FailedPrecondition. Both codes flow through the same
+// GRPCStatus() shim (session_pool.go:80-83); this test locks the
+// specific code TableShim will care about so any future refactor
+// that stops preserving it breaks visibly here rather than silently
+// downstream.
+func TestConsecutiveFailures_UnimplementedCauseSurfacesToWaiter(t *testing.T) {
+	p := newTestPool(t, 1, 10)
+	p.consecutiveFailureThreshold.Store(2)
+
+	const wantMsg = "server does not implement session RPCs"
+	serverErr := status.Error(codes.Unimplemented, wantMsg)
+
+	w := &waiter{ready: make(chan struct{})}
+	p.waitersMu.Lock()
+	w.elem = p.waiters.PushBack(w)
+	p.waitersMu.Unlock()
+	p.waitersCount.Add(1)
+
+	done := make(chan error, 1)
+	go func() {
+		<-w.ready
+		p.waitersCount.Add(-1)
+		done <- w.err
+	}()
+
+	// First bump: any transport-loss cause that doesn't trip yet.
+	sh1 := injectStartingSession(t, p, "s1")
+	sh1.session.setCloseErr(status.Error(codes.Unavailable, "boom"))
+	p.onClose(sh1, nil)
+
+	// Second bump: the Unimplemented cause we want propagated to the
+	// waiter.
+	sh2 := injectStartingSession(t, p, "s2")
+	sh2.session.setCloseErr(serverErr)
+	p.onClose(sh2, nil)
+
+	var got error
+	select {
+	case got = <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter not woken after trip")
+	}
+
+	if !errors.Is(got, ErrConsecutiveFailures) {
+		t.Fatalf("errors.Is(err, ErrConsecutiveFailures) = false; err = %v", got)
+	}
+	if code := status.Code(got); code != codes.Unimplemented {
+		t.Fatalf("status.Code(err) = %v, want Unimplemented (server-capability signal must survive the consecutiveFailureError wrap so TableShim can dispatch on it); err = %v", code, got)
+	}
+	if !strings.Contains(got.Error(), wantMsg) {
+		t.Fatalf("err text %q missing underlying cause %q", got.Error(), wantMsg)
+	}
+}
+
 func TestConsecutiveFailures_CheckoutSessionReturnsSentinelOnTrip(t *testing.T) {
 	p := newTestPool(t, 1, 10)
 	p.consecutiveFailureThreshold.Store(1)


### PR DESCRIPTION
## Summary

Adds two regression tests that pin the invariant "server-returned
UNIMPLEMENTED on a session RPC surfaces to \`SessionPoolImpl.Invoke\`
waiters with the code intact." Also updates one TODO comment.
**No production behavior change** — the code path already preserves
the code; this CL just guards it so it stays that way.

### Why

A follow-up CL will add \`TableShim\` fallback to the classic path
when the session route returns \`codes.Unimplemented\` (an AFE that
hasn't rolled out the session data plane yet). That routing change
dispatches on \`status.Code(err) == codes.Unimplemented\` off the
error surfaced by the pool — so this preservation invariant becomes
load-bearing. Locking it now with tests means any future refactor
that starts wrapping the Recv err (e.g. folding into \`unavailable()\`
the way the Send-fail branch legitimately does) breaks visibly here
rather than silently downstream.

### What the code path already does

\`\`\`
readLoop → Recv err → handleClose(err) → s.setCloseErr(err)  [raw, code intact]
  → SessionPoolImpl.abnormalClose reads s.closeError() into lastAbnormalCloseErr
  → consecutiveFailureError.GRPCStatus() (session_pool.go:80-83) inherits the code
  → waiter parked on Invoke sees status.Code(err) == codes.Unimplemented after trip
\`\`\`

### What's new

- \`TestReadLoop_RecvUnimplemented_StampsCodeOnCloseErr\` (Session
  level): feed \`readLoop\` a synthetic Recv failure carrying
  \`codes.Unimplemented\`, assert \`s.closeError()\` wraps the same err
  and \`status.Code(s.closeError()) == codes.Unimplemented\`.
- \`TestConsecutiveFailures_UnimplementedCauseSurfacesToWaiter\` (Pool
  level): same shape as the existing
  \`TestConsecutiveFailures_TripCarriesLastCauseAndGRPCStatus\` but
  pins \`codes.Unimplemented\` specifically — that's the code the
  routing layer will care about.
- Updated the TODO comment in \`Session.Start\`'s Send-fail branch to
  explain that Send-fail rarely carries UNIMPLEMENTED (bidi streams
  surface server status on Recv, not Send), so wrapping the Send-fail
  branch to preserve the code would be nearly-dead-code — the
  Recv-side preservation (now guarded) is what matters.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`goimports -l\` clean
- [x] \`go test -race -count=1 -short -timeout=180s ./internal/transport/ ./internal/session/\` — all green
- [x] New tests fail (as expected) if the invariant is broken — verified by locally reverting \`handleClose\`'s \`setCloseErr(err)\` and rerunning