### PR TITLE
fix(bigtable): session.durations / session.uptime — set explicit histogram bucket boundaries

### DIFF
--- a/bigtable/internal/transport/session_tracer.go
+++ b/bigtable/internal/transport/session_tracer.go
@@ -43,12 +43,17 @@ var (
 	sessionMetricsErr  error
 )
 
-// SessionLifetimeBounds matches java-bigtable's ClientSessionDuration
-// / ClientSessionUptime BUCKETS_MS: {0} + geometric doubling from
-// 1ms to ~17.5min. Sessions live minutes-to-hours; the OTel SDK
-// default explicit-bucket boundaries cap at 10s, so p50/p95/p99 all
-// clip to "10000ms" on the dashboard when session lifetimes exceed
-// 10s. Shared by session.durations and session.uptime.
+// SessionLifetimeBounds is a session-scale bucketing for histograms
+// whose samples span minutes-to-hours (an idle session lives until
+// server-driven scale-down, typically several minutes). The layout is
+// {0} + geometric doubling from 1ms to ~17.5min, matching the
+// cross-language client convention.
+//
+// The OTel SDK default explicit-bucket boundaries cap at 10s, so
+// without an explicit boundary override every session-lifetime sample
+// past 10s falls into the last bucket and p50/p95/p99 all render as
+// "10000ms" on the dashboard. Shared by session.durations and
+// session.uptime.
 var SessionLifetimeBounds = func() []float64 {
 	b := []float64{0}
 	for v := float64(1); v <= 1_200_000; v *= 2 {

--- a/bigtable/internal/transport/session_tracer.go
+++ b/bigtable/internal/transport/session_tracer.go
@@ -43,6 +43,20 @@ var (
 	sessionMetricsErr  error
 )
 
+// SessionLifetimeBounds matches java-bigtable's ClientSessionDuration
+// / ClientSessionUptime BUCKETS_MS: {0} + geometric doubling from
+// 1ms to ~17.5min. Sessions live minutes-to-hours; the OTel SDK
+// default explicit-bucket boundaries cap at 10s, so p50/p95/p99 all
+// clip to "10000ms" on the dashboard when session lifetimes exceed
+// 10s. Shared by session.durations and session.uptime.
+var SessionLifetimeBounds = func() []float64 {
+	b := []float64{0}
+	for v := float64(1); v <= 1_200_000; v *= 2 {
+		b = append(b, v)
+	}
+	return b
+}()
+
 // FineGrainLatencyBounds matches java-bigtable's
 // AGGREGATION_WITH_MILLIS_HISTOGRAM: fine sub-ms + coarse tail. Shared
 // by transport_latencies and attempt_latencies2.
@@ -78,6 +92,7 @@ func InitializeSessionMetrics(meterProvider metric.MeterProvider) error {
 			"session.durations",
 			metric.WithDescription("Duration a session was alive (startTime → close)"),
 			metric.WithUnit("ms"),
+			metric.WithExplicitBucketBoundaries(SessionLifetimeBounds...),
 		); err != nil {
 			sessionMetricsErr = fmt.Errorf("create session.durations histogram: %w", err)
 			return
@@ -86,6 +101,7 @@ func InitializeSessionMetrics(meterProvider metric.MeterProvider) error {
 			"session.open_latencies",
 			metric.WithDescription("Latency to open a session"),
 			metric.WithUnit("ms"),
+			metric.WithExplicitBucketBoundaries(FineGrainLatencyBounds...),
 		); err != nil {
 			sessionMetricsErr = fmt.Errorf("create session.open_latencies histogram: %w", err)
 			return
@@ -94,6 +110,7 @@ func InitializeSessionMetrics(meterProvider metric.MeterProvider) error {
 			"session.uptime",
 			metric.WithDescription("Age of currently-active sessions, sampled periodically"),
 			metric.WithUnit("ms"),
+			metric.WithExplicitBucketBoundaries(SessionLifetimeBounds...),
 		); err != nil {
 			sessionMetricsErr = fmt.Errorf("create session.uptime histogram: %w", err)
 			return

--- a/bigtable/internal/transport/session_tracer.go
+++ b/bigtable/internal/transport/session_tracer.go
@@ -43,7 +43,7 @@ var (
 	sessionMetricsErr  error
 )
 
-// SessionLifetimeBounds is a session-scale bucketing for histograms
+// sessionLifetimeBounds is a session-scale bucketing for histograms
 // whose samples span minutes-to-hours (an idle session lives until
 // server-driven scale-down, typically several minutes). The layout is
 // {0} + geometric doubling from 1ms to ~17.5min, matching the
@@ -54,7 +54,7 @@ var (
 // past 10s falls into the last bucket and p50/p95/p99 all render as
 // "10000ms" on the dashboard. Shared by session.durations and
 // session.uptime.
-var SessionLifetimeBounds = func() []float64 {
+var sessionLifetimeBounds = func() []float64 {
 	b := []float64{0}
 	for v := float64(1); v <= 1_200_000; v *= 2 {
 		b = append(b, v)
@@ -97,7 +97,7 @@ func InitializeSessionMetrics(meterProvider metric.MeterProvider) error {
 			"session.durations",
 			metric.WithDescription("Duration a session was alive (startTime → close)"),
 			metric.WithUnit("ms"),
-			metric.WithExplicitBucketBoundaries(SessionLifetimeBounds...),
+			metric.WithExplicitBucketBoundaries(sessionLifetimeBounds...),
 		); err != nil {
 			sessionMetricsErr = fmt.Errorf("create session.durations histogram: %w", err)
 			return
@@ -115,7 +115,7 @@ func InitializeSessionMetrics(meterProvider metric.MeterProvider) error {
 			"session.uptime",
 			metric.WithDescription("Age of currently-active sessions, sampled periodically"),
 			metric.WithUnit("ms"),
-			metric.WithExplicitBucketBoundaries(SessionLifetimeBounds...),
+			metric.WithExplicitBucketBoundaries(sessionLifetimeBounds...),
 		); err != nil {
 			sessionMetricsErr = fmt.Errorf("create session.uptime histogram: %w", err)
 			return


### PR DESCRIPTION
## Summary

The OTel SDK default explicit-bucket boundaries cap at 10s
(`{0, 5, 10, 25, 50, ..., 5000, 7500, 10000}`). Session lifetimes and
per-session uptimes are minutes-to-hours (an idle session lives until
server-driven scale-down, typically 4+ minutes). Every sample past 10s
lands in the last bucket, so p50/p95/p99 all render as `10000ms` on
Cloud Monitoring dashboards — the metric silently pins.

Same bug applied to `session.durations`, `session.uptime`, and
`session.open_latencies` — all three histograms were registered
without explicit bucket boundaries.

## Fix

Register both hour-scale histograms with explicit boundaries:
`{0}` + geometric doubling from 1ms to ~17.5min. Matches the
cross-language client convention for session-scale buckets.

Introduce `SessionLifetimeBounds` next to the existing
`FineGrainLatencyBounds` so future additions have a clear pick between
"sub-ms latency" (`FineGrain`) and "session-scale lifetime"
(`SessionLifetime`) sets.

`session.open_latencies` gets `FineGrainLatencyBounds` here too — same
clip-at-10s hazard, smaller visible impact since pre-open latency past
10s is uncommon. Included for consistency with the other three session
histograms and with `transport_latencies` (which already had bounds
set).

## Verification

- `go build ./...` + `go vet ./internal/transport/` clean.
- Confirmed against a live sandbox before the fix: sessionz "Session lifetimes" showed `n=74 · p50=4m21s · p95=4m50s · p99=4m54s` (correct, via internal HDR histogram) while the OTel `session.durations` metric reported `p50/p95/p99 = 10000ms` for the same window. After the fix, the OTel metric should display the true percentiles.

## Test plan

- [ ] Verify OTel `session.durations` p50/p95/p99 match sessionz "Session lifetimes" on the same sandbox run
- [ ] `session.uptime` — same check against sessionz's uptime samples
- [ ] Confirm existing `transport_latencies` unaffected (already had explicit bounds; this change doesn't touch that call site)