### PR TITLE
feat(bigtable): route Client.Open()-returned *Table through the Diverter

### DIFF
--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -380,7 +380,22 @@ func (t *Table) readRows(ctx context.Context, arg RowSet, f func(Row) bool, opts
 
 // ReadRow is a convenience implementation of a single-row reader.
 // A missing row will return nil for both Row and error.
+//
+// When t.divertible is set (populated by Open on Clients with a
+// Diverter), the call routes through the shim so it can be diverted
+// to the session data path. Otherwise it runs the classic
+// ReadRows-with-LimitRows(1) flow.
 func (t *Table) ReadRow(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+	if t.divertible != nil {
+		return t.divertible.ReadRow(ctx, row, opts...)
+	}
+	return t.readRowClassic(ctx, row, opts...)
+}
+
+// readRowClassic is the classic single-row reader — called directly by
+// tableImpl.ReadRow (which bypasses the divertible gate) and by the
+// gate in Table.ReadRow when no divertible shim is wired.
+func (t *Table) readRowClassic(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
 	var r Row
 
 	opts = append([]ReadOption{LimitRows(1)}, opts...)
@@ -894,7 +909,22 @@ var maxMutations = 100000
 
 // Apply mutates a row atomically. A mutation must contain at least one
 // operation and at most 100000 operations.
-func (t *Table) Apply(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) (err error) {
+//
+// When t.divertible is set (populated by Open on Clients with a
+// Diverter), the call routes through the shim so it can be diverted
+// to the session data path. Otherwise it runs the classic MutateRow
+// (or CheckAndMutateRow for conditional mutations) flow inline.
+func (t *Table) Apply(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
+	if t.divertible != nil {
+		return t.divertible.Apply(ctx, row, m, opts...)
+	}
+	return t.applyClassic(ctx, row, m, opts...)
+}
+
+// applyClassic is the classic Apply body — called directly by
+// tableImpl.Apply (which bypasses the divertible gate) and by the
+// gate in Table.Apply when no divertible shim is wired.
+func (t *Table) applyClassic(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) (err error) {
 	ctx = mergeOutgoingMetadata(ctx, t.md)
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/bigtable/Apply")
 	defer func() { trace.EndSpan(ctx, err) }()

--- a/bigtable/open.go
+++ b/bigtable/open.go
@@ -20,13 +20,14 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// Open opens a table for use with the classic data path helpers that
-// still take *Table directly (BulkMutation, etc.). The returned *Table
-// is always the classic implementation regardless of the Client's
-// session-load ratio — callers who want the divertible surface should
-// use OpenTable / OpenAuthorizedView / OpenMaterializedView.
+// Open opens a table. The returned *Table honors the Client's Diverter:
+// when c.diverter is set, Apply and ReadRow are routed through an
+// internal TableShim so calls can be diverted to the session data path
+// under the diverter's SessionLoad ratio. Backward-compatible — the
+// return type stays *Table and every method that already existed keeps
+// its signature and behavior.
 func (c *Client) Open(table string) *Table {
-	return &Table{
+	t := &Table{
 		c:     c,
 		table: table,
 		md: metadata.Join(metadata.Pairs(
@@ -34,6 +35,54 @@ func (c *Client) Open(table string) *Table {
 			requestParamsHeader, c.reqParamsHeaderValTable(table),
 		), c.featureFlagsMD),
 	}
+	t.divertible = c.buildDivertible(t, func() session.TableAPI {
+		return c.getOrCreateSessionTable(table)
+	})
+	return t
+}
+
+// buildDivertible wraps a *Table's classic side in a TableShim so
+// Apply / ReadRow can be routed to the session data path. Returns nil
+// when the client has no Diverter (classic-only mode) so callers can
+// assign the result straight into Table.divertible.
+//
+// The classic side is a *tableImpl over a snapshot of t with divertible
+// EXPLICITLY nil-ed — that break in the loop is what prevents
+// tableImpl.Apply/ReadRow from recursing back through the outer gate.
+// openSession is called eagerly when the diverter is present AND the
+// session client is wired — this matches OpenTable's pre-existing
+// behavior of registering a session pool entry at Open time. Callers
+// pass nil openSession to skip the session backend entirely (TableShim
+// treats nil session as classic-only).
+//
+// Cardinality note. There are three cardinalities in play and only one
+// of them shifts with this Open-time registration:
+//
+//  1. c.sessionTables map size — grows with each unique Open call now
+//     (previously only OpenTable). Cost per entry is a string key +
+//     one *SessionTable struct (~110 B total). No I/O.
+//  2. SessionPoolImpl count (and therefore OTel session_name label
+//     cardinality) — UNCHANGED. Sessions and their pools are still
+//     opened lazily by lazyPool.get() on the first ReadRow/Apply for
+//     the table.
+//  3. Server-side OpenSession stream count — UNCHANGED, same trigger.
+//
+// So an app that Opens 10k tables but only exercises a handful sees a
+// bounded map growth and zero change in dashboards or server load. If
+// that map growth ever matters, hoist openSession into a lazy closure
+// held by TableShim so it fires on first RPC — costs a mutex round on
+// the hot path in exchange, which is why we don't do it today.
+func (c *Client) buildDivertible(t *Table, openSession func() session.TableAPI) TableAPI {
+	if c.diverter == nil {
+		return nil
+	}
+	inner := *t
+	inner.divertible = nil
+	var sess session.TableAPI
+	if c.sessionImpl != nil && openSession != nil {
+		sess = openSession()
+	}
+	return NewTableShim(&tableImpl{Table: inner}, sess, c.diverter)
 }
 
 // OpenTable opens a table. Returns a TableShim that routes each RPC via

--- a/bigtable/open.go
+++ b/bigtable/open.go
@@ -41,37 +41,19 @@ func (c *Client) Open(table string) *Table {
 	return t
 }
 
-// buildDivertible wraps a *Table's classic side in a TableShim so
-// Apply / ReadRow can be routed to the session data path. Returns nil
-// when the client has no Diverter (classic-only mode) so callers can
-// assign the result straight into Table.divertible.
+// buildDivertible wraps t's classic side in a TableShim so Apply /
+// ReadRow can be routed to the session data path. Returns nil when
+// c.diverter is nil so the caller stays on the zero-cost classic path.
 //
-// The classic side is a *tableImpl over a snapshot of t with divertible
-// EXPLICITLY nil-ed — that break in the loop is what prevents
+// The classic side is a *tableImpl over a value-copy of t with
+// divertible nil-ed — that break in the loop is what stops
 // tableImpl.Apply/ReadRow from recursing back through the outer gate.
-// openSession is called eagerly when the diverter is present AND the
-// session client is wired — this matches OpenTable's pre-existing
-// behavior of registering a session pool entry at Open time. Callers
-// pass nil openSession to skip the session backend entirely (TableShim
-// treats nil session as classic-only).
 //
-// Cardinality note. There are three cardinalities in play and only one
-// of them shifts with this Open-time registration:
-//
-//  1. c.sessionTables map size — grows with each unique Open call now
-//     (previously only OpenTable). Cost per entry is a string key +
-//     one *SessionTable struct (~110 B total). No I/O.
-//  2. SessionPoolImpl count (and therefore OTel session_name label
-//     cardinality) — UNCHANGED. Sessions and their pools are still
-//     opened lazily by lazyPool.get() on the first ReadRow/Apply for
-//     the table.
-//  3. Server-side OpenSession stream count — UNCHANGED, same trigger.
-//
-// So an app that Opens 10k tables but only exercises a handful sees a
-// bounded map growth and zero change in dashboards or server load. If
-// that map growth ever matters, hoist openSession into a lazy closure
-// held by TableShim so it fires on first RPC — costs a mutex round on
-// the hot path in exchange, which is why we don't do it today.
+// Cost per unique Open call (when both c.diverter and c.sessionImpl
+// are wired): one cache entry in c.sessionTables. No I/O — session
+// pools materialize lazily on first RPC via lazyPool.get(), so
+// SessionPoolImpl count and server-side OpenSession stream count
+// are unchanged.
 func (c *Client) buildDivertible(t *Table, openSession func() session.TableAPI) TableAPI {
 	if c.diverter == nil {
 		return nil

--- a/bigtable/open.go
+++ b/bigtable/open.go
@@ -49,8 +49,9 @@ func (c *Client) Open(table string) *Table {
 // divertible nil-ed — that break in the loop is what stops
 // tableImpl.Apply/ReadRow from recursing back through the outer gate.
 //
-// Cost per unique Open call (when both c.diverter and c.sessionImpl
-// are wired): one cache entry in c.sessionTables. No I/O — session
+// Cost (when both c.diverter and c.sessionImpl are wired): one
+// c.sessionTables entry per unique fully-qualified table name.
+// Repeated Open of the same table hits the cache. No I/O — session
 // pools materialize lazily on first RPC via lazyPool.get(), so
 // SessionPoolImpl count and server-side OpenSession stream count
 // are unchanged.

--- a/bigtable/open.go
+++ b/bigtable/open.go
@@ -48,13 +48,6 @@ func (c *Client) Open(table string) *Table {
 // The classic side is a *tableImpl over a value-copy of t with
 // divertible nil-ed — that break in the loop is what stops
 // tableImpl.Apply/ReadRow from recursing back through the outer gate.
-//
-// Cost (when both c.diverter and c.sessionImpl are wired): one
-// c.sessionTables entry per unique fully-qualified table name.
-// Repeated Open of the same table hits the cache. No I/O — session
-// pools materialize lazily on first RPC via lazyPool.get(), so
-// SessionPoolImpl count and server-side OpenSession stream count
-// are unchanged.
 func (c *Client) buildDivertible(t *Table, openSession func() session.TableAPI) TableAPI {
 	if c.diverter == nil {
 		return nil

--- a/bigtable/open_test.go
+++ b/bigtable/open_test.go
@@ -242,14 +242,20 @@ func (p *panickingTableAPI) ApplyReadModifyWrite(context.Context, string, *ReadM
 // would just be pure indirection since the shim also always delegates
 // them to classic (see TableShim.ReadRows / ApplyBulk / etc).
 //
-// Uses the same panickingTableAPI spy as TestTableImpl_BypassesDivertibleGate:
-// if any of these methods started dispatching to divertible, the spy
-// panics with a distinctive sentinel. Reaching classic (which panics
-// on the nil gRPC conn) is the expected outcome.
+// Fixture matches a realistic session-wired client (session backend +
+// diverter with SessionLoad=1.0), then swaps divertible for the
+// panickingTableAPI spy so we can distinguish gate-dispatch (spy
+// panic) from classic-body execution (nil-conn panic in the classic
+// body). Under the natural configuration where a stray gate would
+// actually route to session, this is where the accident would show.
 func TestOpen_ClassicOnlyMethodsSkipDivertibleGate(t *testing.T) {
+	fsc := newFakeSessionClient()
+	c := newSessionWiredClient(t, fsc)
+	c.diverter.SetSessionLoad(1.0)
+
 	newTable := func() *Table {
 		return &Table{
-			c:          newBareClientForOpenTests(t, 0.0),
+			c:          c,
 			table:      "mytable",
 			divertible: &panickingTableAPI{},
 		}

--- a/bigtable/open_test.go
+++ b/bigtable/open_test.go
@@ -43,12 +43,12 @@ func newBareClientForOpenTests(t *testing.T, sessionLoad float64) *Client {
 	}
 }
 
-// TestOpen_ReturnsBareTable pins the post-Option-B-revert contract:
-// Client.Open returns a plain *Table with no session-routing wrapper.
-// Callers holding *Table (BulkMutation, ReadModifyWrite consumers,
-// external code) stay on the classic path regardless of Client's
-// diverter setting.
-func TestOpen_ReturnsBareTable(t *testing.T) {
+// TestOpen_WiresDivertibleWhenDiverterPresent pins Open's session-
+// routing contract: when c.diverter is set, the returned *Table has
+// divertible populated with a *TableShim, so Apply / ReadRow route
+// through the shim. Backward-compatible: the return type stays
+// *Table and every non-Apply/ReadRow method is untouched.
+func TestOpen_WiresDivertibleWhenDiverterPresent(t *testing.T) {
 	c := newBareClientForOpenTests(t, 0.0)
 
 	tbl := c.Open("mytable")
@@ -67,6 +67,172 @@ func TestOpen_ReturnsBareTable(t *testing.T) {
 	if tbl.materializedView != "" {
 		t.Errorf("Open→Table.materializedView = %q, want empty", tbl.materializedView)
 	}
+	if tbl.divertible == nil {
+		t.Fatal("Open→Table.divertible = nil, want *TableShim (c.diverter is set)")
+	}
+	shim, ok := tbl.divertible.(*TableShim)
+	if !ok {
+		t.Fatalf("Open→Table.divertible = %T, want *TableShim", tbl.divertible)
+	}
+	if shim.diverter != c.diverter {
+		t.Errorf("shim.diverter = %p, want client's diverter %p", shim.diverter, c.diverter)
+	}
+}
+
+// TestOpen_NoDivertibleWhenDiverterAbsent pins the zero-cost classic
+// path: with c.diverter nil, Open must return a *Table with
+// divertible=nil so the Apply / ReadRow gate short-circuits to the
+// *Classic helpers without any shim allocation.
+func TestOpen_NoDivertibleWhenDiverterAbsent(t *testing.T) {
+	c := &Client{
+		project:        "p",
+		instance:       "i",
+		appProfile:     "ap",
+		featureFlagsMD: metadata.MD{},
+		// diverter deliberately unset.
+	}
+	tbl := c.Open("mytable")
+	if tbl.divertible != nil {
+		t.Errorf("Open→Table.divertible = %v, want nil (no diverter → no shim)", tbl.divertible)
+	}
+}
+
+// TestOpen_DivertibleShimBreaksRecursionLoop pins the anti-recursion
+// invariant that makes Table.Apply / Table.ReadRow gate-then-classic
+// pattern safe: the *tableImpl on the shim's classic side wraps a
+// SNAPSHOT of the outer Table with divertible EXPLICITLY nil-ed.
+//
+// Without this break, tableImpl.Apply → Table.Apply would re-enter
+// the gate → shim → tableImpl.Apply → ... forever. The tableImpl
+// override calling applyClassic/readRowClassic directly is the second
+// half of the safety net; this test guards the first half — the
+// value-copy + nil field trick.
+func TestOpen_DivertibleShimBreaksRecursionLoop(t *testing.T) {
+	c := newBareClientForOpenTests(t, 0.0)
+
+	tbl := c.Open("mytable")
+	shim, ok := tbl.divertible.(*TableShim)
+	if !ok {
+		t.Fatalf("divertible = %T, want *TableShim", tbl.divertible)
+	}
+	inner, ok := shim.classic.(*tableImpl)
+	if !ok {
+		t.Fatalf("shim.classic = %T, want *tableImpl", shim.classic)
+	}
+	if inner.table != "mytable" {
+		t.Errorf("inner.table = %q, want %q (snapshot must carry the same table id)", inner.table, "mytable")
+	}
+	if inner.divertible != nil {
+		t.Errorf("inner.divertible = %v, want nil (must be cleared to break the recursion loop)", inner.divertible)
+	}
+}
+
+// TestOpen_ApplyRoutesThroughDivertible drives an end-to-end Apply on
+// the *Table returned by Open with a wired session backend and
+// SessionLoad=1.0. Proves the session path is reached — i.e., the
+// divertible gate fires and the shim dispatches to session, not the
+// classic MutateRow (which would panic here because the client has
+// no gRPC connection).
+func TestOpen_ApplyRoutesThroughDivertible(t *testing.T) {
+	fsc := newFakeSessionClient()
+	c := newSessionWiredClient(t, fsc)
+	c.diverter.SetSessionLoad(1.0)
+
+	tbl := c.Open("mytable")
+	if tbl.divertible == nil {
+		t.Fatal("divertible = nil, want shim (diverter + sessionImpl wired)")
+	}
+
+	mut := NewMutation()
+	mut.Set("cf", "q", 1_000_000, []byte("v"))
+	if err := tbl.Apply(context.Background(), "row-1", mut); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if got := len(fsc.openTableCalls); got != 1 || fsc.openTableCalls[0] != "mytable" {
+		t.Errorf("fake session OpenTable calls = %v, want [mytable]", fsc.openTableCalls)
+	}
+}
+
+// TestOpen_ReadRowRoutesThroughDivertible mirrors the Apply test for
+// the read side. Same setup, same proof — the divertible gate on
+// Table.ReadRow dispatches to the shim's session path.
+func TestOpen_ReadRowRoutesThroughDivertible(t *testing.T) {
+	fsc := newFakeSessionClient()
+	c := newSessionWiredClient(t, fsc)
+	c.diverter.SetSessionLoad(1.0)
+
+	tbl := c.Open("mytable")
+	if _, err := tbl.ReadRow(context.Background(), "row-1"); err != nil {
+		t.Fatalf("ReadRow: %v", err)
+	}
+	if got := len(fsc.openTableCalls); got != 1 || fsc.openTableCalls[0] != "mytable" {
+		t.Errorf("fake session OpenTable calls = %v, want [mytable]", fsc.openTableCalls)
+	}
+}
+
+// TestTableImpl_BypassesDivertibleGate pins the second half of the
+// anti-recursion safety net: even if a tableImpl is somehow given a
+// Table with divertible set (defensive — buildDivertible always nil-s
+// it), the tableImpl.Apply / tableImpl.ReadRow overrides must call
+// the *Classic helpers directly and NOT re-enter the gate.
+//
+// Uses a spy divertible whose methods panic — if the gate fires, the
+// test panics; if the bypass works, the test reaches classic and
+// fails predictably (no gRPC conn → panic in unrelated code); we
+// catch that with recover to distinguish the two failure modes.
+func TestTableImpl_BypassesDivertibleGate(t *testing.T) {
+	spy := &panickingTableAPI{}
+	ti := &tableImpl{Table: Table{
+		c:          newBareClientForOpenTests(t, 0.0),
+		table:      "mytable",
+		divertible: spy, // if the gate fires, spy panics with a distinctive message
+	}}
+
+	// Apply: catch any panic and check it's NOT from the spy.
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				if _, ok := r.(spyPanic); ok {
+					t.Errorf("tableImpl.Apply reached the divertible spy — gate must be bypassed")
+				}
+				// Classic body panicking on missing gRPC conn is expected here.
+			}
+		}()
+		_ = ti.Apply(context.Background(), "row-1", NewMutation())
+	}()
+
+	// ReadRow: same shape.
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				if _, ok := r.(spyPanic); ok {
+					t.Errorf("tableImpl.ReadRow reached the divertible spy — gate must be bypassed")
+				}
+			}
+		}()
+		_, _ = ti.ReadRow(context.Background(), "row-1")
+	}()
+}
+
+type spyPanic struct{}
+
+type panickingTableAPI struct{}
+
+func (p *panickingTableAPI) ReadRow(context.Context, string, ...ReadOption) (Row, error) {
+	panic(spyPanic{})
+}
+func (p *panickingTableAPI) Apply(context.Context, string, *Mutation, ...ApplyOption) error {
+	panic(spyPanic{})
+}
+func (p *panickingTableAPI) ReadRows(context.Context, RowSet, func(Row) bool, ...ReadOption) error {
+	panic(spyPanic{})
+}
+func (p *panickingTableAPI) SampleRowKeys(context.Context) ([]string, error) { panic(spyPanic{}) }
+func (p *panickingTableAPI) ApplyBulk(context.Context, []string, []*Mutation, ...ApplyOption) ([]error, error) {
+	panic(spyPanic{})
+}
+func (p *panickingTableAPI) ApplyReadModifyWrite(context.Context, string, *ReadModifyWrite) (Row, error) {
+	panic(spyPanic{})
 }
 
 // TestOpenTable_ProducesNilSessionShim pins the shim shape returned by

--- a/bigtable/open_test.go
+++ b/bigtable/open_test.go
@@ -235,6 +235,54 @@ func (p *panickingTableAPI) ApplyReadModifyWrite(context.Context, string, *ReadM
 	panic(spyPanic{})
 }
 
+// TestOpen_ClassicOnlyMethodsSkipDivertibleGate pins the invariant
+// that Table methods with no session equivalent (ReadRows, ApplyBulk,
+// SampleRowKeys, ApplyReadModifyWrite) MUST NOT gate on t.divertible.
+// They run the classic body directly — TableShim's own delegation
+// would just be pure indirection since the shim also always delegates
+// them to classic (see TableShim.ReadRows / ApplyBulk / etc).
+//
+// Uses the same panickingTableAPI spy as TestTableImpl_BypassesDivertibleGate:
+// if any of these methods started dispatching to divertible, the spy
+// panics with a distinctive sentinel. Reaching classic (which panics
+// on the nil gRPC conn) is the expected outcome.
+func TestOpen_ClassicOnlyMethodsSkipDivertibleGate(t *testing.T) {
+	newTable := func() *Table {
+		return &Table{
+			c:          newBareClientForOpenTests(t, 0.0),
+			table:      "mytable",
+			divertible: &panickingTableAPI{},
+		}
+	}
+
+	assertNotSpyPanic := func(t *testing.T, method string) {
+		t.Helper()
+		if r := recover(); r != nil {
+			if _, ok := r.(spyPanic); ok {
+				t.Errorf("Table.%s reached divertible spy — this method must NOT gate on divertible", method)
+			}
+			// Any other panic (nil-conn from classic body) is expected.
+		}
+	}
+
+	t.Run("ReadRows", func(t *testing.T) {
+		defer assertNotSpyPanic(t, "ReadRows")
+		_ = newTable().ReadRows(context.Background(), InfiniteRange(""), func(Row) bool { return true })
+	})
+	t.Run("ApplyBulk", func(t *testing.T) {
+		defer assertNotSpyPanic(t, "ApplyBulk")
+		_, _ = newTable().ApplyBulk(context.Background(), []string{"r"}, []*Mutation{NewMutation()})
+	})
+	t.Run("SampleRowKeys", func(t *testing.T) {
+		defer assertNotSpyPanic(t, "SampleRowKeys")
+		_, _ = newTable().SampleRowKeys(context.Background())
+	})
+	t.Run("ApplyReadModifyWrite", func(t *testing.T) {
+		defer assertNotSpyPanic(t, "ApplyReadModifyWrite")
+		_, _ = newTable().ApplyReadModifyWrite(context.Background(), "r", &ReadModifyWrite{})
+	})
+}
+
 // TestOpenTable_ProducesNilSessionShim pins the shim shape returned by
 // OpenTable: a *TableShim whose classic side is a *tableImpl and whose
 // session side is nil (session data path isn't wired here). The

--- a/bigtable/table.go
+++ b/bigtable/table.go
@@ -47,14 +47,38 @@ type Table struct {
 	md               metadata.MD
 	authorizedView   string
 	materializedView string
+
+	// divertible, when non-nil, layers session routing on top of the
+	// classic body for the two methods that have session equivalents
+	// (Apply, ReadRow). Populated by Open when c.diverter != nil so
+	// callers that hold a bare *Table transparently participate in the
+	// session/classic split. Nil for classic-only clients — the gate in
+	// Table.Apply / Table.ReadRow short-circuits to the *Classic helper,
+	// preserving the old fast path.
+	//
+	// The value is a *TableShim whose classic side wraps a *tableImpl
+	// built from a snapshot of this Table with divertible EXPLICITLY
+	// nil-ed. That break in the loop is what prevents infinite
+	// recursion: the shim's classic branch dispatches into tableImpl,
+	// whose Apply/ReadRow overrides land on applyClassic/readRowClassic
+	// directly — not back through the gated Table.Apply/ReadRow.
+	divertible TableAPI
 }
 
 func (ti *tableImpl) ReadRows(ctx context.Context, arg RowSet, f func(Row) bool, opts ...ReadOption) error {
 	return ti.Table.ReadRows(ctx, arg, f, opts...)
 }
 
+// ReadRow bypasses the Table.ReadRow divertible gate — a tableImpl used
+// as the classic side of a TableShim would otherwise recurse back through
+// the gate into the shim itself. See Table.divertible.
+func (ti *tableImpl) ReadRow(ctx context.Context, row string, opts ...ReadOption) (Row, error) {
+	return ti.Table.readRowClassic(ctx, row, opts...)
+}
+
+// Apply bypasses the Table.Apply divertible gate — same reason as ReadRow.
 func (ti *tableImpl) Apply(ctx context.Context, row string, m *Mutation, opts ...ApplyOption) error {
-	return ti.Table.Apply(ctx, row, m, opts...)
+	return ti.Table.applyClassic(ctx, row, m, opts...)
 }
 
 func (ti *tableImpl) ApplyBulk(ctx context.Context, rowKeys []string, muts []*Mutation, opts ...ApplyOption) ([]error, error) {


### PR DESCRIPTION
## Summary

Backward-compatible session-routing wiring on the bare \`*Table\`
surface. When \`c.diverter\` is set, \`Apply\` and \`ReadRow\` on a
\`*Table\` returned by \`Client.Open()\` now route through an internal
\`TableShim\` so calls can be diverted to the session data path under
the diverter's SessionLoad ratio. Return type stays \`*Table\`; every
existing method keeps its signature and behavior.

## Why

Callers that use \`Open()\` (BulkMutation, existing app code that holds
\`*Table\` across many ops) previously never saw session routing —
only \`OpenTable\` did. This closes the gap so the same \`*Table\` works
for both paths.

## Design

- **\`Table.divertible TableAPI\` field.** Nil for classic-only clients
  (no diverter) → gate short-circuits and the classic fast path runs
  unchanged. Populated by \`Open()\` when the client has a diverter.
- **\`Table.Apply\` and \`Table.ReadRow\` gain a one-line gate at the
  top:** if \`t.divertible != nil\`, dispatch there; else fall through
  to the new \`applyClassic\` / \`readRowClassic\` helpers (pre-existing
  bodies extracted verbatim).
- **\`tableImpl.Apply\` and \`tableImpl.ReadRow\` bypass the gate** —
  they call \`applyClassic\` / \`readRowClassic\` directly. Necessary
  because \`tableImpl\` is what \`NewTableShim\` wraps as its classic
  side; without the bypass the shim would recurse into itself.
- **\`Open()\` calls \`c.buildDivertible(t, ...)\`** which returns a
  \`*TableShim\` wrapping a snapshot of \`t\` (with \`divertible\`
  nil-ed). \`buildDivertible\` returns nil when \`c.diverter\` is nil,
  so the zero-cost path stays intact.

## Cardinality

The \`sessionTables\` cache map grows one entry per unique \`Open()\`
call now (previously only per \`OpenTable\`). Cost per entry is
~110 B — a fully-qualified table name string + a \`*SessionTable\`.
**No new sessions or streams open** — sessions still materialize
lazily on first RPC per \`lazyPool.get()\`. See \`buildDivertible\` doc
for the full cardinality analysis (three cardinalities in play, only
one shifts).

## Files

| file | change |
|---|---|
| \`bigtable/open.go\` | \`Open()\` wires \`t.divertible\`; new \`buildDivertible\` helper |
| \`bigtable/table.go\` | \`Table\` gains \`divertible TableAPI\` field; \`tableImpl\` overrides \`Apply\` / \`ReadRow\` to bypass the gate |
| \`bigtable/bigtable.go\` | \`Table.Apply\` / \`Table.ReadRow\` gain a divertible gate; classic bodies extracted into \`applyClassic\` / \`readRowClassic\` |

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`goimports -l\` clean
- [x] full \`go test -race -count=1 -short -timeout=180s ./bigtable/ ./bigtable/internal/session/ ./bigtable/internal/transport/\` green modulo the two pre-existing flakes on \`upstream/main\` (\`TestIntegration_NewClientWithEmulatorHost\` — emulator-host resolver; \`TestSessionTableCache_TTLSweepEvictsIdle\` — passes in isolation)