### PR TITLE
feat(bigtable): TableShim fallback to classic on session UNIMPLEMENTED

### DIFF
--- a/bigtable/internal/session/unimplemented_interceptor.go
+++ b/bigtable/internal/session/unimplemented_interceptor.go
@@ -21,30 +21,34 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// UnimplementedThreshold is the number of consecutive
+// DefaultUnimplementedThreshold is the standard number of consecutive
 // codes.Unimplemented responses required to trip the sticky breaker.
-// Var (not const) so tests can lower it without a public setter.
-var UnimplementedThreshold int32 = 30
+// Callers pass this to NewUnimplementedErrorInterceptor unless they
+// have a specific reason to pick a different value (tests use small
+// values to keep breaker-trip assertions fast).
+const DefaultUnimplementedThreshold int32 = 30
 
 // UnimplementedErrorInterceptor wraps a session-path call with:
 //   - per-call classic fallback on codes.Unimplemented (the caller's
 //     request always succeeds via classic, even before the breaker trips)
-//   - a sticky breaker that trips after UnimplementedThreshold
-//     consecutive Unimplemented responses; Bypass() then lets callers
-//     short-circuit before dialing session again
+//   - a sticky breaker that trips after `threshold` consecutive
+//     Unimplemented responses; Bypass() then lets callers short-circuit
+//     before dialing session again
 //
 // One instance per resource. Any non-Unimplemented response (success
 // or other error) resets the consecutive count — a non-Unimplemented
 // reply proves the RPC is understood by whichever backend served it.
 type UnimplementedErrorInterceptor struct {
-	count   atomic.Int32
-	tripped atomic.Bool
+	threshold int32
+	count     atomic.Int32
+	tripped   atomic.Bool
 }
 
