### PR TITLE
feat(bigtable/accelerator): add V2-to-session request adapters

### DIFF
--- a/bigtable/internal/accelerator/adapters/common.go
+++ b/bigtable/internal/accelerator/adapters/common.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapters
+
+// ResourceKind identifies which kind of Bigtable resource a request targets.
+// The adapter knows this from which V2 name field the caller populated, so
+// downstream routing switches on the kind instead of re-parsing the name.
+type ResourceKind int
+
+const (
+	// ResourceTable is a standard table ("projects/P/instances/I/tables/T").
+	ResourceTable ResourceKind = iota
+	// ResourceAuthorizedView is an authorized view
+	// ("projects/P/instances/I/tables/T/authorizedViews/V").
+	ResourceAuthorizedView
+	// ResourceMaterializedView is a materialized view
+	// ("projects/P/instances/I/materializedViews/V"). Read-only.
+	ResourceMaterializedView
+)
+
+// Resource is the fully-qualified resource a request targets, tagged with its
+// kind so callers route without inspecting the name string.
+type Resource struct {
+	Kind ResourceKind
+	Name string
+}
+
+// Adapter defines a generic interface for adapting one type to another.
+type Adapter[From any, To any] interface {
+	Adapt(from From) (To, error)
+}
+
+// RequestAdapter represents a specialized adapter for request routing.
+type RequestAdapter[From any, To any] interface {
+	Adapter[From, To]
+	ExtractResource(from From) (Resource, error)
+}
+
+// Default request and response adapter singletons.
+var (
+	DefaultReadRowRequestAdapter    = &ReadRowRequestAdapter{}
+	DefaultReadRowResponseAdapter   = &ReadRowResponseAdapter{}
+	DefaultMutateRowRequestAdapter  = &MutateRowRequestAdapter{}
+	DefaultMutateRowResponseAdapter = &MutateRowResponseAdapter{}
+)

--- a/bigtable/internal/accelerator/adapters/common_test.go
+++ b/bigtable/internal/accelerator/adapters/common_test.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapters
+
+import "testing"
+
+func TestAdaptersExist(t *testing.T) {
+	if DefaultReadRowRequestAdapter == nil {
+		t.Error("expected DefaultReadRowRequestAdapter to be non-nil")
+	}
+	if DefaultReadRowResponseAdapter == nil {
+		t.Error("expected DefaultReadRowResponseAdapter to be non-nil")
+	}
+	if DefaultMutateRowRequestAdapter == nil {
+		t.Error("expected DefaultMutateRowRequestAdapter to be non-nil")
+	}
+	if DefaultMutateRowResponseAdapter == nil {
+		t.Error("expected DefaultMutateRowResponseAdapter to be non-nil")
+	}
+}

--- a/bigtable/internal/accelerator/adapters/mutate_row.go
+++ b/bigtable/internal/accelerator/adapters/mutate_row.go
@@ -23,6 +23,8 @@ import (
 // MutateRowRequestAdapter adapts V2 MutateRowRequest to SessionMutateRowRequest.
 type MutateRowRequestAdapter struct{}
 
+// Adapt converts a V2 MutateRowRequest into a SessionMutateRowRequest,
+// carrying over the row key and mutations. It returns nil for a nil input.
 func (a *MutateRowRequestAdapter) Adapt(from *v2pb.MutateRowRequest) (*v2pb.SessionMutateRowRequest, error) {
 	if from == nil {
 		return nil, nil
@@ -55,6 +57,9 @@ func (a *MutateRowRequestAdapter) ExtractResource(from *v2pb.MutateRowRequest) (
 // MutateRowResponseAdapter adapts SessionMutateRowResponse to MutateRowResponse.
 type MutateRowResponseAdapter struct{}
 
+// Adapt converts a SessionMutateRowResponse into a V2 MutateRowResponse. The V2
+// response carries no fields, so this returns an empty response on success and
+// nil for a nil input.
 func (a *MutateRowResponseAdapter) Adapt(from *v2pb.SessionMutateRowResponse) (*v2pb.MutateRowResponse, error) {
 	if from == nil {
 		return nil, nil

--- a/bigtable/internal/accelerator/adapters/mutate_row.go
+++ b/bigtable/internal/accelerator/adapters/mutate_row.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapters
+
+import (
+	v2pb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// MutateRowRequestAdapter adapts V2 MutateRowRequest to SessionMutateRowRequest.
+type MutateRowRequestAdapter struct{}
+
+func (a *MutateRowRequestAdapter) Adapt(from *v2pb.MutateRowRequest) (*v2pb.SessionMutateRowRequest, error) {
+	if from == nil {
+		return nil, nil
+	}
+	return &v2pb.SessionMutateRowRequest{
+		Key:       from.RowKey,
+		Mutations: from.Mutations,
+	}, nil
+}
+
+// ExtractResource returns the resource the request targets, tagged with its
+// kind. A MutateRowRequest names either a table or an authorized view
+// (materialized views are read-only and have no field here); the authorized
+// view is checked first so the correct resource is surfaced regardless of which
+// the caller populated.
+func (a *MutateRowRequestAdapter) ExtractResource(from *v2pb.MutateRowRequest) (Resource, error) {
+	if from == nil {
+		return Resource{}, status.Errorf(codes.InvalidArgument, "request is nil")
+	}
+	switch {
+	case from.AuthorizedViewName != "":
+		return Resource{Kind: ResourceAuthorizedView, Name: from.AuthorizedViewName}, nil
+	case from.TableName != "":
+		return Resource{Kind: ResourceTable, Name: from.TableName}, nil
+	default:
+		return Resource{}, status.Errorf(codes.InvalidArgument, "MutateRowRequest names no table or authorized view")
+	}
+}
+
+// MutateRowResponseAdapter adapts SessionMutateRowResponse to MutateRowResponse.
+type MutateRowResponseAdapter struct{}
+
+func (a *MutateRowResponseAdapter) Adapt(from *v2pb.SessionMutateRowResponse) (*v2pb.MutateRowResponse, error) {
+	if from == nil {
+		return nil, nil
+	}
+	// Bare minimum scaffold.
+	return &v2pb.MutateRowResponse{}, nil
+}

--- a/bigtable/internal/accelerator/adapters/mutate_row_test.go
+++ b/bigtable/internal/accelerator/adapters/mutate_row_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapters
+
+import (
+	"testing"
+
+	v2pb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestMutateRowRequestAdapter(t *testing.T) {
+	reqAdapter := &MutateRowRequestAdapter{}
+	v2Req := &v2pb.MutateRowRequest{
+		TableName: "projects/p1/instances/i1/tables/t1",
+		RowKey:    []byte("row-key"),
+		Mutations: []*v2pb.Mutation{
+			{
+				Mutation: &v2pb.Mutation_SetCell_{
+					SetCell: &v2pb.Mutation_SetCell{
+						FamilyName:      "fam",
+						ColumnQualifier: []byte("qual"),
+						Value:           []byte("val"),
+						TimestampMicros: 1000,
+					},
+				},
+			},
+		},
+	}
+
+	jsReq, err := reqAdapter.Adapt(v2Req)
+	if err != nil {
+		t.Fatalf("Adapt failed: %v", err)
+	}
+
+	if string(jsReq.Key) != "row-key" {
+		t.Errorf("expected key 'row-key', got %s", string(jsReq.Key))
+	}
+
+	if len(jsReq.Mutations) != 1 {
+		t.Fatalf("expected 1 mutation, got %d", len(jsReq.Mutations))
+	}
+
+	setCell := jsReq.Mutations[0].GetSetCell()
+	if setCell == nil {
+		t.Fatal("expected SetCell mutation")
+	}
+
+	if setCell.FamilyName != "fam" || string(setCell.ColumnQualifier) != "qual" || string(setCell.Value) != "val" {
+		t.Errorf("unexpected set cell content: %+v", setCell)
+	}
+
+	res, err := reqAdapter.ExtractResource(v2Req)
+	if err != nil {
+		t.Fatalf("ExtractResource failed: %v", err)
+	}
+	if res.Kind != ResourceTable || res.Name != "projects/p1/instances/i1/tables/t1" {
+		t.Errorf("ExtractResource = %+v; want {ResourceTable, projects/p1/instances/i1/tables/t1}", res)
+	}
+}
+
+func TestMutateRowRequestAdapter_ExtractResource(t *testing.T) {
+	reqAdapter := &MutateRowRequestAdapter{}
+	cases := []struct {
+		name string
+		req  *v2pb.MutateRowRequest
+		want Resource
+	}{
+		{
+			"table",
+			&v2pb.MutateRowRequest{TableName: "projects/p/instances/i/tables/t"},
+			Resource{Kind: ResourceTable, Name: "projects/p/instances/i/tables/t"},
+		},
+		{
+			"authorized-view",
+			&v2pb.MutateRowRequest{AuthorizedViewName: "projects/p/instances/i/tables/t/authorizedViews/v"},
+			Resource{Kind: ResourceAuthorizedView, Name: "projects/p/instances/i/tables/t/authorizedViews/v"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := reqAdapter.ExtractResource(tc.req)
+			if err != nil {
+				t.Fatalf("ExtractResource: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("ExtractResource = %+v; want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMutateRowRequestAdapter_ExtractResource_Empty(t *testing.T) {
+	reqAdapter := &MutateRowRequestAdapter{}
+	_, err := reqAdapter.ExtractResource(&v2pb.MutateRowRequest{})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("ExtractResource(empty) code = %v; want InvalidArgument", status.Code(err))
+	}
+}
+
+func TestMutateRowResponseAdapter(t *testing.T) {
+	resAdapter := &MutateRowResponseAdapter{}
+	jsRes := &v2pb.SessionMutateRowResponse{}
+	v2Res, err := resAdapter.Adapt(jsRes)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if v2Res == nil {
+		t.Fatal("expected non-nil v2Res")
+	}
+}

--- a/bigtable/internal/accelerator/adapters/read_row.go
+++ b/bigtable/internal/accelerator/adapters/read_row.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapters
+
+import (
+	v2pb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// ReadRowRequestAdapter adapts V2 ReadRowsRequest to SessionReadRowRequest.
+type ReadRowRequestAdapter struct{}
+
+func (a *ReadRowRequestAdapter) Adapt(from *v2pb.ReadRowsRequest) (*v2pb.SessionReadRowRequest, error) {
+	if from == nil {
+		return nil, nil
+	}
+	req := &v2pb.SessionReadRowRequest{Filter: from.Filter}
+	if from.Rows == nil {
+		return req, nil
+	}
+	switch {
+	case len(from.Rows.RowKeys) > 0:
+		req.Key = from.Rows.RowKeys[0]
+	case len(from.Rows.RowRanges) > 0:
+		if r, ok := from.Rows.RowRanges[0].StartKey.(*v2pb.RowRange_StartKeyClosed); ok {
+			req.Key = r.StartKeyClosed
+		}
+	}
+	return req, nil
+}
+
+// ExtractResource returns the resource the request targets, tagged with its
+// kind. A ReadRowsRequest names exactly one of a table, an authorized view, or
+// a materialized view; the more-specific fields are checked first so the
+// correct resource is surfaced regardless of which the caller populated.
+func (a *ReadRowRequestAdapter) ExtractResource(from *v2pb.ReadRowsRequest) (Resource, error) {
+	if from == nil {
+		return Resource{}, status.Errorf(codes.InvalidArgument, "request is nil")
+	}
+	switch {
+	case from.MaterializedViewName != "":
+		return Resource{Kind: ResourceMaterializedView, Name: from.MaterializedViewName}, nil
+	case from.AuthorizedViewName != "":
+		return Resource{Kind: ResourceAuthorizedView, Name: from.AuthorizedViewName}, nil
+	case from.TableName != "":
+		return Resource{Kind: ResourceTable, Name: from.TableName}, nil
+	default:
+		return Resource{}, status.Errorf(codes.InvalidArgument, "ReadRowsRequest names no table, authorized view, or materialized view")
+	}
+}
+
+// ReadRowResponseAdapter adapts SessionReadRowResponse to ReadRowsResponse,
+// flattening Row.Families → Columns → Cells into a sequence of CellChunks
+// with the on-wire boundary markers (RowKey on the first chunk of the row,
+// FamilyName at each family transition, Qualifier at each column transition,
+// CommitRow on the last chunk).
+type ReadRowResponseAdapter struct{}
+
+func (a *ReadRowResponseAdapter) Adapt(from *v2pb.SessionReadRowResponse) (*v2pb.ReadRowsResponse, error) {
+	if from == nil || from.Row == nil {
+		return nil, nil
+	}
+	row := from.Row
+
+	var chunks []*v2pb.ReadRowsResponse_CellChunk
+	first := true
+	for _, fam := range row.Families {
+		familyEmitted := false
+		for _, col := range fam.Columns {
+			columnEmitted := false
+			for _, cell := range col.Cells {
+				cc := &v2pb.ReadRowsResponse_CellChunk{
+					TimestampMicros: cell.TimestampMicros,
+					Value:           cell.Value,
+					Labels:          cell.Labels,
+				}
+				if first {
+					cc.RowKey = row.Key
+					first = false
+				}
+				if !familyEmitted {
+					cc.FamilyName = &wrapperspb.StringValue{Value: fam.Name}
+					familyEmitted = true
+				}
+				if !columnEmitted {
+					cc.Qualifier = &wrapperspb.BytesValue{Value: col.Qualifier}
+					columnEmitted = true
+				}
+				chunks = append(chunks, cc)
+			}
+		}
+	}
+	if len(chunks) == 0 {
+		return nil, nil
+	}
+	chunks[len(chunks)-1].RowStatus = &v2pb.ReadRowsResponse_CellChunk_CommitRow{CommitRow: true}
+	return &v2pb.ReadRowsResponse{Chunks: chunks}, nil
+}

--- a/bigtable/internal/accelerator/adapters/read_row.go
+++ b/bigtable/internal/accelerator/adapters/read_row.go
@@ -24,6 +24,10 @@ import (
 // ReadRowRequestAdapter adapts V2 ReadRowsRequest to SessionReadRowRequest.
 type ReadRowRequestAdapter struct{}
 
+// Adapt converts a V2 ReadRowsRequest into a SessionReadRowRequest for a point
+// read, carrying over the filter and extracting the single row key from either
+// RowKeys[0] or the closed start key of RowRanges[0]. It returns nil for a nil
+// input.
 func (a *ReadRowRequestAdapter) Adapt(from *v2pb.ReadRowsRequest) (*v2pb.SessionReadRowRequest, error) {
 	if from == nil {
 		return nil, nil
@@ -70,6 +74,10 @@ func (a *ReadRowRequestAdapter) ExtractResource(from *v2pb.ReadRowsRequest) (Res
 // CommitRow on the last chunk).
 type ReadRowResponseAdapter struct{}
 
+// Adapt converts a SessionReadRowResponse into a V2 ReadRowsResponse, flattening
+// the row's families, columns, and cells into CellChunks with the on-wire
+// boundary markers. It returns nil when the input or its row is nil, or when the
+// row contains no cells.
 func (a *ReadRowResponseAdapter) Adapt(from *v2pb.SessionReadRowResponse) (*v2pb.ReadRowsResponse, error) {
 	if from == nil || from.Row == nil {
 		return nil, nil

--- a/bigtable/internal/accelerator/adapters/read_row_test.go
+++ b/bigtable/internal/accelerator/adapters/read_row_test.go
@@ -1,0 +1,421 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapters
+
+import (
+	"bytes"
+	"testing"
+
+	v2pb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestReadRowRequestAdapter(t *testing.T) {
+	reqAdapter := &ReadRowRequestAdapter{}
+	v2Req := &v2pb.ReadRowsRequest{
+		TableName: "projects/p1/instances/i1/tables/t1",
+		Rows: &v2pb.RowSet{
+			RowKeys: [][]byte{[]byte("test-key")},
+		},
+		Filter: &v2pb.RowFilter{
+			Filter: &v2pb.RowFilter_FamilyNameRegexFilter{FamilyNameRegexFilter: "family-regex"},
+		},
+	}
+	jsReq, err := reqAdapter.Adapt(v2Req)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if jsReq == nil {
+		t.Fatal("expected non-nil jsReq")
+	}
+
+	if string(jsReq.Key) != "test-key" {
+		t.Errorf("expected Key test-key, got %s", string(jsReq.Key))
+	}
+
+	if jsReq.Filter.GetFamilyNameRegexFilter() != "family-regex" {
+		t.Errorf("expected Filter family-regex, got %s", jsReq.Filter.GetFamilyNameRegexFilter())
+	}
+
+	res, err := reqAdapter.ExtractResource(v2Req)
+	if err != nil {
+		t.Fatalf("ExtractResource failed: %v", err)
+	}
+	if res.Kind != ResourceTable || res.Name != "projects/p1/instances/i1/tables/t1" {
+		t.Errorf("ExtractResource = %+v; want {ResourceTable, projects/p1/instances/i1/tables/t1}", res)
+	}
+}
+
+func TestReadRowRequestAdapter_ExtractResource(t *testing.T) {
+	reqAdapter := &ReadRowRequestAdapter{}
+	cases := []struct {
+		name string
+		req  *v2pb.ReadRowsRequest
+		want Resource
+	}{
+		{
+			"table",
+			&v2pb.ReadRowsRequest{TableName: "projects/p/instances/i/tables/t"},
+			Resource{Kind: ResourceTable, Name: "projects/p/instances/i/tables/t"},
+		},
+		{
+			"authorized-view",
+			&v2pb.ReadRowsRequest{AuthorizedViewName: "projects/p/instances/i/tables/t/authorizedViews/v"},
+			Resource{Kind: ResourceAuthorizedView, Name: "projects/p/instances/i/tables/t/authorizedViews/v"},
+		},
+		{
+			"materialized-view",
+			&v2pb.ReadRowsRequest{MaterializedViewName: "projects/p/instances/i/materializedViews/mv"},
+			Resource{Kind: ResourceMaterializedView, Name: "projects/p/instances/i/materializedViews/mv"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := reqAdapter.ExtractResource(tc.req)
+			if err != nil {
+				t.Fatalf("ExtractResource: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("ExtractResource = %+v; want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadRowRequestAdapter_ExtractResource_Empty(t *testing.T) {
+	reqAdapter := &ReadRowRequestAdapter{}
+	_, err := reqAdapter.ExtractResource(&v2pb.ReadRowsRequest{})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("ExtractResource(empty) code = %v; want InvalidArgument", status.Code(err))
+	}
+}
+
+func TestReadRowRequestAdapter_ClosedClosedRange(t *testing.T) {
+	reqAdapter := &ReadRowRequestAdapter{}
+	v2Req := &v2pb.ReadRowsRequest{
+		TableName: "projects/p1/instances/i1/tables/t1",
+		Rows: &v2pb.RowSet{
+			RowRanges: []*v2pb.RowRange{{
+				StartKey: &v2pb.RowRange_StartKeyClosed{StartKeyClosed: []byte("range-key")},
+				EndKey:   &v2pb.RowRange_EndKeyClosed{EndKeyClosed: []byte("range-key")},
+			}},
+		},
+	}
+	jsReq, err := reqAdapter.Adapt(v2Req)
+	if err != nil {
+		t.Fatalf("Adapt error: %v", err)
+	}
+	if jsReq == nil {
+		t.Fatal("Adapt returned nil")
+	}
+	if string(jsReq.Key) != "range-key" {
+		t.Errorf("Key = %q; want range-key", jsReq.Key)
+	}
+}
+
+func TestReadRowResponseAdapter_NilAndEmpty(t *testing.T) {
+	a := &ReadRowResponseAdapter{}
+
+	got, err := a.Adapt(nil)
+	if err != nil {
+		t.Fatalf("Adapt(nil) error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Adapt(nil) = %v; want nil", got)
+	}
+
+	got, err = a.Adapt(&v2pb.SessionReadRowResponse{}) // Row == nil → missing row
+	if err != nil {
+		t.Fatalf("Adapt(missing row) error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Adapt(missing row) = %v; want nil", got)
+	}
+
+	got, err = a.Adapt(&v2pb.SessionReadRowResponse{Row: &v2pb.Row{Key: []byte("k")}}) // no families
+	if err != nil {
+		t.Fatalf("Adapt(empty row) error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Adapt(empty row) = %v; want nil", got)
+	}
+}
+
+func TestReadRowResponseAdapter_SingleCell(t *testing.T) {
+	a := &ReadRowResponseAdapter{}
+	resp := &v2pb.SessionReadRowResponse{
+		Row: &v2pb.Row{
+			Key: []byte("rk"),
+			Families: []*v2pb.Family{{
+				Name: "fam",
+				Columns: []*v2pb.Column{{
+					Qualifier: []byte("q"),
+					Cells: []*v2pb.Cell{{
+						TimestampMicros: 1234,
+						Value:           []byte("v"),
+						Labels:          []string{"L"},
+					}},
+				}},
+			}},
+		},
+	}
+	got, err := a.Adapt(resp)
+	if err != nil {
+		t.Fatalf("Adapt error: %v", err)
+	}
+	if got == nil || len(got.Chunks) != 1 {
+		t.Fatalf("Chunks len = %d; want 1 (got=%+v)", len(got.GetChunks()), got)
+	}
+	cc := got.Chunks[0]
+	if !bytes.Equal(cc.RowKey, []byte("rk")) {
+		t.Errorf("RowKey = %q; want rk", cc.RowKey)
+	}
+	if cc.FamilyName == nil || cc.FamilyName.Value != "fam" {
+		t.Errorf("FamilyName = %v; want fam", cc.FamilyName)
+	}
+	if cc.Qualifier == nil || !bytes.Equal(cc.Qualifier.Value, []byte("q")) {
+		t.Errorf("Qualifier = %v; want q", cc.Qualifier)
+	}
+	if cc.TimestampMicros != 1234 {
+		t.Errorf("TimestampMicros = %d; want 1234", cc.TimestampMicros)
+	}
+	if !bytes.Equal(cc.Value, []byte("v")) {
+		t.Errorf("Value = %q; want v", cc.Value)
+	}
+	if len(cc.Labels) != 1 || cc.Labels[0] != "L" {
+		t.Errorf("Labels = %v; want [L]", cc.Labels)
+	}
+	commit, ok := cc.RowStatus.(*v2pb.ReadRowsResponse_CellChunk_CommitRow)
+	if !ok || !commit.CommitRow {
+		t.Errorf("RowStatus = %v; want CommitRow=true", cc.RowStatus)
+	}
+}
+
+func TestReadRowResponseAdapter_MultiFamilyMultiCell_ChunkBoundaries(t *testing.T) {
+	a := &ReadRowResponseAdapter{}
+	resp := &v2pb.SessionReadRowResponse{
+		Row: &v2pb.Row{
+			Key: []byte("rk"),
+			Families: []*v2pb.Family{
+				{
+					Name: "fam1",
+					Columns: []*v2pb.Column{
+						{
+							Qualifier: []byte("c1"),
+							Cells: []*v2pb.Cell{
+								{TimestampMicros: 30, Value: []byte("v1")},
+								{TimestampMicros: 20, Value: []byte("v2")},
+							},
+						},
+						{
+							Qualifier: []byte("c2"),
+							Cells: []*v2pb.Cell{
+								{TimestampMicros: 10, Value: []byte("v3")},
+							},
+						},
+					},
+				},
+				{
+					Name: "fam2",
+					Columns: []*v2pb.Column{{
+						Qualifier: []byte("c3"),
+						Cells: []*v2pb.Cell{
+							{TimestampMicros: 5, Value: []byte("v4")},
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	got, err := a.Adapt(resp)
+	if err != nil {
+		t.Fatalf("Adapt error: %v", err)
+	}
+	if got == nil || len(got.Chunks) != 4 {
+		t.Fatalf("Chunks len = %d; want 4", len(got.GetChunks()))
+	}
+
+	want := []chunkExpect{
+		{[]byte("rk"), "fam1", []byte("c1"), 30, "v1", false},
+		{nil, "", nil, 20, "v2", false},
+		{nil, "", []byte("c2"), 10, "v3", false},
+		{nil, "fam2", []byte("c3"), 5, "v4", true},
+	}
+	assertChunks(t, got.Chunks, want)
+}
+
+type chunkExpect struct {
+	rowKey     []byte
+	familyName string // "" → expect nil FamilyName
+	qualifier  []byte // nil → expect nil Qualifier
+	ts         int64
+	value      string
+	commit     bool
+}
+
+func assertChunks(t *testing.T, got []*v2pb.ReadRowsResponse_CellChunk, want []chunkExpect) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("Chunks len = %d; want %d", len(got), len(want))
+	}
+	for i, cc := range got {
+		w := want[i]
+		if !bytes.Equal(cc.RowKey, w.rowKey) {
+			t.Errorf("chunk[%d].RowKey = %q; want %q", i, cc.RowKey, w.rowKey)
+		}
+		if w.familyName == "" {
+			if cc.FamilyName != nil {
+				t.Errorf("chunk[%d].FamilyName = %v; want nil", i, cc.FamilyName)
+			}
+		} else if cc.FamilyName == nil || cc.FamilyName.Value != w.familyName {
+			t.Errorf("chunk[%d].FamilyName = %v; want %q", i, cc.FamilyName, w.familyName)
+		}
+		if w.qualifier == nil {
+			if cc.Qualifier != nil {
+				t.Errorf("chunk[%d].Qualifier = %v; want nil", i, cc.Qualifier)
+			}
+		} else if cc.Qualifier == nil || !bytes.Equal(cc.Qualifier.Value, w.qualifier) {
+			t.Errorf("chunk[%d].Qualifier = %v; want %q", i, cc.Qualifier, w.qualifier)
+		}
+		if cc.TimestampMicros != w.ts {
+			t.Errorf("chunk[%d].TimestampMicros = %d; want %d", i, cc.TimestampMicros, w.ts)
+		}
+		if string(cc.Value) != w.value {
+			t.Errorf("chunk[%d].Value = %q; want %q", i, cc.Value, w.value)
+		}
+		commit, isCommit := cc.RowStatus.(*v2pb.ReadRowsResponse_CellChunk_CommitRow)
+		gotCommit := isCommit && commit.CommitRow
+		if gotCommit != w.commit {
+			t.Errorf("chunk[%d].CommitRow = %v; want %v", i, gotCommit, w.commit)
+		}
+	}
+}
+
+// oneCell is a helper for concise fixture construction.
+func oneCell(ts int64, val string) *v2pb.Cell {
+	return &v2pb.Cell{TimestampMicros: ts, Value: []byte(val)}
+}
+
+// TestReadRowResponseAdapter_TwoFamiliesTwoColumns_QualifierRepeats covers
+// cf1:{a,b}, cf2:{b,c}. Verifies that (a) qualifier "b" is emitted at both
+// family boundaries even though the byte string is the same, (b) FamilyName
+// is set on the first chunk of each family, (c) RowKey only appears on the
+// first chunk, and (d) CommitRow only on the last.
+func TestReadRowResponseAdapter_TwoFamiliesTwoColumns_QualifierRepeats(t *testing.T) {
+	a := &ReadRowResponseAdapter{}
+	resp := &v2pb.SessionReadRowResponse{
+		Row: &v2pb.Row{
+			Key: []byte("rk"),
+			Families: []*v2pb.Family{
+				{
+					Name: "cf1",
+					Columns: []*v2pb.Column{
+						{Qualifier: []byte("a"), Cells: []*v2pb.Cell{oneCell(40, "va")}},
+						{Qualifier: []byte("b"), Cells: []*v2pb.Cell{oneCell(30, "v1b")}},
+					},
+				},
+				{
+					Name: "cf2",
+					Columns: []*v2pb.Column{
+						{Qualifier: []byte("b"), Cells: []*v2pb.Cell{oneCell(20, "v2b")}},
+						{Qualifier: []byte("c"), Cells: []*v2pb.Cell{oneCell(10, "vc")}},
+					},
+				},
+			},
+		},
+	}
+	got, err := a.Adapt(resp)
+	if err != nil {
+		t.Fatalf("Adapt error: %v", err)
+	}
+	assertChunks(t, got.GetChunks(), []chunkExpect{
+		{[]byte("rk"), "cf1", []byte("a"), 40, "va", false},
+		{nil, "", []byte("b"), 30, "v1b", false},
+		{nil, "cf2", []byte("b"), 20, "v2b", false},
+		{nil, "", []byte("c"), 10, "vc", true},
+	})
+}
+
+// TestReadRowResponseAdapter_TwoFamiliesMultiCell covers the same shape as
+// above but with multiple cells per column, exercising the inner "cell after
+// the first in a column has no boundary markers" rule.
+func TestReadRowResponseAdapter_TwoFamiliesMultiCell(t *testing.T) {
+	a := &ReadRowResponseAdapter{}
+	resp := &v2pb.SessionReadRowResponse{
+		Row: &v2pb.Row{
+			Key: []byte("rk"),
+			Families: []*v2pb.Family{
+				{
+					Name: "cf1",
+					Columns: []*v2pb.Column{
+						{Qualifier: []byte("a"), Cells: []*v2pb.Cell{oneCell(40, "va")}},
+						{Qualifier: []byte("b"), Cells: []*v2pb.Cell{oneCell(35, "v1b_new"), oneCell(30, "v1b_old")}},
+					},
+				},
+				{
+					Name: "cf2",
+					Columns: []*v2pb.Column{
+						{Qualifier: []byte("b"), Cells: []*v2pb.Cell{oneCell(20, "v2b")}},
+						{Qualifier: []byte("c"), Cells: []*v2pb.Cell{oneCell(15, "vc_new"), oneCell(10, "vc_old")}},
+					},
+				},
+			},
+		},
+	}
+	got, err := a.Adapt(resp)
+	if err != nil {
+		t.Fatalf("Adapt error: %v", err)
+	}
+	assertChunks(t, got.GetChunks(), []chunkExpect{
+		{[]byte("rk"), "cf1", []byte("a"), 40, "va", false},
+		{nil, "", []byte("b"), 35, "v1b_new", false},
+		{nil, "", nil, 30, "v1b_old", false}, // second cell in cf1:b — no boundary markers
+		{nil, "cf2", []byte("b"), 20, "v2b", false},
+		{nil, "", []byte("c"), 15, "vc_new", false},
+		{nil, "", nil, 10, "vc_old", true}, // last chunk — CommitRow
+	})
+}
+
+// TestReadRowResponseAdapter_FamilyWithNoColumns treats a family whose
+// Columns slice is empty as contributing zero chunks — it must not emit a
+// bare FamilyName chunk with no cell payload, and it must not shift where
+// CommitRow lands.
+func TestReadRowResponseAdapter_FamilyWithNoColumns(t *testing.T) {
+	a := &ReadRowResponseAdapter{}
+	resp := &v2pb.SessionReadRowResponse{
+		Row: &v2pb.Row{
+			Key: []byte("rk"),
+			Families: []*v2pb.Family{
+				{Name: "empty"}, // no columns
+				{
+					Name: "cf1",
+					Columns: []*v2pb.Column{
+						{Qualifier: []byte("q"), Cells: []*v2pb.Cell{oneCell(1, "v")}},
+					},
+				},
+			},
+		},
+	}
+	got, err := a.Adapt(resp)
+	if err != nil {
+		t.Fatalf("Adapt error: %v", err)
+	}
+	assertChunks(t, got.GetChunks(), []chunkExpect{
+		{[]byte("rk"), "cf1", []byte("q"), 1, "v", true},
+	})
+}


### PR DESCRIPTION
Translate incoming V2 Bigtable protos (ReadRow, MutateRow) to and from the internal/session vRPC types, and tag each request with the resource kind it targets (table, authorized view, or materialized view) so callers can route without parsing the resource name.

Change-Id: Ib2b54ca40a18bbfbdaf88114cb1ae8c8b7579d01