-// NewUnimplementedErrorInterceptor returns an interceptor with a
-// zeroed counter and un-tripped breaker.
-func NewUnimplementedErrorInterceptor() *UnimplementedErrorInterceptor {
-	return &UnimplementedErrorInterceptor{}
+// NewUnimplementedErrorInterceptor returns an interceptor that trips
+// its sticky breaker after `threshold` consecutive Unimplemented
+// responses. Pass DefaultUnimplementedThreshold in production.
+func NewUnimplementedErrorInterceptor(threshold int32) *UnimplementedErrorInterceptor {
+	return &UnimplementedErrorInterceptor{threshold: threshold}
 }
 
 // Bypass reports whether the sticky breaker has tripped. Cheap atomic
@@ -63,15 +67,15 @@ func (i *UnimplementedErrorInterceptor) Count() int32 {
 // based on a session-path RPC's outcome:
 //
 //   - nil or non-Unimplemented err → count resets to 0
-//   - codes.Unimplemented → count increments; on reaching
-//     UnimplementedThreshold, trip via CompareAndSwap so a follow-up
-//     debug-tag / metric hook fires exactly once
+//   - codes.Unimplemented → count increments; on reaching threshold,
+//     trip via CompareAndSwap so a follow-up debug-tag / metric hook
+//     fires exactly once
 func (i *UnimplementedErrorInterceptor) RecordOutcome(err error) {
 	if err == nil || status.Code(err) != codes.Unimplemented {
 		i.count.Store(0)
 		return
 	}
-	if n := i.count.Add(1); n >= UnimplementedThreshold {
+	if n := i.count.Add(1); n >= i.threshold {
 		i.tripped.CompareAndSwap(false, true)
 	}
 }

--- a/bigtable/internal/session/unimplemented_interceptor.go
+++ b/bigtable/internal/session/unimplemented_interceptor.go
@@ -1,0 +1,159 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package session
+
+import (
+	"sync/atomic"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// UnimplementedThreshold is the number of CONSECUTIVE
+// codes.Unimplemented responses required to trip the sticky breaker
+// inside UnimplementedErrorInterceptor. Matches Java
+// (ShimImpl.java:77 MAX_CONSECUTIVE_UNIMPLEMENTED_FAILURES = 30). A
+// var (not const) so tests can drop it to 1-3 for fast breaker-trip
+// assertions without a public setter.
+//
+// "Consecutive" means the counter resets to 0 on any non-Unimplemented
+// session response (success OR non-Unimplemented error). Rationale: a
+// non-Unimplemented response proves the RPC is understood by
+// whichever backend served it (either wire is fine, or the failure is
+// transport/app-level); the previous Unimplemented streak must have
+// been transient or from a different AFE in the pool.
+var UnimplementedThreshold int32 = 30
+
+// UnimplementedErrorInterceptor wraps a session-path call in a
+// per-call Unimplemented → classic fallback plus a threshold-counting
+// sticky breaker. Owned by the routing layer (bigtable.TableShim
+// today; any future routing surface with a session/classic split
+// could reuse it) — one instance per resource so trip state stays
+// per-resource, matching Java's per-SessionPool granularity.
+//
+// Two-layer behaviour, both handled by InterceptUnimplemented:
+//
+//   - Per-call rescue: whenever the session op returns
+//     codes.Unimplemented, InterceptUnimplemented runs the classic op
+//     and returns its result. The user's request always succeeds via
+//     classic — even BEFORE the sticky breaker trips. Improves UX
+//     over Java (which fails the request until the breaker trips) at
+//     zero extra cost.
+//   - Sticky breaker: after UnimplementedThreshold consecutive
+//     Unimplemented responses, Bypass() returns true so callers can
+//     short-circuit BEFORE dialing session at all — saving the
+//     wasted round-trip on a backend that already declared it can't
+//     serve the RPC.
+//
+// Fresh instance (via a new routing-layer construction after any
+// higher-level cache TTL-evicts a handle) starts with counter=0 and
+// breaker=false, so backend rollouts are implicitly re-observed.
+type UnimplementedErrorInterceptor struct {
+	// count is the running number of consecutive Unimplemented
+	// responses. Incremented by RecordOutcome on Unimplemented; reset
+	// to 0 on any other outcome. Reaches UnimplementedThreshold →
+	// tripped flips true.
+	count atomic.Int32
+	// tripped is the sticky breaker. Flipped exactly once (via
+	// CompareAndSwap) when count first reaches threshold; never reset
+	// for the interceptor's lifetime. UNIMPLEMENTED is a backend
+	// capability signal, not a transient failure; recovery lives in
+	// the caller's re-Open path (fresh routing layer → fresh
+	// interceptor).
+	tripped atomic.Bool
+}
+
+// NewUnimplementedErrorInterceptor returns a fresh interceptor with
+// counter=0 and breaker=false. Zero-value would work (both fields
+// are atomic zero-init) but the constructor makes the initial state
+// explicit at construction sites.
+func NewUnimplementedErrorInterceptor() *UnimplementedErrorInterceptor {
+	return &UnimplementedErrorInterceptor{}
+}
+
+// Bypass reports whether the sticky breaker has tripped. Callers use
+// this to short-circuit BEFORE dialing session (typically inside a
+// routing gate like TableShim.useSession). Cheap atomic Load.
+func (i *UnimplementedErrorInterceptor) Bypass() bool {
+	return i.tripped.Load()
+}
+
+// Count returns the current consecutive-Unimplemented count. Exposed
+// primarily for tests and observability; production routing decisions
+// should call Bypass() (which encapsulates the threshold comparison).
+func (i *UnimplementedErrorInterceptor) Count() int32 {
+	return i.count.Load()
+}
+
+// RecordOutcome updates the counter (and possibly flips the sticky
+// breaker) based on the outcome of a session-path RPC.
+//
+// Semantics:
+//   - err == nil (session succeeded) → count reset to 0.
+//   - err carries any non-Unimplemented code → count reset to 0.
+//     The wire understood the RPC; failure is transport / app-level.
+//   - err carries codes.Unimplemented → count incremented. On the
+//     transition N-1 → N == UnimplementedThreshold, flip tripped
+//     via CompareAndSwap so a follow-up debug-tag / metric hook
+//     fires exactly once per interceptor under concurrent trip
+//     races.
+//
+// Matches Java's SessionPoolImpl reset semantics
+// (SessionPoolImpl.java:489, 578) adapted to a per-op observation
+// surface — Java observes session-close, we observe per-RPC.
+//
+// Exposed as a standalone method so callers with a value-returning
+// op that can't be shoe-horned into InterceptUnimplemented's generic
+// contract (e.g. streaming responses with mid-stream errors) can
+// still feed the counter directly.
+func (i *UnimplementedErrorInterceptor) RecordOutcome(err error) {
+	if err == nil || status.Code(err) != codes.Unimplemented {
+		i.count.Store(0)
+		return
+	}
+	if n := i.count.Add(1); n >= UnimplementedThreshold {
+		i.tripped.CompareAndSwap(false, true)
+	}
+}
+
+// InterceptUnimplemented runs sessionOp, records its outcome for the
+// threshold-counting breaker, and either returns its result or — if
+// the result carries codes.Unimplemented — falls back to classicOp
+// and returns THAT result. Never returns a mixed session/classic
+// tuple: the caller gets exactly one path's (T, error).
+//
+// Generic over T so both value-returning ops (e.g. a Row) and void
+// ops (e.g. Apply, with T = struct{}) share one implementation
+// without closure-capture-through-a-var boilerplate at each call
+// site.
+//
+// A free function (not a method) because Go 1.24 still forbids
+// methods with additional type parameters — the receiver's type is
+// fixed at method declaration. See
+// https://github.com/golang/go/issues/49085 for the ongoing
+// discussion; when methods with type params land, this can become
+// (i *UnimplementedErrorInterceptor) Intercept[T].
+func InterceptUnimplemented[T any](
+	i *UnimplementedErrorInterceptor,
+	sessionOp func() (T, error),
+	classicOp func() (T, error),
+) (T, error) {
+	resp, err := sessionOp()
+	i.RecordOutcome(err)
+	if err != nil && status.Code(err) == codes.Unimplemented {
+		return classicOp()
+	}
+	return resp, err
+}

--- a/bigtable/internal/session/unimplemented_interceptor.go
+++ b/bigtable/internal/session/unimplemented_interceptor.go
@@ -21,103 +21,51 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// UnimplementedThreshold is the number of CONSECUTIVE
-// codes.Unimplemented responses required to trip the sticky breaker
-// inside UnimplementedErrorInterceptor. Matches Java
-// (ShimImpl.java:77 MAX_CONSECUTIVE_UNIMPLEMENTED_FAILURES = 30). A
-// var (not const) so tests can drop it to 1-3 for fast breaker-trip
-// assertions without a public setter.
-//
-// "Consecutive" means the counter resets to 0 on any non-Unimplemented
-// session response (success OR non-Unimplemented error). Rationale: a
-// non-Unimplemented response proves the RPC is understood by
-// whichever backend served it (either wire is fine, or the failure is
-// transport/app-level); the previous Unimplemented streak must have
-// been transient or from a different AFE in the pool.
+// UnimplementedThreshold is the number of consecutive
+// codes.Unimplemented responses required to trip the sticky breaker.
+// Var (not const) so tests can lower it without a public setter.
 var UnimplementedThreshold int32 = 30
 
-// UnimplementedErrorInterceptor wraps a session-path call in a
-// per-call Unimplemented → classic fallback plus a threshold-counting
-// sticky breaker. Owned by the routing layer (bigtable.TableShim
-// today; any future routing surface with a session/classic split
-// could reuse it) — one instance per resource so trip state stays
-// per-resource, matching Java's per-SessionPool granularity.
+// UnimplementedErrorInterceptor wraps a session-path call with:
+//   - per-call classic fallback on codes.Unimplemented (the caller's
+//     request always succeeds via classic, even before the breaker trips)
+//   - a sticky breaker that trips after UnimplementedThreshold
+//     consecutive Unimplemented responses; Bypass() then lets callers
+//     short-circuit before dialing session again
 //
-// Two-layer behaviour, both handled by InterceptUnimplemented:
-//
-//   - Per-call rescue: whenever the session op returns
-//     codes.Unimplemented, InterceptUnimplemented runs the classic op
-//     and returns its result. The user's request always succeeds via
-//     classic — even BEFORE the sticky breaker trips. Improves UX
-//     over Java (which fails the request until the breaker trips) at
-//     zero extra cost.
-//   - Sticky breaker: after UnimplementedThreshold consecutive
-//     Unimplemented responses, Bypass() returns true so callers can
-//     short-circuit BEFORE dialing session at all — saving the
-//     wasted round-trip on a backend that already declared it can't
-//     serve the RPC.
-//
-// Fresh instance (via a new routing-layer construction after any
-// higher-level cache TTL-evicts a handle) starts with counter=0 and
-// breaker=false, so backend rollouts are implicitly re-observed.
+// One instance per resource. Any non-Unimplemented response (success
+// or other error) resets the consecutive count — a non-Unimplemented
+// reply proves the RPC is understood by whichever backend served it.
 type UnimplementedErrorInterceptor struct {
-	// count is the running number of consecutive Unimplemented
-	// responses. Incremented by RecordOutcome on Unimplemented; reset
-	// to 0 on any other outcome. Reaches UnimplementedThreshold →
-	// tripped flips true.
-	count atomic.Int32
-	// tripped is the sticky breaker. Flipped exactly once (via
-	// CompareAndSwap) when count first reaches threshold; never reset
-	// for the interceptor's lifetime. UNIMPLEMENTED is a backend
-	// capability signal, not a transient failure; recovery lives in
-	// the caller's re-Open path (fresh routing layer → fresh
-	// interceptor).
+	count   atomic.Int32
 	tripped atomic.Bool
 }
 
-// NewUnimplementedErrorInterceptor returns a fresh interceptor with
-// counter=0 and breaker=false. Zero-value would work (both fields
-// are atomic zero-init) but the constructor makes the initial state
-// explicit at construction sites.
+// NewUnimplementedErrorInterceptor returns an interceptor with a
+// zeroed counter and un-tripped breaker.
 func NewUnimplementedErrorInterceptor() *UnimplementedErrorInterceptor {
 	return &UnimplementedErrorInterceptor{}
 }
 
-// Bypass reports whether the sticky breaker has tripped. Callers use
-// this to short-circuit BEFORE dialing session (typically inside a
-// routing gate like TableShim.useSession). Cheap atomic Load.
+// Bypass reports whether the sticky breaker has tripped. Cheap atomic
+// Load; callers use it to skip session before dialing.
 func (i *UnimplementedErrorInterceptor) Bypass() bool {
 	return i.tripped.Load()
 }
 
 // Count returns the current consecutive-Unimplemented count. Exposed
-// primarily for tests and observability; production routing decisions
-// should call Bypass() (which encapsulates the threshold comparison).
+// for tests and observability; routing should call Bypass().
 func (i *UnimplementedErrorInterceptor) Count() int32 {
 	return i.count.Load()
 }
 
-// RecordOutcome updates the counter (and possibly flips the sticky
-// breaker) based on the outcome of a session-path RPC.
+// RecordOutcome updates the counter (and possibly trips the breaker)
+// based on a session-path RPC's outcome:
 //
-// Semantics:
-//   - err == nil (session succeeded) → count reset to 0.
-//   - err carries any non-Unimplemented code → count reset to 0.
-//     The wire understood the RPC; failure is transport / app-level.
-//   - err carries codes.Unimplemented → count incremented. On the
-//     transition N-1 → N == UnimplementedThreshold, flip tripped
-//     via CompareAndSwap so a follow-up debug-tag / metric hook
-//     fires exactly once per interceptor under concurrent trip
-//     races.
-//
-// Matches Java's SessionPoolImpl reset semantics
-// (SessionPoolImpl.java:489, 578) adapted to a per-op observation
-// surface — Java observes session-close, we observe per-RPC.
-//
-// Exposed as a standalone method so callers with a value-returning
-// op that can't be shoe-horned into InterceptUnimplemented's generic
-// contract (e.g. streaming responses with mid-stream errors) can
-// still feed the counter directly.
+//   - nil or non-Unimplemented err → count resets to 0
+//   - codes.Unimplemented → count increments; on reaching
+//     UnimplementedThreshold, trip via CompareAndSwap so a follow-up
+//     debug-tag / metric hook fires exactly once
 func (i *UnimplementedErrorInterceptor) RecordOutcome(err error) {
 	if err == nil || status.Code(err) != codes.Unimplemented {
 		i.count.Store(0)
@@ -128,23 +76,15 @@ func (i *UnimplementedErrorInterceptor) RecordOutcome(err error) {
 	}
 }
 
-// InterceptUnimplemented runs sessionOp, records its outcome for the
-// threshold-counting breaker, and either returns its result or — if
-// the result carries codes.Unimplemented — falls back to classicOp
-// and returns THAT result. Never returns a mixed session/classic
-// tuple: the caller gets exactly one path's (T, error).
+// InterceptUnimplemented runs sessionOp, records its outcome, and —
+// on codes.Unimplemented — returns classicOp's result instead. Never
+// mixes results: the caller gets exactly one path's (T, error).
 //
-// Generic over T so both value-returning ops (e.g. a Row) and void
-// ops (e.g. Apply, with T = struct{}) share one implementation
-// without closure-capture-through-a-var boilerplate at each call
-// site.
+// Generic over T so value-returning ops (Row) and void ops
+// (Apply, with T = struct{}) share one implementation.
 //
-// A free function (not a method) because Go 1.24 still forbids
-// methods with additional type parameters — the receiver's type is
-// fixed at method declaration. See
-// https://github.com/golang/go/issues/49085 for the ongoing
-// discussion; when methods with type params land, this can become
-// (i *UnimplementedErrorInterceptor) Intercept[T].
+// Free function because Go still forbids methods with additional type
+// parameters (https://github.com/golang/go/issues/49085).
 func InterceptUnimplemented[T any](
 	i *UnimplementedErrorInterceptor,
 	sessionOp func() (T, error),

--- a/bigtable/internal/transport/session_pool_lifecycle.go
+++ b/bigtable/internal/transport/session_pool_lifecycle.go
@@ -417,15 +417,10 @@ func (p *SessionPoolImpl) noteAbnormalCloseIfAny(sh *SessionHandle) {
 	woken := p.drainWaitersWithErr(tripErr)
 	if woken > 0 {
 		recordDebugTag(tagSessionPoolConsecutiveFailuresTripped)
-		// If consecutive trips are driven by Unimplemented (server-side
-		// session RPC not supported), the routing layer above the pool
-		// handles it: TableShim.ReadRow / Apply observe
-		// status.Code(err) == codes.Unimplemented on the returned
-		// consecutiveFailureError (whose GRPCStatus inherits the
-		// underlying code) and flip a sticky per-resource breaker so
-		// future calls skip the session path and go straight to
-		// classic. The pool only surfaces the trip cause; TableShim
-		// owns the divert-forever decision.
+		// Unimplemented-driven trips are handled by the routing layer:
+		// TableShim reads status.Code on consecutiveFailureError
+		// (GRPCStatus inherits the underlying code) and flips its
+		// sticky per-resource breaker. Pool only surfaces the cause.
 	}
 }
 

--- a/bigtable/internal/transport/session_pool_lifecycle.go
+++ b/bigtable/internal/transport/session_pool_lifecycle.go
@@ -417,13 +417,15 @@ func (p *SessionPoolImpl) noteAbnormalCloseIfAny(sh *SessionHandle) {
 	woken := p.drainWaitersWithErr(tripErr)
 	if woken > 0 {
 		recordDebugTag(tagSessionPoolConsecutiveFailuresTripped)
-		// TODO(mutianf): if consecutive trips are driven by Unimplemented
-		// (server-side session RPC not supported — the classic-path
-		// fallback signal), transition the client back to unary Bigtable
-		// RPCs instead of continuing to trip and drain. Routing flip is
-		// SessionClient / Diverter's decision, not the pool's — the pool
-		// only surfaces the trip cause; the layer above owns the choice
-		// to divert future opens to the classic (unary) path.
+		// If consecutive trips are driven by Unimplemented (server-side
+		// session RPC not supported), the routing layer above the pool
+		// handles it: TableShim.ReadRow / Apply observe
+		// status.Code(err) == codes.Unimplemented on the returned
+		// consecutiveFailureError (whose GRPCStatus inherits the
+		// underlying code) and flip a sticky per-resource breaker so
+		// future calls skip the session path and go straight to
+		// classic. The pool only surfaces the trip cause; TableShim
+		// owns the divert-forever decision.
 	}
 }
 

--- a/bigtable/table_shim.go
+++ b/bigtable/table_shim.go
@@ -25,6 +25,24 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// sessionUnimplementedThreshold is the number of CONSECUTIVE
+// codes.Unimplemented responses from the session path required to
+// trip TableShim's sticky per-resource breaker. Matches Java
+// (ShimImpl.java:77 MAX_CONSECUTIVE_UNIMPLEMENTED_FAILURES = 30). A
+// var (not const) so tests can drop it to 1 for fast breaker-trip
+// assertions without touching production code — same pattern as
+// sessionTableCacheTTL / sessionTableCacheSweepInt in
+// session_table_cache.go.
+//
+// "Consecutive" means the counter resets to 0 on any non-Unimplemented
+// session response (success OR non-Unimplemented error) — see
+// recordSessionOutcome. Rationale: a non-Unimplemented response proves
+// the session RPC is understood by whatever backend served it (either
+// wire is fine, or the failure is transport/app-level); the previous
+// Unimplemented streak must have been transient or from a different
+// AFE in the pool.
+var sessionUnimplementedThreshold int32 = 30
+
 // TableShim implements TableAPI by routing between a classic gRPC
 // data-plane and a proto-native session data-plane
 // (session.TableAPI). Traffic direction is decided per-call by
@@ -36,27 +54,41 @@ import (
 // Conditional mutations always route to classic — session vRPC does
 // not support the CheckAndMutateRow shape today.
 //
-// UNIMPLEMENTED fallback: when a session-path RPC returns
-// codes.Unimplemented (the server-side session backend isn't rolled
-// out on this AFE), TableShim transparently re-issues the request on
-// the classic path AND flips a sticky per-resource breaker so all
-// subsequent calls on this shim skip the session path entirely. See
-// sessionUnimplemented + tripSessionBreaker.
+// UNIMPLEMENTED fallback (two-layer):
+//   - Per-call rescue: whenever a session-path RPC returns
+//     codes.Unimplemented, TableShim transparently re-issues on the
+//     classic path so the user's request always succeeds — even
+//     BEFORE the sticky breaker trips. Improves UX over Java (which
+//     fails the request until the breaker trips) at zero extra cost
+//     (classic re-issue would happen on the next call anyway).
+//   - Sticky per-resource breaker: after
+//     sessionUnimplementedThreshold consecutive Unimplemented
+//     responses, all subsequent calls skip the session path outright
+//     via useSession()'s short-circuit. See sessionUnimplemented +
+//     unimplementedCount + recordSessionOutcome.
 type TableShim struct {
 	classic  TableAPI
 	session  session.TableAPI
 	diverter *btransport.Diverter
 	// sessionUnimplemented is the sticky per-resource UNIMPLEMENTED
-	// breaker. Flipped by tripSessionBreaker on the first Unimplemented
-	// from the session path; useSession() short-circuits on it so
-	// subsequent calls never hit session for the same resource. Sticky
-	// for the shim's lifetime — no retry, no probe. UNIMPLEMENTED
+	// breaker. Flipped by recordSessionOutcome when unimplementedCount
+	// reaches sessionUnimplementedThreshold; useSession() short-circuits
+	// on it so subsequent calls never hit session for the same resource.
+	// Sticky for the shim's lifetime — no retry, no probe. UNIMPLEMENTED
 	// is a backend capability signal (this AFE doesn't implement the
 	// session RPC), not a transient failure; a fresh shim (via
 	// bigtable.Client.OpenTable after the sessionTableCache TTL-evicts
 	// this handle) starts un-tripped and can re-observe if backends
 	// have since rolled out.
 	sessionUnimplemented atomic.Bool
+	// unimplementedCount is the running count of consecutive
+	// Unimplemented responses from the session path. Incremented by
+	// recordSessionOutcome on Unimplemented; reset to 0 on any other
+	// session response (success OR non-Unimplemented error). Reaches
+	// sessionUnimplementedThreshold → sessionUnimplemented flips true.
+	// atomic.Int32 (not int32 + mutex) because updates are single-writer
+	// per goroutine call and readers only take the value momentarily.
+	unimplementedCount atomic.Int32
 }
 
 // NewTableShim wraps a classic TableAPI + a proto-native session API
@@ -95,9 +127,9 @@ func (t *TableShim) ReadRow(ctx context.Context, row string, opts ...ReadOption)
 		Filter: tmpReq.Filter,
 	}
 	resp, err := t.session.ReadRow(ctx, req)
+	t.recordSessionOutcome(err)
 	if err != nil {
 		if status.Code(err) == codes.Unimplemented {
-			t.tripSessionBreaker()
 			return t.classic.ReadRow(ctx, row, opts...)
 		}
 		return nil, err
@@ -130,9 +162,10 @@ func (t *TableShim) Apply(ctx context.Context, row string, m *Mutation, opts ...
 		Key:       []byte(row),
 		Mutations: m.ops,
 	}
-	if _, err := t.session.MutateRow(ctx, req); err != nil {
+	_, err := t.session.MutateRow(ctx, req)
+	t.recordSessionOutcome(err)
+	if err != nil {
 		if status.Code(err) == codes.Unimplemented {
-			t.tripSessionBreaker()
 			return t.classic.Apply(ctx, row, m, opts...)
 		}
 		return err
@@ -173,13 +206,36 @@ func (t *TableShim) useSession() bool {
 		t.diverter.UseSession()
 }
 
-// tripSessionBreaker atomically flips sessionUnimplemented from false
-// to true. Uses CompareAndSwap so concurrent Unimplemented responses
-// coalesce into a single trip — useful once observability lands (the
-// intended debug-tag / metric fire on the winning CAS emits exactly
-// once per resource, not once per racing caller).
-func (t *TableShim) tripSessionBreaker() {
-	t.sessionUnimplemented.CompareAndSwap(false, true)
+// recordSessionOutcome updates the consecutive-Unimplemented counter
+// (and possibly flips the sticky breaker) based on the outcome of a
+// session-path RPC. Called by ReadRow and Apply immediately after the
+// session response, before the per-call fallback decision.
+//
+// Semantics:
+//   - err == nil (session succeeded) → counter reset to 0. Proves the
+//     RPC is understood — any prior Unimplemented streak was transient
+//     or from a different AFE in the pool.
+//   - err carries any non-Unimplemented code → counter reset to 0.
+//     Same reasoning: the wire understood the RPC (failure is
+//     transport / app-level), so the streak breaks.
+//   - err carries codes.Unimplemented → counter increment. On the
+//     transition from N-1 → N == sessionUnimplementedThreshold, flip
+//     sessionUnimplemented true via CompareAndSwap so a follow-up
+//     debug tag / metric hook (to be wired when RecordDebugTag lands
+//     in the public transport surface) fires exactly once per
+//     resource under concurrent trip races.
+//
+// Matches Java's SessionPoolImpl reset semantics
+// (SessionPoolImpl.java:489, 578) adapted to our per-op observation
+// surface — Java's signal source is session-close, ours is per-RPC.
+func (t *TableShim) recordSessionOutcome(err error) {
+	if err == nil || status.Code(err) != codes.Unimplemented {
+		t.unimplementedCount.Store(0)
+		return
+	}
+	if n := t.unimplementedCount.Add(1); n >= sessionUnimplementedThreshold {
+		t.sessionUnimplemented.CompareAndSwap(false, true)
+	}
 }
 
 // protoRowToRow converts a proto Row (the wire shape returned by a

--- a/bigtable/table_shim.go
+++ b/bigtable/table_shim.go
@@ -16,37 +16,16 @@ package bigtable
 
 import (
 	"context"
-	"sync/atomic"
 
 	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
 	"cloud.google.com/go/bigtable/internal/session"
 	btransport "cloud.google.com/go/bigtable/internal/transport"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
-
-// sessionUnimplementedThreshold is the number of CONSECUTIVE
-// codes.Unimplemented responses from the session path required to
-// trip TableShim's sticky per-resource breaker. Matches Java
-// (ShimImpl.java:77 MAX_CONSECUTIVE_UNIMPLEMENTED_FAILURES = 30). A
-// var (not const) so tests can drop it to 1 for fast breaker-trip
-// assertions without touching production code — same pattern as
-// sessionTableCacheTTL / sessionTableCacheSweepInt in
-// session_table_cache.go.
-//
-// "Consecutive" means the counter resets to 0 on any non-Unimplemented
-// session response (success OR non-Unimplemented error) — see
-// recordSessionOutcome. Rationale: a non-Unimplemented response proves
-// the session RPC is understood by whatever backend served it (either
-// wire is fine, or the failure is transport/app-level); the previous
-// Unimplemented streak must have been transient or from a different
-// AFE in the pool.
-var sessionUnimplementedThreshold int32 = 30
 
 // TableShim implements TableAPI by routing between a classic gRPC
 // data-plane and a proto-native session data-plane
-// (session.TableAPI). Traffic direction is decided per-call by
-// the Diverter's SessionLoad ratio. TableShim owns the proto ↔
+// (session.TableAPI). Traffic direction is decided per-call by the
+// Diverter's SessionLoad ratio. TableShim owns the proto ↔
 // bigtable.Row conversion so the session package can stay proto-native.
 //
 // Methods with no session equivalent (ReadRows, SampleRowKeys,
@@ -54,41 +33,22 @@ var sessionUnimplementedThreshold int32 = 30
 // Conditional mutations always route to classic — session vRPC does
 // not support the CheckAndMutateRow shape today.
 //
-// UNIMPLEMENTED fallback (two-layer):
-//   - Per-call rescue: whenever a session-path RPC returns
-//     codes.Unimplemented, TableShim transparently re-issues on the
-//     classic path so the user's request always succeeds — even
-//     BEFORE the sticky breaker trips. Improves UX over Java (which
-//     fails the request until the breaker trips) at zero extra cost
-//     (classic re-issue would happen on the next call anyway).
-//   - Sticky per-resource breaker: after
-//     sessionUnimplementedThreshold consecutive Unimplemented
-//     responses, all subsequent calls skip the session path outright
-//     via useSession()'s short-circuit. See sessionUnimplemented +
-//     unimplementedCount + recordSessionOutcome.
+// UNIMPLEMENTED fallback lives in session.UnimplementedErrorInterceptor.
+// TableShim owns one instance per resource; ReadRow and Apply route
+// their session call through session.InterceptUnimplemented so a server that
+// returns codes.Unimplemented on the session RPC transparently
+// falls back to the classic path AND, after N consecutive
+// Unimplemented responses, trips the interceptor's sticky breaker
+// so useSession() short-circuits future calls at the routing gate.
 type TableShim struct {
 	classic  TableAPI
 	session  session.TableAPI
 	diverter *btransport.Diverter
-	// sessionUnimplemented is the sticky per-resource UNIMPLEMENTED
-	// breaker. Flipped by recordSessionOutcome when unimplementedCount
-	// reaches sessionUnimplementedThreshold; useSession() short-circuits
-	// on it so subsequent calls never hit session for the same resource.
-	// Sticky for the shim's lifetime — no retry, no probe. UNIMPLEMENTED
-	// is a backend capability signal (this AFE doesn't implement the
-	// session RPC), not a transient failure; a fresh shim (via
-	// bigtable.Client.OpenTable after the sessionTableCache TTL-evicts
-	// this handle) starts un-tripped and can re-observe if backends
-	// have since rolled out.
-	sessionUnimplemented atomic.Bool
-	// unimplementedCount is the running count of consecutive
-	// Unimplemented responses from the session path. Incremented by
-	// recordSessionOutcome on Unimplemented; reset to 0 on any other
-	// session response (success OR non-Unimplemented error). Reaches
-	// sessionUnimplementedThreshold → sessionUnimplemented flips true.
-	// atomic.Int32 (not int32 + mutex) because updates are single-writer
-	// per goroutine call and readers only take the value momentarily.
-	unimplementedCount atomic.Int32
+	// unimplemented handles both the per-call classic fallback on
+	// codes.Unimplemented AND the sticky breaker that skips session
+	// entirely after N consecutive Unimplemented responses. See
+	// session.UnimplementedErrorInterceptor for reset/trip semantics.
+	unimplemented *session.UnimplementedErrorInterceptor
 }
 
 // NewTableShim wraps a classic TableAPI + a proto-native session API
@@ -96,9 +56,10 @@ type TableShim struct {
 // in which case the shim behaves like classic-only.
 func NewTableShim(classic TableAPI, sessionAPI session.TableAPI, diverter *btransport.Diverter) TableAPI {
 	return &TableShim{
-		classic:  classic,
-		session:  sessionAPI,
-		diverter: diverter,
+		classic:       classic,
+		session:       sessionAPI,
+		diverter:      diverter,
+		unimplemented: session.NewUnimplementedErrorInterceptor(),
 	}
 }
 
@@ -108,9 +69,8 @@ func NewTableShim(classic TableAPI, sessionAPI session.TableAPI, diverter *btran
 // (row, opts) → SessionReadRowRequest, then translates the response
 // back via protoRowToRow. WithFullReadStats callbacks fire from here.
 //
-// If the session path returns codes.Unimplemented, transparently
-// re-issues the request via classic and trips the breaker so future
-// ReadRow / Apply calls skip session directly.
+// A session-path Unimplemented is transparently rescued via classic
+// by the interceptor; see session.UnimplementedErrorInterceptor doc.
 func (t *TableShim) ReadRow(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
 	if !t.useSession() {
 		return t.classic.ReadRow(ctx, row, opts...)
@@ -126,19 +86,22 @@ func (t *TableShim) ReadRow(ctx context.Context, row string, opts ...ReadOption)
 		Key:    []byte(row),
 		Filter: tmpReq.Filter,
 	}
-	resp, err := t.session.ReadRow(ctx, req)
-	t.recordSessionOutcome(err)
-	if err != nil {
-		if status.Code(err) == codes.Unimplemented {
+	return session.InterceptUnimplemented(t.unimplemented,
+		func() (Row, error) {
+			resp, err := t.session.ReadRow(ctx, req)
+			if err != nil {
+				return nil, err
+			}
+			if resp.GetStats() != nil && settings.fullReadStatsFunc != nil {
+				stats := makeFullReadStats(resp.GetStats())
+				settings.fullReadStatsFunc(&stats)
+			}
+			return protoRowToRow(resp.GetRow()), nil
+		},
+		func() (Row, error) {
 			return t.classic.ReadRow(ctx, row, opts...)
-		}
-		return nil, err
-	}
-	if resp.GetStats() != nil && settings.fullReadStatsFunc != nil {
-		stats := makeFullReadStats(resp.GetStats())
-		settings.fullReadStatsFunc(&stats)
-	}
-	return protoRowToRow(resp.GetRow()), nil
+		},
+	)
 }
 
 // Apply implements TableAPI. Non-conditional mutations may route
@@ -148,9 +111,8 @@ func (t *TableShim) ReadRow(ctx context.Context, row string, opts ...ReadOption)
 // client's nil-handling error surfaces exactly as it always has,
 // rather than panicking here on m.ops.
 //
-// If the session path returns codes.Unimplemented, transparently
-// re-issues the mutation via classic and trips the breaker so future
-// ReadRow / Apply calls skip session directly.
+// A session-path Unimplemented is transparently rescued via classic
+// by the interceptor; see session.UnimplementedErrorInterceptor doc.
 func (t *TableShim) Apply(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
 	if m == nil || m.isConditional {
 		return t.classic.Apply(ctx, row, m, opts...)
@@ -162,15 +124,19 @@ func (t *TableShim) Apply(ctx context.Context, row string, m *Mutation, opts ...
 		Key:       []byte(row),
 		Mutations: m.ops,
 	}
-	_, err := t.session.MutateRow(ctx, req)
-	t.recordSessionOutcome(err)
-	if err != nil {
-		if status.Code(err) == codes.Unimplemented {
-			return t.classic.Apply(ctx, row, m, opts...)
-		}
-		return err
-	}
-	return nil
+	// Apply returns only an error; use struct{} for the value slot so
+	// the interceptor's generic contract is satisfied without a
+	// pretend-response type.
+	_, err := session.InterceptUnimplemented(t.unimplemented,
+		func() (struct{}, error) {
+			_, e := t.session.MutateRow(ctx, req)
+			return struct{}{}, e
+		},
+		func() (struct{}, error) {
+			return struct{}{}, t.classic.Apply(ctx, row, m, opts...)
+		},
+	)
+	return err
 }
 
 // ReadRows delegates to classic — session support is not implemented.
@@ -194,48 +160,16 @@ func (t *TableShim) ApplyReadModifyWrite(ctx context.Context, row string, m *Rea
 }
 
 // useSession returns true when both a session API and diverter are
-// configured, the UNIMPLEMENTED breaker has NOT tripped for this
-// resource, AND the diverter says this call should go over session.
-// The sessionUnimplemented check is a cheap atomic Load that gates
-// the diverter roll — a tripped shim never rolls, never dials, and
-// never calls into the session backend.
+// configured, the interceptor's sticky UNIMPLEMENTED breaker has NOT
+// tripped for this resource, AND the diverter says this call should
+// go over session. The bypass check is a cheap atomic Load — a
+// tripped shim never rolls the diverter, never dials, and never
+// calls into the session backend.
 func (t *TableShim) useSession() bool {
 	return t.session != nil &&
 		t.diverter != nil &&
-		!t.sessionUnimplemented.Load() &&
+		!t.unimplemented.Bypass() &&
 		t.diverter.UseSession()
-}
-
-// recordSessionOutcome updates the consecutive-Unimplemented counter
-// (and possibly flips the sticky breaker) based on the outcome of a
-// session-path RPC. Called by ReadRow and Apply immediately after the
-// session response, before the per-call fallback decision.
-//
-// Semantics:
-//   - err == nil (session succeeded) → counter reset to 0. Proves the
-//     RPC is understood — any prior Unimplemented streak was transient
-//     or from a different AFE in the pool.
-//   - err carries any non-Unimplemented code → counter reset to 0.
-//     Same reasoning: the wire understood the RPC (failure is
-//     transport / app-level), so the streak breaks.
-//   - err carries codes.Unimplemented → counter increment. On the
-//     transition from N-1 → N == sessionUnimplementedThreshold, flip
-//     sessionUnimplemented true via CompareAndSwap so a follow-up
-//     debug tag / metric hook (to be wired when RecordDebugTag lands
-//     in the public transport surface) fires exactly once per
-//     resource under concurrent trip races.
-//
-// Matches Java's SessionPoolImpl reset semantics
-// (SessionPoolImpl.java:489, 578) adapted to our per-op observation
-// surface — Java's signal source is session-close, ours is per-RPC.
-func (t *TableShim) recordSessionOutcome(err error) {
-	if err == nil || status.Code(err) != codes.Unimplemented {
-		t.unimplementedCount.Store(0)
-		return
-	}
-	if n := t.unimplementedCount.Add(1); n >= sessionUnimplementedThreshold {
-		t.sessionUnimplemented.CompareAndSwap(false, true)
-	}
 }
 
 // protoRowToRow converts a proto Row (the wire shape returned by a

--- a/bigtable/table_shim.go
+++ b/bigtable/table_shim.go
@@ -16,10 +16,13 @@ package bigtable
 
 import (
 	"context"
+	"sync/atomic"
 
 	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
 	"cloud.google.com/go/bigtable/internal/session"
 	btransport "cloud.google.com/go/bigtable/internal/transport"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // TableShim implements TableAPI by routing between a classic gRPC
@@ -32,10 +35,28 @@ import (
 // ApplyBulk, ApplyReadModifyWrite) always delegate to classic.
 // Conditional mutations always route to classic — session vRPC does
 // not support the CheckAndMutateRow shape today.
+//
+// UNIMPLEMENTED fallback: when a session-path RPC returns
+// codes.Unimplemented (the server-side session backend isn't rolled
+// out on this AFE), TableShim transparently re-issues the request on
+// the classic path AND flips a sticky per-resource breaker so all
+// subsequent calls on this shim skip the session path entirely. See
+// sessionUnimplemented + tripSessionBreaker.
 type TableShim struct {
 	classic  TableAPI
 	session  session.TableAPI
 	diverter *btransport.Diverter
+	// sessionUnimplemented is the sticky per-resource UNIMPLEMENTED
+	// breaker. Flipped by tripSessionBreaker on the first Unimplemented
+	// from the session path; useSession() short-circuits on it so
+	// subsequent calls never hit session for the same resource. Sticky
+	// for the shim's lifetime — no retry, no probe. UNIMPLEMENTED
+	// is a backend capability signal (this AFE doesn't implement the
+	// session RPC), not a transient failure; a fresh shim (via
+	// bigtable.Client.OpenTable after the sessionTableCache TTL-evicts
+	// this handle) starts un-tripped and can re-observe if backends
+	// have since rolled out.
+	sessionUnimplemented atomic.Bool
 }
 
 // NewTableShim wraps a classic TableAPI + a proto-native session API
@@ -54,6 +75,10 @@ func NewTableShim(classic TableAPI, sessionAPI session.TableAPI, diverter *btran
 // delegates to classic. On the session path, translates
 // (row, opts) → SessionReadRowRequest, then translates the response
 // back via protoRowToRow. WithFullReadStats callbacks fire from here.
+//
+// If the session path returns codes.Unimplemented, transparently
+// re-issues the request via classic and trips the breaker so future
+// ReadRow / Apply calls skip session directly.
 func (t *TableShim) ReadRow(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
 	if !t.useSession() {
 		return t.classic.ReadRow(ctx, row, opts...)
@@ -71,6 +96,10 @@ func (t *TableShim) ReadRow(ctx context.Context, row string, opts ...ReadOption)
 	}
 	resp, err := t.session.ReadRow(ctx, req)
 	if err != nil {
+		if status.Code(err) == codes.Unimplemented {
+			t.tripSessionBreaker()
+			return t.classic.ReadRow(ctx, row, opts...)
+		}
 		return nil, err
 	}
 	if resp.GetStats() != nil && settings.fullReadStatsFunc != nil {
@@ -86,6 +115,10 @@ func (t *TableShim) ReadRow(ctx context.Context, row string, opts ...ReadOption)
 // equivalent. Nil mutations also route to classic so the classic
 // client's nil-handling error surfaces exactly as it always has,
 // rather than panicking here on m.ops.
+//
+// If the session path returns codes.Unimplemented, transparently
+// re-issues the mutation via classic and trips the breaker so future
+// ReadRow / Apply calls skip session directly.
 func (t *TableShim) Apply(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
 	if m == nil || m.isConditional {
 		return t.classic.Apply(ctx, row, m, opts...)
@@ -98,6 +131,10 @@ func (t *TableShim) Apply(ctx context.Context, row string, m *Mutation, opts ...
 		Mutations: m.ops,
 	}
 	if _, err := t.session.MutateRow(ctx, req); err != nil {
+		if status.Code(err) == codes.Unimplemented {
+			t.tripSessionBreaker()
+			return t.classic.Apply(ctx, row, m, opts...)
+		}
 		return err
 	}
 	return nil
@@ -124,9 +161,25 @@ func (t *TableShim) ApplyReadModifyWrite(ctx context.Context, row string, m *Rea
 }
 
 // useSession returns true when both a session API and diverter are
-// configured AND the diverter says this call should go over session.
+// configured, the UNIMPLEMENTED breaker has NOT tripped for this
+// resource, AND the diverter says this call should go over session.
+// The sessionUnimplemented check is a cheap atomic Load that gates
+// the diverter roll — a tripped shim never rolls, never dials, and
+// never calls into the session backend.
 func (t *TableShim) useSession() bool {
-	return t.session != nil && t.diverter != nil && t.diverter.UseSession()
+	return t.session != nil &&
+		t.diverter != nil &&
+		!t.sessionUnimplemented.Load() &&
+		t.diverter.UseSession()
+}
+
+// tripSessionBreaker atomically flips sessionUnimplemented from false
+// to true. Uses CompareAndSwap so concurrent Unimplemented responses
+// coalesce into a single trip — useful once observability lands (the
+// intended debug-tag / metric fire on the winning CAS emits exactly
+// once per resource, not once per racing caller).
+func (t *TableShim) tripSessionBreaker() {
+	t.sessionUnimplemented.CompareAndSwap(false, true)
 }
 
 // protoRowToRow converts a proto Row (the wire shape returned by a

--- a/bigtable/table_shim.go
+++ b/bigtable/table_shim.go
@@ -53,7 +53,7 @@ func NewTableShim(classic TableAPI, sessionAPI session.TableAPI, diverter *btran
 		classic:       classic,
 		session:       sessionAPI,
 		diverter:      diverter,
-		unimplemented: session.NewUnimplementedErrorInterceptor(),
+		unimplemented: session.NewUnimplementedErrorInterceptor(session.DefaultUnimplementedThreshold),
 	}
 }
 

--- a/bigtable/table_shim.go
+++ b/bigtable/table_shim.go
@@ -33,21 +33,15 @@ import (
 // Conditional mutations always route to classic — session vRPC does
 // not support the CheckAndMutateRow shape today.
 //
-// UNIMPLEMENTED fallback lives in session.UnimplementedErrorInterceptor.
-// TableShim owns one instance per resource; ReadRow and Apply route
-// their session call through session.InterceptUnimplemented so a server that
-// returns codes.Unimplemented on the session RPC transparently
-// falls back to the classic path AND, after N consecutive
-// Unimplemented responses, trips the interceptor's sticky breaker
-// so useSession() short-circuits future calls at the routing gate.
+// ReadRow and Apply route their session call through
+// session.InterceptUnimplemented: a codes.Unimplemented response falls
+// back to classic, and after enough consecutive Unimplementeds the
+// interceptor's sticky breaker gates useSession() so future calls skip
+// session entirely.
 type TableShim struct {
-	classic  TableAPI
-	session  session.TableAPI
-	diverter *btransport.Diverter
-	// unimplemented handles both the per-call classic fallback on
-	// codes.Unimplemented AND the sticky breaker that skips session
-	// entirely after N consecutive Unimplemented responses. See
-	// session.UnimplementedErrorInterceptor for reset/trip semantics.
+	classic       TableAPI
+	session       session.TableAPI
+	diverter      *btransport.Diverter
 	unimplemented *session.UnimplementedErrorInterceptor
 }
 
@@ -68,9 +62,6 @@ func NewTableShim(classic TableAPI, sessionAPI session.TableAPI, diverter *btran
 // delegates to classic. On the session path, translates
 // (row, opts) → SessionReadRowRequest, then translates the response
 // back via protoRowToRow. WithFullReadStats callbacks fire from here.
-//
-// A session-path Unimplemented is transparently rescued via classic
-// by the interceptor; see session.UnimplementedErrorInterceptor doc.
 func (t *TableShim) ReadRow(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
 	if !t.useSession() {
 		return t.classic.ReadRow(ctx, row, opts...)
@@ -110,9 +101,6 @@ func (t *TableShim) ReadRow(ctx context.Context, row string, opts ...ReadOption)
 // equivalent. Nil mutations also route to classic so the classic
 // client's nil-handling error surfaces exactly as it always has,
 // rather than panicking here on m.ops.
-//
-// A session-path Unimplemented is transparently rescued via classic
-// by the interceptor; see session.UnimplementedErrorInterceptor doc.
 func (t *TableShim) Apply(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
 	if m == nil || m.isConditional {
 		return t.classic.Apply(ctx, row, m, opts...)
@@ -124,9 +112,8 @@ func (t *TableShim) Apply(ctx context.Context, row string, m *Mutation, opts ...
 		Key:       []byte(row),
 		Mutations: m.ops,
 	}
-	// Apply returns only an error; use struct{} for the value slot so
-	// the interceptor's generic contract is satisfied without a
-	// pretend-response type.
+	// Apply returns only an error; use struct{} to satisfy the
+	// interceptor's generic value slot without a stand-in response.
 	_, err := session.InterceptUnimplemented(t.unimplemented,
 		func() (struct{}, error) {
 			_, e := t.session.MutateRow(ctx, req)
@@ -159,12 +146,9 @@ func (t *TableShim) ApplyReadModifyWrite(ctx context.Context, row string, m *Rea
 	return t.classic.ApplyReadModifyWrite(ctx, row, m)
 }
 
-// useSession returns true when both a session API and diverter are
-// configured, the interceptor's sticky UNIMPLEMENTED breaker has NOT
-// tripped for this resource, AND the diverter says this call should
-// go over session. The bypass check is a cheap atomic Load — a
-// tripped shim never rolls the diverter, never dials, and never
-// calls into the session backend.
+// useSession returns true when session + diverter are configured, the
+// interceptor's Unimplemented breaker hasn't tripped, and the diverter
+// says this call should go over session.
 func (t *TableShim) useSession() bool {
 	return t.session != nil &&
 		t.diverter != nil &&

--- a/bigtable/table_shim_test.go
+++ b/bigtable/table_shim_test.go
@@ -569,11 +569,19 @@ func TestTableShim_Apply_UnimplementedFallsBackToClassic(t *testing.T) {
 }
 
 // TestTableShim_BreakerTrippedSkipsSession pins the sticky-per-resource
-// arm of the fallback: once ANY Unimplemented has flipped the breaker,
-// EVERY subsequent ReadRow / Apply skips the session path outright.
-// Session invoker call count stays at 1 across many calls — proves
-// the breaker short-circuits at useSession() before dialing session.
+// arm of the fallback: once the consecutive-Unimplemented counter hits
+// sessionUnimplementedThreshold, EVERY subsequent ReadRow / Apply
+// skips the session path outright. Session invoker call count stops
+// climbing at threshold — proves the breaker short-circuits at
+// useSession() before dialing session.
+//
+// Overrides sessionUnimplementedThreshold to 1 for the test so a
+// single Unimplemented flips the breaker (production threshold is 30,
+// same value Java uses; this test isn't the place to burn 30
+// iterations to prove sticky behavior).
 func TestTableShim_BreakerTrippedSkipsSession(t *testing.T) {
+	withThreshold(t, 1)
+
 	classic := &mockClassicTable{}
 	session := &mockSessionTable{
 		readRowFn: func(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
@@ -602,6 +610,158 @@ func TestTableShim_BreakerTrippedSkipsSession(t *testing.T) {
 	}
 	if classic.readRowCalls != 10 {
 		t.Errorf("classic.readRowCalls after 10 total calls = %d, want 10", classic.readRowCalls)
+	}
+}
+
+// withThreshold overrides sessionUnimplementedThreshold for the test
+// duration and restores it on cleanup. Keeps threshold-sensitive tests
+// fast without exposing a public setter or making the threshold a
+// TableShim field.
+func withThreshold(t *testing.T, v int32) {
+	t.Helper()
+	orig := sessionUnimplementedThreshold
+	sessionUnimplementedThreshold = v
+	t.Cleanup(func() { sessionUnimplementedThreshold = orig })
+}
+
+// TestTableShim_UnimplementedTripsBreakerAtThreshold pins the counter
+// semantics: N-1 Unimplemented responses do NOT trip; the Nth does.
+// Uses threshold=3 so the test iterates a small explicit number and
+// asserts the transition boundary rather than the hard-coded 30.
+func TestTableShim_UnimplementedTripsBreakerAtThreshold(t *testing.T) {
+	withThreshold(t, 3)
+
+	classic := &mockClassicTable{}
+	session := &mockSessionTable{
+		readRowFn: func(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
+			return nil, status.Error(codes.Unimplemented, "not implemented")
+		},
+	}
+	shim := NewTableShim(classic, session, btransport.NewDiverter(1.0)).(*TableShim)
+
+	// Calls 1 and 2 hit session (still under threshold), fall back to
+	// classic per-call. Breaker stays untripped.
+	for i := 0; i < 2; i++ {
+		if _, err := shim.ReadRow(context.Background(), "r"); err != nil {
+			t.Fatalf("call #%d err = %v, want nil", i+1, err)
+		}
+		if shim.sessionUnimplemented.Load() {
+			t.Fatalf("breaker tripped after %d/%d Unimplemented — expected trip only at threshold=3", i+1, sessionUnimplementedThreshold)
+		}
+	}
+
+	// Call 3 hits session (still under, then increments to threshold)
+	// AND flips the breaker.
+	if _, err := shim.ReadRow(context.Background(), "r"); err != nil {
+		t.Fatalf("call #3 err = %v, want nil", err)
+	}
+	if !shim.sessionUnimplemented.Load() {
+		t.Errorf("breaker NOT tripped after 3/3 Unimplemented — recordSessionOutcome must flip sessionUnimplemented when count reaches threshold")
+	}
+	if session.readRowCalls != 3 {
+		t.Errorf("session.readRowCalls = %d, want 3 (one attempt per call until trip)", session.readRowCalls)
+	}
+
+	// Call 4 skips session outright (breaker gate at useSession).
+	if _, err := shim.ReadRow(context.Background(), "r"); err != nil {
+		t.Fatalf("call #4 err = %v, want nil (classic-only after trip)", err)
+	}
+	if session.readRowCalls != 3 {
+		t.Errorf("session.readRowCalls after post-trip call = %d, want 3 (breaker must gate useSession)", session.readRowCalls)
+	}
+	if classic.readRowCalls != 4 {
+		t.Errorf("classic.readRowCalls = %d, want 4 (3 per-call fallbacks + 1 breaker-gated)", classic.readRowCalls)
+	}
+}
+
+// TestTableShim_UnimplementedCounterResetsOnSuccess pins the "consecutive"
+// arm of the counter. A successful session response resets the count
+// to 0 — after that, another N-1 Unimplemented responses still don't
+// trip. Guards against a monotonically-growing "total lifetime
+// Unimplemented" bug that would trip long-running clients that saw
+// scattered failures during transient AFE hiccups.
+func TestTableShim_UnimplementedCounterResetsOnSuccess(t *testing.T) {
+	withThreshold(t, 3)
+
+	// Programmable session: first 2 calls Unimplemented, next 1 success,
+	// next 2 Unimplemented — total 4 Unimplemented but never 3
+	// consecutive, so breaker MUST NOT trip.
+	callN := 0
+	classic := &mockClassicTable{}
+	session := &mockSessionTable{
+		readRowFn: func(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
+			callN++
+			switch callN {
+			case 1, 2, 4, 5:
+				return nil, status.Error(codes.Unimplemented, "unimpl")
+			}
+			// Call 3: session succeeds — resets counter.
+			return &btpb.SessionReadRowResponse{Row: &btpb.Row{Key: req.GetKey()}}, nil
+		},
+	}
+	shim := NewTableShim(classic, session, btransport.NewDiverter(1.0)).(*TableShim)
+
+	for i := 0; i < 5; i++ {
+		if _, err := shim.ReadRow(context.Background(), "r"); err != nil {
+			t.Fatalf("call #%d err = %v, want nil", i+1, err)
+		}
+	}
+	if shim.sessionUnimplemented.Load() {
+		t.Errorf("breaker tripped after 4 non-consecutive Unimplemented (call 3 succeeded — counter must have reset)")
+	}
+	if got := shim.unimplementedCount.Load(); got != 2 {
+		t.Errorf("unimplementedCount = %d, want 2 (calls 4 and 5, counting from post-reset)", got)
+	}
+}
+
+// TestTableShim_UnimplementedCounterResetsOnNonUnimplementedError pins
+// the second reset path: a non-Unimplemented error (e.g. Unavailable)
+// also resets the counter, because that response proves the wire
+// understood the RPC. Matches Java SessionPoolImpl.java:578.
+func TestTableShim_UnimplementedCounterResetsOnNonUnimplementedError(t *testing.T) {
+	withThreshold(t, 3)
+
+	unavail := status.Error(codes.Unavailable, "boom")
+
+	callN := 0
+	classic := &mockClassicTable{}
+	session := &mockSessionTable{
+		readRowFn: func(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
+			callN++
+			switch callN {
+			case 1, 2:
+				return nil, status.Error(codes.Unimplemented, "unimpl")
+			case 3:
+				return nil, unavail // resets counter
+			default:
+				return nil, status.Error(codes.Unimplemented, "unimpl")
+			}
+		},
+	}
+	shim := NewTableShim(classic, session, btransport.NewDiverter(1.0)).(*TableShim)
+
+	// Calls 1 and 2 fall back to classic transparently.
+	for i := 0; i < 2; i++ {
+		if _, err := shim.ReadRow(context.Background(), "r"); err != nil {
+			t.Fatalf("call #%d err = %v, want nil", i+1, err)
+		}
+	}
+	// Call 3 propagates Unavailable (non-Unimplemented — no fallback).
+	if _, err := shim.ReadRow(context.Background(), "r"); !errors.Is(err, unavail) {
+		t.Fatalf("call #3 err = %v, want unwrap to %v", err, unavail)
+	}
+	if got := shim.unimplementedCount.Load(); got != 0 {
+		t.Fatalf("unimplementedCount after Unavailable = %d, want 0 (non-Unimplemented response must reset counter)", got)
+	}
+	// Calls 4 and 5 Unimplemented — counter climbs from 0 again, still
+	// below threshold=3.
+	for i := 0; i < 2; i++ {
+		if _, err := shim.ReadRow(context.Background(), "r"); err != nil {
+			t.Fatalf("call #%d err = %v, want nil", i+4, err)
+		}
+	}
+	if shim.sessionUnimplemented.Load() {
+		t.Errorf("breaker tripped after Unavailable reset — counter should be at 2, not threshold=3")
 	}
 }
 

--- a/bigtable/table_shim_test.go
+++ b/bigtable/table_shim_test.go
@@ -567,12 +567,10 @@ func TestTableShim_Apply_UnimplementedFallsBackToClassic(t *testing.T) {
 }
 
 // TestTableShim_BreakerTrippedSkipsSession: once the counter hits
-// session.UnimplementedThreshold, subsequent ReadRow / Apply skip
-// the session path outright at useSession(). Threshold overridden
-// to 1 so one Unimplemented trips.
+// the interceptor's configured threshold, subsequent ReadRow /
+// Apply skip the session path outright at useSession(). Threshold
+// overridden to 1 so one Unimplemented trips.
 func TestTableShim_BreakerTrippedSkipsSession(t *testing.T) {
-	withThreshold(t, 1)
-
 	classic := &mockClassicTable{}
 	sess := &mockSessionTable{
 		readRowFn: func(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
@@ -580,6 +578,7 @@ func TestTableShim_BreakerTrippedSkipsSession(t *testing.T) {
 		},
 	}
 	shim := NewTableShim(classic, sess, btransport.NewDiverter(1.0))
+	withThreshold(t, shim, 1)
 
 	// First ReadRow trips the breaker + falls back to classic.
 	if _, err := shim.ReadRow(context.Background(), "r1"); err != nil {
@@ -604,21 +603,21 @@ func TestTableShim_BreakerTrippedSkipsSession(t *testing.T) {
 	}
 }
 
-// withThreshold overrides session.UnimplementedThreshold for the test
-// duration and restores it on cleanup.
-func withThreshold(t *testing.T, v int32) {
+// withThreshold swaps shim's interceptor for one with a smaller
+// threshold so breaker-trip assertions don't have to iterate 30
+// times. Accepts the TableAPI value returned by NewTableShim and
+// casts to *TableShim internally. Caller must run this BEFORE
+// issuing any requests through the shim (prior interceptor state is
+// dropped).
+func withThreshold(t *testing.T, shim TableAPI, threshold int32) {
 	t.Helper()
-	orig := session.UnimplementedThreshold
-	session.UnimplementedThreshold = v
-	t.Cleanup(func() { session.UnimplementedThreshold = orig })
+	shim.(*TableShim).unimplemented = session.NewUnimplementedErrorInterceptor(threshold)
 }
 
 // TestTableShim_UnimplementedTripsBreakerAtThreshold: N-1
 // Unimplementeds don't trip; the Nth does. Threshold=3 to keep the
 // transition boundary explicit.
 func TestTableShim_UnimplementedTripsBreakerAtThreshold(t *testing.T) {
-	withThreshold(t, 3)
-
 	classic := &mockClassicTable{}
 	sess := &mockSessionTable{
 		readRowFn: func(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
@@ -626,6 +625,7 @@ func TestTableShim_UnimplementedTripsBreakerAtThreshold(t *testing.T) {
 		},
 	}
 	shim := NewTableShim(classic, sess, btransport.NewDiverter(1.0)).(*TableShim)
+	withThreshold(t, shim, 3)
 
 	// Calls 1 and 2 hit session (still under threshold), fall back to
 	// classic per-call. Breaker stays untripped.
@@ -634,7 +634,7 @@ func TestTableShim_UnimplementedTripsBreakerAtThreshold(t *testing.T) {
 			t.Fatalf("call #%d err = %v, want nil", i+1, err)
 		}
 		if shim.unimplemented.Bypass() {
-			t.Fatalf("breaker tripped after %d/%d Unimplemented — expected trip only at threshold=3", i+1, session.UnimplementedThreshold)
+			t.Fatalf("breaker tripped after %d/3 Unimplemented — expected trip only at threshold=3", i+1)
 		}
 	}
 
@@ -666,8 +666,6 @@ func TestTableShim_UnimplementedTripsBreakerAtThreshold(t *testing.T) {
 // session response resets the count. 2 unimpl + 1 success + 2 unimpl
 // is 4 total but never 3 consecutive, so the breaker must not trip.
 func TestTableShim_UnimplementedCounterResetsOnSuccess(t *testing.T) {
-	withThreshold(t, 3)
-
 	// Programmable session: first 2 calls Unimplemented, next 1 success,
 	// next 2 Unimplemented — total 4 Unimplemented but never 3
 	// consecutive, so breaker MUST NOT trip.
@@ -685,6 +683,7 @@ func TestTableShim_UnimplementedCounterResetsOnSuccess(t *testing.T) {
 		},
 	}
 	shim := NewTableShim(classic, sess, btransport.NewDiverter(1.0)).(*TableShim)
+	withThreshold(t, shim, 3)
 
 	for i := 0; i < 5; i++ {
 		if _, err := shim.ReadRow(context.Background(), "r"); err != nil {
@@ -703,8 +702,6 @@ func TestTableShim_UnimplementedCounterResetsOnSuccess(t *testing.T) {
 // non-Unimplemented error (e.g. Unavailable) also resets the counter,
 // because that response proves the wire understood the RPC.
 func TestTableShim_UnimplementedCounterResetsOnNonUnimplementedError(t *testing.T) {
-	withThreshold(t, 3)
-
 	unavail := status.Error(codes.Unavailable, "boom")
 
 	callN := 0
@@ -723,6 +720,7 @@ func TestTableShim_UnimplementedCounterResetsOnNonUnimplementedError(t *testing.
 		},
 	}
 	shim := NewTableShim(classic, sess, btransport.NewDiverter(1.0)).(*TableShim)
+	withThreshold(t, shim, 3)
 
 	// Calls 1 and 2 fall back to classic transparently.
 	for i := 0; i < 2; i++ {

--- a/bigtable/table_shim_test.go
+++ b/bigtable/table_shim_test.go
@@ -22,6 +22,8 @@ import (
 
 	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
 	btransport "cloud.google.com/go/bigtable/internal/transport"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // mockClassicTable stands in for a classic TableAPI (bigtable.Table
@@ -360,6 +362,12 @@ func TestTableShim_NilSession_AllMethodsFallBackToClassic(t *testing.T) {
 // Doing so would violate the retry oracle (spec #9) — a session-side
 // TransportFailure on a non-idempotent Apply is not automatically safe to
 // re-run on classic.
+//
+// Exception (see TestTableShim_Apply_UnimplementedFallsBackToClassic +
+// siblings): codes.Unimplemented is a server-capability signal, not a
+// transport failure, and IS retried on classic. This test uses a plain
+// errors.New — status.Code returns codes.Unknown, so the fallback
+// branch does not fire and the retry-safety contract still holds.
 func TestTableShim_SessionErrorNotRetriedOnClassic(t *testing.T) {
 	wantErr := errors.New("session apply failed")
 	classic := &mockClassicTable{}
@@ -493,6 +501,164 @@ func TestProtoRowToRow(t *testing.T) {
 			got := protoRowToRow(tc.in)
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("protoRowToRow(%+v)\n got  = %#v\n want = %#v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- UNIMPLEMENTED → classic fallback ---------------------------------------
+
+// TestTableShim_ReadRow_UnimplementedFallsBackToClassic pins the core
+// fallback: when the session ReadRow returns codes.Unimplemented (the
+// server-side session backend isn't rolled out on this AFE), the shim
+// transparently re-issues on classic and returns classic's row.
+// Trips the sessionUnimplemented breaker as a side effect — see the
+// BreakerTrippedSkipsSession test for that arm.
+func TestTableShim_ReadRow_UnimplementedFallsBackToClassic(t *testing.T) {
+	classicRow := Row{"fam": []ReadItem{{Row: "r1", Column: "fam:q", Value: []byte("classic")}}}
+	classic := &mockClassicTable{
+		readRowFn: func(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+			return classicRow, nil
+		},
+	}
+	session := &mockSessionTable{
+		readRowFn: func(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
+			return nil, status.Error(codes.Unimplemented, "session backend not implemented on this AFE")
+		},
+	}
+	shim := NewTableShim(classic, session, btransport.NewDiverter(1.0))
+
+	got, err := shim.ReadRow(context.Background(), "r1")
+	if err != nil {
+		t.Fatalf("ReadRow err = %v, want nil (classic path should succeed after Unimplemented fallback)", err)
+	}
+	if !reflect.DeepEqual(got, classicRow) {
+		t.Errorf("ReadRow returned %v, want classic row %v (fallback must surface classic's result, not session's error)", got, classicRow)
+	}
+	if session.readRowCalls != 1 {
+		t.Errorf("session.readRowCalls = %d, want 1 (single attempt before fallback)", session.readRowCalls)
+	}
+	if classic.readRowCalls != 1 {
+		t.Errorf("classic.readRowCalls = %d, want 1 (fallback must dispatch to classic)", classic.readRowCalls)
+	}
+}
+
+// TestTableShim_Apply_UnimplementedFallsBackToClassic — same shape for
+// mutations. Non-conditional Apply is the only mutation entrypoint
+// that reaches the session path (conditional and nil bypass earlier).
+func TestTableShim_Apply_UnimplementedFallsBackToClassic(t *testing.T) {
+	classic := &mockClassicTable{}
+	session := &mockSessionTable{
+		mutateRowFn: func(ctx context.Context, req *btpb.SessionMutateRowRequest) (*btpb.SessionMutateRowResponse, error) {
+			return nil, status.Error(codes.Unimplemented, "session backend not implemented on this AFE")
+		},
+	}
+	shim := NewTableShim(classic, session, btransport.NewDiverter(1.0))
+
+	mut := NewMutation()
+	mut.Set("fam", "col", 1_000_000, []byte("v"))
+	if err := shim.Apply(context.Background(), "r1", mut); err != nil {
+		t.Fatalf("Apply err = %v, want nil (classic path should succeed after Unimplemented fallback)", err)
+	}
+	if session.mutateRowCalls != 1 {
+		t.Errorf("session.mutateRowCalls = %d, want 1 (single attempt before fallback)", session.mutateRowCalls)
+	}
+	if classic.applyCalls != 1 {
+		t.Errorf("classic.applyCalls = %d, want 1 (fallback must dispatch to classic)", classic.applyCalls)
+	}
+}
+
+// TestTableShim_BreakerTrippedSkipsSession pins the sticky-per-resource
+// arm of the fallback: once ANY Unimplemented has flipped the breaker,
+// EVERY subsequent ReadRow / Apply skips the session path outright.
+// Session invoker call count stays at 1 across many calls — proves
+// the breaker short-circuits at useSession() before dialing session.
+func TestTableShim_BreakerTrippedSkipsSession(t *testing.T) {
+	classic := &mockClassicTable{}
+	session := &mockSessionTable{
+		readRowFn: func(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
+			return nil, status.Error(codes.Unimplemented, "not implemented")
+		},
+	}
+	shim := NewTableShim(classic, session, btransport.NewDiverter(1.0))
+
+	// First ReadRow trips the breaker + falls back to classic.
+	if _, err := shim.ReadRow(context.Background(), "r1"); err != nil {
+		t.Fatalf("first ReadRow err = %v, want nil (classic fallback)", err)
+	}
+	if session.readRowCalls != 1 {
+		t.Fatalf("session.readRowCalls after first call = %d, want 1", session.readRowCalls)
+	}
+
+	// Nine more calls. If the breaker is working, session.readRowCalls
+	// stays at 1 (never re-attempted). classic.readRowCalls climbs.
+	for i := 0; i < 9; i++ {
+		if _, err := shim.ReadRow(context.Background(), "r"); err != nil {
+			t.Fatalf("post-trip ReadRow #%d err = %v, want nil", i+2, err)
+		}
+	}
+	if session.readRowCalls != 1 {
+		t.Errorf("session.readRowCalls after 10 total calls = %d, want 1 (breaker must gate useSession)", session.readRowCalls)
+	}
+	if classic.readRowCalls != 10 {
+		t.Errorf("classic.readRowCalls after 10 total calls = %d, want 10", classic.readRowCalls)
+	}
+}
+
+// TestTableShim_NonUnimplementedError_DoesNotFallBack is the regression
+// guard. For every gRPC code OTHER than Unimplemented (Unavailable,
+// DeadlineExceeded, PermissionDenied, Canceled, Internal, ...) the
+// session error MUST propagate unchanged and the breaker MUST NOT trip.
+// Fallback is a capability-signal-only concession; transport failures
+// stay on their own path per SESSION_SPEC.md #14 + #9.
+func TestTableShim_NonUnimplementedError_DoesNotFallBack(t *testing.T) {
+	nonFallbackCodes := []codes.Code{
+		codes.Unavailable,
+		codes.DeadlineExceeded,
+		codes.PermissionDenied,
+		codes.Canceled,
+		codes.Internal,
+		codes.ResourceExhausted,
+		codes.FailedPrecondition,
+	}
+
+	for _, code := range nonFallbackCodes {
+		t.Run(code.String(), func(t *testing.T) {
+			sessErr := status.Error(code, "session err")
+			classic := &mockClassicTable{}
+			session := &mockSessionTable{
+				readRowFn: func(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
+					return nil, sessErr
+				},
+				mutateRowFn: func(ctx context.Context, req *btpb.SessionMutateRowRequest) (*btpb.SessionMutateRowResponse, error) {
+					return nil, sessErr
+				},
+			}
+			shim := NewTableShim(classic, session, btransport.NewDiverter(1.0)).(*TableShim)
+
+			// ReadRow: session err must propagate, no classic fallback.
+			_, gotRead := shim.ReadRow(context.Background(), "r")
+			if !errors.Is(gotRead, sessErr) {
+				t.Errorf("ReadRow err = %v, want unwrap to %v", gotRead, sessErr)
+			}
+			if classic.readRowCalls != 0 {
+				t.Errorf("classic.readRowCalls = %d, want 0 (only Unimplemented triggers fallback)", classic.readRowCalls)
+			}
+
+			// Apply: same contract for mutations.
+			mut := NewMutation()
+			mut.Set("fam", "col", 1_000_000, []byte("v"))
+			gotApply := shim.Apply(context.Background(), "r", mut)
+			if !errors.Is(gotApply, sessErr) {
+				t.Errorf("Apply err = %v, want unwrap to %v", gotApply, sessErr)
+			}
+			if classic.applyCalls != 0 {
+				t.Errorf("classic.applyCalls = %d, want 0 (only Unimplemented triggers fallback)", classic.applyCalls)
+			}
+
+			// Breaker must NOT have tripped — subsequent calls still route session.
+			if shim.sessionUnimplemented.Load() {
+				t.Errorf("sessionUnimplemented tripped after code=%v; only codes.Unimplemented may trip it", code)
 			}
 		})
 	}

--- a/bigtable/table_shim_test.go
+++ b/bigtable/table_shim_test.go
@@ -364,10 +364,9 @@ func TestTableShim_NilSession_AllMethodsFallBackToClassic(t *testing.T) {
 // TransportFailure on a non-idempotent Apply is not automatically safe to
 // re-run on classic.
 //
-// Exception (see TestTableShim_Apply_UnimplementedFallsBackToClassic +
-// siblings): codes.Unimplemented is a server-capability signal, not a
-// transport failure, and IS retried on classic. This test uses a plain
-// errors.New — status.Code returns codes.Unknown, so the fallback
+// codes.Unimplemented is the sole exception (see
+// TestTableShim_Apply_UnimplementedFallsBackToClassic). Here we use
+// plain errors.New — status.Code returns Unknown — so the fallback
 // branch does not fire and the retry-safety contract still holds.
 func TestTableShim_SessionErrorNotRetriedOnClassic(t *testing.T) {
 	wantErr := errors.New("session apply failed")
@@ -509,12 +508,10 @@ func TestProtoRowToRow(t *testing.T) {
 
 // --- UNIMPLEMENTED → classic fallback ---------------------------------------
 
-// TestTableShim_ReadRow_UnimplementedFallsBackToClassic pins the core
-// fallback: when the session ReadRow returns codes.Unimplemented (the
-// server-side session backend isn't rolled out on this AFE), the shim
-// transparently re-issues on classic and returns classic's row.
-// Trips the sessionUnimplemented breaker as a side effect — see the
-// BreakerTrippedSkipsSession test for that arm.
+// TestTableShim_ReadRow_UnimplementedFallsBackToClassic: session
+// ReadRow returns codes.Unimplemented → shim transparently re-issues
+// on classic and returns classic's row. See BreakerTrippedSkipsSession
+// for the sticky-breaker arm.
 func TestTableShim_ReadRow_UnimplementedFallsBackToClassic(t *testing.T) {
 	classicRow := Row{"fam": []ReadItem{{Row: "r1", Column: "fam:q", Value: []byte("classic")}}}
 	classic := &mockClassicTable{
@@ -544,9 +541,9 @@ func TestTableShim_ReadRow_UnimplementedFallsBackToClassic(t *testing.T) {
 	}
 }
 
-// TestTableShim_Apply_UnimplementedFallsBackToClassic — same shape for
-// mutations. Non-conditional Apply is the only mutation entrypoint
-// that reaches the session path (conditional and nil bypass earlier).
+// TestTableShim_Apply_UnimplementedFallsBackToClassic — same shape
+// for mutations. Non-conditional Apply is the only mutation
+// entrypoint that reaches the session path.
 func TestTableShim_Apply_UnimplementedFallsBackToClassic(t *testing.T) {
 	classic := &mockClassicTable{}
 	sess := &mockSessionTable{
@@ -569,17 +566,10 @@ func TestTableShim_Apply_UnimplementedFallsBackToClassic(t *testing.T) {
 	}
 }
 
-// TestTableShim_BreakerTrippedSkipsSession pins the sticky-per-resource
-// arm of the fallback: once the consecutive-Unimplemented counter hits
-// session.UnimplementedThreshold, EVERY subsequent ReadRow / Apply
-// skips the session path outright. Session invoker call count stops
-// climbing at threshold — proves the breaker short-circuits at
-// useSession() before dialing session.
-//
-// Overrides session.UnimplementedThreshold to 1 for the test so a
-// single Unimplemented flips the breaker (production threshold is 30,
-// same value Java uses; this test isn't the place to burn 30
-// iterations to prove sticky behavior).
+// TestTableShim_BreakerTrippedSkipsSession: once the counter hits
+// session.UnimplementedThreshold, subsequent ReadRow / Apply skip
+// the session path outright at useSession(). Threshold overridden
+// to 1 so one Unimplemented trips.
 func TestTableShim_BreakerTrippedSkipsSession(t *testing.T) {
 	withThreshold(t, 1)
 
@@ -615,9 +605,7 @@ func TestTableShim_BreakerTrippedSkipsSession(t *testing.T) {
 }
 
 // withThreshold overrides session.UnimplementedThreshold for the test
-// duration and restores it on cleanup. Keeps threshold-sensitive tests
-// fast without exposing a public setter or making the threshold a
-// TableShim field.
+// duration and restores it on cleanup.
 func withThreshold(t *testing.T, v int32) {
 	t.Helper()
 	orig := session.UnimplementedThreshold
@@ -625,10 +613,9 @@ func withThreshold(t *testing.T, v int32) {
 	t.Cleanup(func() { session.UnimplementedThreshold = orig })
 }
 
-// TestTableShim_UnimplementedTripsBreakerAtThreshold pins the counter
-// semantics: N-1 Unimplemented responses do NOT trip; the Nth does.
-// Uses threshold=3 so the test iterates a small explicit number and
-// asserts the transition boundary rather than the hard-coded 30.
+// TestTableShim_UnimplementedTripsBreakerAtThreshold: N-1
+// Unimplementeds don't trip; the Nth does. Threshold=3 to keep the
+// transition boundary explicit.
 func TestTableShim_UnimplementedTripsBreakerAtThreshold(t *testing.T) {
 	withThreshold(t, 3)
 
@@ -675,12 +662,9 @@ func TestTableShim_UnimplementedTripsBreakerAtThreshold(t *testing.T) {
 	}
 }
 
-// TestTableShim_UnimplementedCounterResetsOnSuccess pins the "consecutive"
-// arm of the counter. A successful session response resets the count
-// to 0 — after that, another N-1 Unimplemented responses still don't
-// trip. Guards against a monotonically-growing "total lifetime
-// Unimplemented" bug that would trip long-running clients that saw
-// scattered failures during transient AFE hiccups.
+// TestTableShim_UnimplementedCounterResetsOnSuccess: a successful
+// session response resets the count. 2 unimpl + 1 success + 2 unimpl
+// is 4 total but never 3 consecutive, so the breaker must not trip.
 func TestTableShim_UnimplementedCounterResetsOnSuccess(t *testing.T) {
 	withThreshold(t, 3)
 
@@ -715,10 +699,9 @@ func TestTableShim_UnimplementedCounterResetsOnSuccess(t *testing.T) {
 	}
 }
 
-// TestTableShim_UnimplementedCounterResetsOnNonUnimplementedError pins
-// the second reset path: a non-Unimplemented error (e.g. Unavailable)
-// also resets the counter, because that response proves the wire
-// understood the RPC. Matches Java SessionPoolImpl.java:578.
+// TestTableShim_UnimplementedCounterResetsOnNonUnimplementedError: a
+// non-Unimplemented error (e.g. Unavailable) also resets the counter,
+// because that response proves the wire understood the RPC.
 func TestTableShim_UnimplementedCounterResetsOnNonUnimplementedError(t *testing.T) {
 	withThreshold(t, 3)
 
@@ -766,12 +749,10 @@ func TestTableShim_UnimplementedCounterResetsOnNonUnimplementedError(t *testing.
 	}
 }
 
-// TestTableShim_NonUnimplementedError_DoesNotFallBack is the regression
-// guard. For every gRPC code OTHER than Unimplemented (Unavailable,
-// DeadlineExceeded, PermissionDenied, Canceled, Internal, ...) the
-// session error MUST propagate unchanged and the breaker MUST NOT trip.
-// Fallback is a capability-signal-only concession; transport failures
-// stay on their own path per SESSION_SPEC.md #14 + #9.
+// TestTableShim_NonUnimplementedError_DoesNotFallBack: for every gRPC
+// code other than Unimplemented, the session error propagates
+// unchanged and the breaker does not trip. Fallback is a
+// capability-signal concession only.
 func TestTableShim_NonUnimplementedError_DoesNotFallBack(t *testing.T) {
 	nonFallbackCodes := []codes.Code{
 		codes.Unavailable,

--- a/bigtable/table_shim_test.go
+++ b/bigtable/table_shim_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"cloud.google.com/go/bigtable/internal/session"
 	btransport "cloud.google.com/go/bigtable/internal/transport"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -123,8 +124,8 @@ func (m *mockSessionTable) Close() error { return nil }
 func TestTableShim_ReadRow_RoutesByDiverter(t *testing.T) {
 	t.Run("classic when SessionLoad=0.0", func(t *testing.T) {
 		classic := &mockClassicTable{}
-		session := &mockSessionTable{}
-		shim := NewTableShim(classic, session, btransport.NewDiverter(0.0))
+		sess := &mockSessionTable{}
+		shim := NewTableShim(classic, sess, btransport.NewDiverter(0.0))
 
 		row, err := shim.ReadRow(context.Background(), "r1")
 		if err != nil {
@@ -136,15 +137,15 @@ func TestTableShim_ReadRow_RoutesByDiverter(t *testing.T) {
 		if classic.readRowCalls != 1 {
 			t.Errorf("classic.readRowCalls = %d, want 1", classic.readRowCalls)
 		}
-		if session.readRowCalls != 0 {
-			t.Errorf("session.readRowCalls = %d, want 0", session.readRowCalls)
+		if sess.readRowCalls != 0 {
+			t.Errorf("sess.readRowCalls = %d, want 0", sess.readRowCalls)
 		}
 	})
 
 	t.Run("session when SessionLoad=1.0", func(t *testing.T) {
 		classic := &mockClassicTable{}
-		session := &mockSessionTable{}
-		shim := NewTableShim(classic, session, btransport.NewDiverter(1.0))
+		sess := &mockSessionTable{}
+		shim := NewTableShim(classic, sess, btransport.NewDiverter(1.0))
 
 		row, err := shim.ReadRow(context.Background(), "r2")
 		if err != nil {
@@ -156,8 +157,8 @@ func TestTableShim_ReadRow_RoutesByDiverter(t *testing.T) {
 		if classic.readRowCalls != 0 {
 			t.Errorf("classic.readRowCalls = %d, want 0", classic.readRowCalls)
 		}
-		if session.readRowCalls != 1 {
-			t.Errorf("session.readRowCalls = %d, want 1", session.readRowCalls)
+		if sess.readRowCalls != 1 {
+			t.Errorf("sess.readRowCalls = %d, want 1", sess.readRowCalls)
 		}
 	})
 
@@ -176,12 +177,12 @@ func TestTableShim_ReadRow_RoutesByDiverter(t *testing.T) {
 
 	t.Run("session error propagates", func(t *testing.T) {
 		wantErr := errors.New("session read failed")
-		session := &mockSessionTable{
+		sess := &mockSessionTable{
 			readRowFn: func(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
 				return nil, wantErr
 			},
 		}
-		shim := NewTableShim(&mockClassicTable{}, session, btransport.NewDiverter(1.0))
+		shim := NewTableShim(&mockClassicTable{}, sess, btransport.NewDiverter(1.0))
 		_, err := shim.ReadRow(context.Background(), "r4")
 		if !errors.Is(err, wantErr) {
 			t.Errorf("err = %v, want unwrap to %v", err, wantErr)
@@ -194,8 +195,8 @@ func TestTableShim_ReadRow_RoutesByDiverter(t *testing.T) {
 // CheckAndMutateRow has no session equivalent.
 func TestTableShim_Apply_ConditionalAlwaysClassic(t *testing.T) {
 	classic := &mockClassicTable{}
-	session := &mockSessionTable{}
-	shim := NewTableShim(classic, session, btransport.NewDiverter(1.0)) // diverter says session
+	sess := &mockSessionTable{}
+	shim := NewTableShim(classic, sess, btransport.NewDiverter(1.0)) // diverter says session
 
 	cond := NewCondMutation(PassAllFilter(), NewMutation(), nil)
 	if err := shim.Apply(context.Background(), "r", cond); err != nil {
@@ -204,8 +205,8 @@ func TestTableShim_Apply_ConditionalAlwaysClassic(t *testing.T) {
 	if classic.applyCalls != 1 {
 		t.Errorf("classic.applyCalls = %d, want 1 (conditional must go classic)", classic.applyCalls)
 	}
-	if session.mutateRowCalls != 0 {
-		t.Errorf("session.mutateRowCalls = %d, want 0 (conditional must NOT go session)", session.mutateRowCalls)
+	if sess.mutateRowCalls != 0 {
+		t.Errorf("sess.mutateRowCalls = %d, want 0 (conditional must NOT go session)", sess.mutateRowCalls)
 	}
 }
 
@@ -214,31 +215,31 @@ func TestTableShim_Apply_ConditionalAlwaysClassic(t *testing.T) {
 func TestTableShim_Apply_NonConditionalRoutesByDiverter(t *testing.T) {
 	t.Run("session when SessionLoad=1.0", func(t *testing.T) {
 		classic := &mockClassicTable{}
-		session := &mockSessionTable{}
-		shim := NewTableShim(classic, session, btransport.NewDiverter(1.0))
+		sess := &mockSessionTable{}
+		shim := NewTableShim(classic, sess, btransport.NewDiverter(1.0))
 
 		mut := NewMutation()
 		mut.Set("fam", "col", 1_000_000, []byte("v"))
 		if err := shim.Apply(context.Background(), "r", mut); err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
-		if classic.applyCalls != 0 || session.mutateRowCalls != 1 {
-			t.Errorf("classic=%d session=%d, want classic=0 session=1", classic.applyCalls, session.mutateRowCalls)
+		if classic.applyCalls != 0 || sess.mutateRowCalls != 1 {
+			t.Errorf("classic=%d session=%d, want classic=0 session=1", classic.applyCalls, sess.mutateRowCalls)
 		}
 	})
 
 	t.Run("classic when SessionLoad=0.0", func(t *testing.T) {
 		classic := &mockClassicTable{}
-		session := &mockSessionTable{}
-		shim := NewTableShim(classic, session, btransport.NewDiverter(0.0))
+		sess := &mockSessionTable{}
+		shim := NewTableShim(classic, sess, btransport.NewDiverter(0.0))
 
 		mut := NewMutation()
 		mut.Set("fam", "col", 1_000_000, []byte("v"))
 		if err := shim.Apply(context.Background(), "r", mut); err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
-		if classic.applyCalls != 1 || session.mutateRowCalls != 0 {
-			t.Errorf("classic=%d session=%d, want classic=1 session=0", classic.applyCalls, session.mutateRowCalls)
+		if classic.applyCalls != 1 || sess.mutateRowCalls != 0 {
+			t.Errorf("classic=%d session=%d, want classic=1 session=0", classic.applyCalls, sess.mutateRowCalls)
 		}
 	})
 }
@@ -371,12 +372,12 @@ func TestTableShim_NilSession_AllMethodsFallBackToClassic(t *testing.T) {
 func TestTableShim_SessionErrorNotRetriedOnClassic(t *testing.T) {
 	wantErr := errors.New("session apply failed")
 	classic := &mockClassicTable{}
-	session := &mockSessionTable{
+	sess := &mockSessionTable{
 		mutateRowFn: func(ctx context.Context, req *btpb.SessionMutateRowRequest) (*btpb.SessionMutateRowResponse, error) {
 			return nil, wantErr
 		},
 	}
-	shim := NewTableShim(classic, session, btransport.NewDiverter(1.0))
+	shim := NewTableShim(classic, sess, btransport.NewDiverter(1.0))
 
 	mut := NewMutation()
 	mut.Set("fam", "col", 1_000_000, []byte("v"))
@@ -385,8 +386,8 @@ func TestTableShim_SessionErrorNotRetriedOnClassic(t *testing.T) {
 	if !errors.Is(err, wantErr) {
 		t.Errorf("err = %v, want unwrap to %v", err, wantErr)
 	}
-	if session.mutateRowCalls != 1 {
-		t.Errorf("session.mutateRowCalls = %d, want 1 (single attempt)", session.mutateRowCalls)
+	if sess.mutateRowCalls != 1 {
+		t.Errorf("sess.mutateRowCalls = %d, want 1 (single attempt)", sess.mutateRowCalls)
 	}
 	if classic.applyCalls != 0 {
 		t.Errorf("classic.applyCalls = %d, want 0 — shim MUST NOT retry session failure on classic (spec #14 + #9)", classic.applyCalls)
@@ -521,12 +522,12 @@ func TestTableShim_ReadRow_UnimplementedFallsBackToClassic(t *testing.T) {
 			return classicRow, nil
 		},
 	}
-	session := &mockSessionTable{
+	sess := &mockSessionTable{
 		readRowFn: func(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
 			return nil, status.Error(codes.Unimplemented, "session backend not implemented on this AFE")
 		},
 	}
-	shim := NewTableShim(classic, session, btransport.NewDiverter(1.0))
+	shim := NewTableShim(classic, sess, btransport.NewDiverter(1.0))
 
 	got, err := shim.ReadRow(context.Background(), "r1")
 	if err != nil {
@@ -535,8 +536,8 @@ func TestTableShim_ReadRow_UnimplementedFallsBackToClassic(t *testing.T) {
 	if !reflect.DeepEqual(got, classicRow) {
 		t.Errorf("ReadRow returned %v, want classic row %v (fallback must surface classic's result, not session's error)", got, classicRow)
 	}
-	if session.readRowCalls != 1 {
-		t.Errorf("session.readRowCalls = %d, want 1 (single attempt before fallback)", session.readRowCalls)
+	if sess.readRowCalls != 1 {
+		t.Errorf("sess.readRowCalls = %d, want 1 (single attempt before fallback)", sess.readRowCalls)
 	}
 	if classic.readRowCalls != 1 {
 		t.Errorf("classic.readRowCalls = %d, want 1 (fallback must dispatch to classic)", classic.readRowCalls)
@@ -548,20 +549,20 @@ func TestTableShim_ReadRow_UnimplementedFallsBackToClassic(t *testing.T) {
 // that reaches the session path (conditional and nil bypass earlier).
 func TestTableShim_Apply_UnimplementedFallsBackToClassic(t *testing.T) {
 	classic := &mockClassicTable{}
-	session := &mockSessionTable{
+	sess := &mockSessionTable{
 		mutateRowFn: func(ctx context.Context, req *btpb.SessionMutateRowRequest) (*btpb.SessionMutateRowResponse, error) {
 			return nil, status.Error(codes.Unimplemented, "session backend not implemented on this AFE")
 		},
 	}
-	shim := NewTableShim(classic, session, btransport.NewDiverter(1.0))
+	shim := NewTableShim(classic, sess, btransport.NewDiverter(1.0))
 
 	mut := NewMutation()
 	mut.Set("fam", "col", 1_000_000, []byte("v"))
 	if err := shim.Apply(context.Background(), "r1", mut); err != nil {
 		t.Fatalf("Apply err = %v, want nil (classic path should succeed after Unimplemented fallback)", err)
 	}
-	if session.mutateRowCalls != 1 {
-		t.Errorf("session.mutateRowCalls = %d, want 1 (single attempt before fallback)", session.mutateRowCalls)
+	if sess.mutateRowCalls != 1 {
+		t.Errorf("sess.mutateRowCalls = %d, want 1 (single attempt before fallback)", sess.mutateRowCalls)
 	}
 	if classic.applyCalls != 1 {
 		t.Errorf("classic.applyCalls = %d, want 1 (fallback must dispatch to classic)", classic.applyCalls)
@@ -570,12 +571,12 @@ func TestTableShim_Apply_UnimplementedFallsBackToClassic(t *testing.T) {
 
 // TestTableShim_BreakerTrippedSkipsSession pins the sticky-per-resource
 // arm of the fallback: once the consecutive-Unimplemented counter hits
-// sessionUnimplementedThreshold, EVERY subsequent ReadRow / Apply
+// session.UnimplementedThreshold, EVERY subsequent ReadRow / Apply
 // skips the session path outright. Session invoker call count stops
 // climbing at threshold — proves the breaker short-circuits at
 // useSession() before dialing session.
 //
-// Overrides sessionUnimplementedThreshold to 1 for the test so a
+// Overrides session.UnimplementedThreshold to 1 for the test so a
 // single Unimplemented flips the breaker (production threshold is 30,
 // same value Java uses; this test isn't the place to burn 30
 // iterations to prove sticky behavior).
@@ -583,45 +584,45 @@ func TestTableShim_BreakerTrippedSkipsSession(t *testing.T) {
 	withThreshold(t, 1)
 
 	classic := &mockClassicTable{}
-	session := &mockSessionTable{
+	sess := &mockSessionTable{
 		readRowFn: func(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
 			return nil, status.Error(codes.Unimplemented, "not implemented")
 		},
 	}
-	shim := NewTableShim(classic, session, btransport.NewDiverter(1.0))
+	shim := NewTableShim(classic, sess, btransport.NewDiverter(1.0))
 
 	// First ReadRow trips the breaker + falls back to classic.
 	if _, err := shim.ReadRow(context.Background(), "r1"); err != nil {
 		t.Fatalf("first ReadRow err = %v, want nil (classic fallback)", err)
 	}
-	if session.readRowCalls != 1 {
-		t.Fatalf("session.readRowCalls after first call = %d, want 1", session.readRowCalls)
+	if sess.readRowCalls != 1 {
+		t.Fatalf("sess.readRowCalls after first call = %d, want 1", sess.readRowCalls)
 	}
 
-	// Nine more calls. If the breaker is working, session.readRowCalls
+	// Nine more calls. If the breaker is working, sess.readRowCalls
 	// stays at 1 (never re-attempted). classic.readRowCalls climbs.
 	for i := 0; i < 9; i++ {
 		if _, err := shim.ReadRow(context.Background(), "r"); err != nil {
 			t.Fatalf("post-trip ReadRow #%d err = %v, want nil", i+2, err)
 		}
 	}
-	if session.readRowCalls != 1 {
-		t.Errorf("session.readRowCalls after 10 total calls = %d, want 1 (breaker must gate useSession)", session.readRowCalls)
+	if sess.readRowCalls != 1 {
+		t.Errorf("sess.readRowCalls after 10 total calls = %d, want 1 (breaker must gate useSession)", sess.readRowCalls)
 	}
 	if classic.readRowCalls != 10 {
 		t.Errorf("classic.readRowCalls after 10 total calls = %d, want 10", classic.readRowCalls)
 	}
 }
 
-// withThreshold overrides sessionUnimplementedThreshold for the test
+// withThreshold overrides session.UnimplementedThreshold for the test
 // duration and restores it on cleanup. Keeps threshold-sensitive tests
 // fast without exposing a public setter or making the threshold a
 // TableShim field.
 func withThreshold(t *testing.T, v int32) {
 	t.Helper()
-	orig := sessionUnimplementedThreshold
-	sessionUnimplementedThreshold = v
-	t.Cleanup(func() { sessionUnimplementedThreshold = orig })
+	orig := session.UnimplementedThreshold
+	session.UnimplementedThreshold = v
+	t.Cleanup(func() { session.UnimplementedThreshold = orig })
 }
 
 // TestTableShim_UnimplementedTripsBreakerAtThreshold pins the counter
@@ -632,12 +633,12 @@ func TestTableShim_UnimplementedTripsBreakerAtThreshold(t *testing.T) {
 	withThreshold(t, 3)
 
 	classic := &mockClassicTable{}
-	session := &mockSessionTable{
+	sess := &mockSessionTable{
 		readRowFn: func(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
 			return nil, status.Error(codes.Unimplemented, "not implemented")
 		},
 	}
-	shim := NewTableShim(classic, session, btransport.NewDiverter(1.0)).(*TableShim)
+	shim := NewTableShim(classic, sess, btransport.NewDiverter(1.0)).(*TableShim)
 
 	// Calls 1 and 2 hit session (still under threshold), fall back to
 	// classic per-call. Breaker stays untripped.
@@ -645,8 +646,8 @@ func TestTableShim_UnimplementedTripsBreakerAtThreshold(t *testing.T) {
 		if _, err := shim.ReadRow(context.Background(), "r"); err != nil {
 			t.Fatalf("call #%d err = %v, want nil", i+1, err)
 		}
-		if shim.sessionUnimplemented.Load() {
-			t.Fatalf("breaker tripped after %d/%d Unimplemented — expected trip only at threshold=3", i+1, sessionUnimplementedThreshold)
+		if shim.unimplemented.Bypass() {
+			t.Fatalf("breaker tripped after %d/%d Unimplemented — expected trip only at threshold=3", i+1, session.UnimplementedThreshold)
 		}
 	}
 
@@ -655,19 +656,19 @@ func TestTableShim_UnimplementedTripsBreakerAtThreshold(t *testing.T) {
 	if _, err := shim.ReadRow(context.Background(), "r"); err != nil {
 		t.Fatalf("call #3 err = %v, want nil", err)
 	}
-	if !shim.sessionUnimplemented.Load() {
+	if !shim.unimplemented.Bypass() {
 		t.Errorf("breaker NOT tripped after 3/3 Unimplemented — recordSessionOutcome must flip sessionUnimplemented when count reaches threshold")
 	}
-	if session.readRowCalls != 3 {
-		t.Errorf("session.readRowCalls = %d, want 3 (one attempt per call until trip)", session.readRowCalls)
+	if sess.readRowCalls != 3 {
+		t.Errorf("sess.readRowCalls = %d, want 3 (one attempt per call until trip)", sess.readRowCalls)
 	}
 
 	// Call 4 skips session outright (breaker gate at useSession).
 	if _, err := shim.ReadRow(context.Background(), "r"); err != nil {
 		t.Fatalf("call #4 err = %v, want nil (classic-only after trip)", err)
 	}
-	if session.readRowCalls != 3 {
-		t.Errorf("session.readRowCalls after post-trip call = %d, want 3 (breaker must gate useSession)", session.readRowCalls)
+	if sess.readRowCalls != 3 {
+		t.Errorf("sess.readRowCalls after post-trip call = %d, want 3 (breaker must gate useSession)", sess.readRowCalls)
 	}
 	if classic.readRowCalls != 4 {
 		t.Errorf("classic.readRowCalls = %d, want 4 (3 per-call fallbacks + 1 breaker-gated)", classic.readRowCalls)
@@ -688,7 +689,7 @@ func TestTableShim_UnimplementedCounterResetsOnSuccess(t *testing.T) {
 	// consecutive, so breaker MUST NOT trip.
 	callN := 0
 	classic := &mockClassicTable{}
-	session := &mockSessionTable{
+	sess := &mockSessionTable{
 		readRowFn: func(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
 			callN++
 			switch callN {
@@ -699,17 +700,17 @@ func TestTableShim_UnimplementedCounterResetsOnSuccess(t *testing.T) {
 			return &btpb.SessionReadRowResponse{Row: &btpb.Row{Key: req.GetKey()}}, nil
 		},
 	}
-	shim := NewTableShim(classic, session, btransport.NewDiverter(1.0)).(*TableShim)
+	shim := NewTableShim(classic, sess, btransport.NewDiverter(1.0)).(*TableShim)
 
 	for i := 0; i < 5; i++ {
 		if _, err := shim.ReadRow(context.Background(), "r"); err != nil {
 			t.Fatalf("call #%d err = %v, want nil", i+1, err)
 		}
 	}
-	if shim.sessionUnimplemented.Load() {
+	if shim.unimplemented.Bypass() {
 		t.Errorf("breaker tripped after 4 non-consecutive Unimplemented (call 3 succeeded — counter must have reset)")
 	}
-	if got := shim.unimplementedCount.Load(); got != 2 {
+	if got := shim.unimplemented.Count(); got != 2 {
 		t.Errorf("unimplementedCount = %d, want 2 (calls 4 and 5, counting from post-reset)", got)
 	}
 }
@@ -725,7 +726,7 @@ func TestTableShim_UnimplementedCounterResetsOnNonUnimplementedError(t *testing.
 
 	callN := 0
 	classic := &mockClassicTable{}
-	session := &mockSessionTable{
+	sess := &mockSessionTable{
 		readRowFn: func(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
 			callN++
 			switch callN {
@@ -738,7 +739,7 @@ func TestTableShim_UnimplementedCounterResetsOnNonUnimplementedError(t *testing.
 			}
 		},
 	}
-	shim := NewTableShim(classic, session, btransport.NewDiverter(1.0)).(*TableShim)
+	shim := NewTableShim(classic, sess, btransport.NewDiverter(1.0)).(*TableShim)
 
 	// Calls 1 and 2 fall back to classic transparently.
 	for i := 0; i < 2; i++ {
@@ -750,7 +751,7 @@ func TestTableShim_UnimplementedCounterResetsOnNonUnimplementedError(t *testing.
 	if _, err := shim.ReadRow(context.Background(), "r"); !errors.Is(err, unavail) {
 		t.Fatalf("call #3 err = %v, want unwrap to %v", err, unavail)
 	}
-	if got := shim.unimplementedCount.Load(); got != 0 {
+	if got := shim.unimplemented.Count(); got != 0 {
 		t.Fatalf("unimplementedCount after Unavailable = %d, want 0 (non-Unimplemented response must reset counter)", got)
 	}
 	// Calls 4 and 5 Unimplemented — counter climbs from 0 again, still
@@ -760,7 +761,7 @@ func TestTableShim_UnimplementedCounterResetsOnNonUnimplementedError(t *testing.
 			t.Fatalf("call #%d err = %v, want nil", i+4, err)
 		}
 	}
-	if shim.sessionUnimplemented.Load() {
+	if shim.unimplemented.Bypass() {
 		t.Errorf("breaker tripped after Unavailable reset — counter should be at 2, not threshold=3")
 	}
 }
@@ -786,7 +787,7 @@ func TestTableShim_NonUnimplementedError_DoesNotFallBack(t *testing.T) {
 		t.Run(code.String(), func(t *testing.T) {
 			sessErr := status.Error(code, "session err")
 			classic := &mockClassicTable{}
-			session := &mockSessionTable{
+			sess := &mockSessionTable{
 				readRowFn: func(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
 					return nil, sessErr
 				},
@@ -794,7 +795,7 @@ func TestTableShim_NonUnimplementedError_DoesNotFallBack(t *testing.T) {
 					return nil, sessErr
 				},
 			}
-			shim := NewTableShim(classic, session, btransport.NewDiverter(1.0)).(*TableShim)
+			shim := NewTableShim(classic, sess, btransport.NewDiverter(1.0)).(*TableShim)
 
 			// ReadRow: session err must propagate, no classic fallback.
 			_, gotRead := shim.ReadRow(context.Background(), "r")
@@ -817,7 +818,7 @@ func TestTableShim_NonUnimplementedError_DoesNotFallBack(t *testing.T) {
 			}
 
 			// Breaker must NOT have tripped — subsequent calls still route session.
-			if shim.sessionUnimplemented.Load() {
+			if shim.unimplemented.Bypass() {
 				t.Errorf("sessionUnimplemented tripped after code=%v; only codes.Unimplemented may trip it", code)
 			}
 		})


### PR DESCRIPTION
## Summary

When the session-path RPC returns \`codes.Unimplemented\`, \`TableShim\`
transparently re-issues the request on the classic path AND flips a
sticky per-resource breaker so future calls skip the session route.

## Why

Session data plane rolls out per-AFE. Backends that don't yet
implement session RPCs return UNIMPLEMENTED — today those errors fail
the user's request outright even though the classic path works fine.
This CL keeps the request successful and stops us from repeatedly
paying an RPC round-trip to a backend that can't handle it.

## Design

| Axis | Choice | Rationale |
|---|---|---|
| Signal | \`status.Code(err) == codes.Unimplemented\` on outermost session err | \`consecutiveFailureError.GRPCStatus()\` already preserves the code end-to-end; routing dispatches directly. |
| Placement | \`TableShim.ReadRow\` / \`.Apply\` | TableShim owns routing; \`sessionTable\` stays agnostic. Java parity (\`DivertingUnaryCallable\`, not the retry interceptor). |
| Granularity | Per-\`TableShim\` (per-resource) | Two tables in the same Client trip independently. Same as Java per-\`SessionPool\`. |
| Stickiness | Forever within shim lifetime | UNIMPLEMENTED is a backend capability signal, not transient. Fresh shim after \`sessionTableCache\` TTL-evict (~1h idle) starts un-tripped → implicit rollout recovery. |
| Concurrency | \`CompareAndSwap(false, true)\` on \`atomic.Bool\` | Coalesces concurrent Unimplemented responses so a follow-up debug tag / metric fires exactly once per resource. |

## What's out of scope

- **Threshold-based tolerance** (Java uses 30 consecutive). Our signal is deterministic — a single Unimplemented is authoritative. Follow-up if we later want to tolerate transient Unimplemented across a rolling deploy.
- **Debug tag / metric** — \`RecordDebugTag\` isn't exported publicly from \`transport\` yet. \`tripSessionBreaker\` is structured (CAS return) so a fire-once observability hook plugs in cleanly when the export lands.
- **\`ReadRows\` / \`SampleRowKeys\` / \`ApplyBulk\` / \`ApplyReadModifyWrite\`** — already route classic-only.

Also closes the \`TODO(mutianf)\` in \`session_pool_lifecycle.go\` that
asked for exactly this routing flip. Comment updated to point at
TableShim as the owner.

## Files

- \`bigtable/table_shim.go\` — \`sessionUnimplemented atomic.Bool\` field, \`tripSessionBreaker\` helper, extended \`useSession()\`, fallback hooks in \`ReadRow\` + \`Apply\`.
- \`bigtable/table_shim_test.go\` — 4 new deterministic tests + updated doc on \`TestTableShim_SessionErrorNotRetriedOnClassic\` naming the Unimplemented exception.
- \`bigtable/internal/transport/session_pool_lifecycle.go\` — TODO(mutianf) → comment describing the TableShim breaker.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`goimports -l\` clean
- [x] \`go test -race -count=1 -short -timeout=180s ./ ./internal/transport/ ./internal/session/\` — green, modulo pre-existing \`TestIntegration_NewClientWithEmulatorHost\` failure on \`upstream/main\` (unrelated: emulator-host resolver plumbing)
- [x] New tests fail as expected if I revert the fallback branch — verified by dry-running with the \`status.Code == Unimplemented\` check commented out