### PR TITLE
feat(bigtable): add AddChannelPoolConfigListener to ClientConfigurationManager

### DIFF
--- a/bigtable/internal/transport/client_configuration_manager.go
+++ b/bigtable/internal/transport/client_configuration_manager.go
@@ -395,6 +395,44 @@ func (m *ClientConfigurationManager) AddSessionPoolListener(listener func(*bigta
 	})
 }
 
+// AddChannelPoolConfigListener registers a callback that receives the
+// server-driven ChannelPoolConfiguration (min/max server count,
+// per-server session count, mode) on every configuration update from a
+// successful poll — plus an immediate fire at registration with the
+// current config (whatever bootstrapped) so consumers don't need to
+// seed themselves. Returns an unregister thunk.
+//
+// Sibling of AddSessionPoolListener at line 375. Same shape: proto
+// diff filters no-op updates so a listener that only cares about the
+// channel-pool tuple doesn't get spurious wakes from unrelated
+// SessionConfiguration edits.
+//
+// nil ChannelConfiguration on the wire falls back to the default from
+// defaultClientConfig — matches the SessionPool listener's behavior
+// and mirrors the sizer bootstrap in NewSessionPoolImpl.
+func (m *ClientConfigurationManager) AddChannelPoolConfigListener(listener func(*bigtablepb.SessionClientConfiguration_ChannelPoolConfiguration)) func() {
+	var (
+		diffMu  sync.Mutex
+		hasPrev bool
+		prev    *bigtablepb.SessionClientConfiguration_ChannelPoolConfiguration
+	)
+	return m.addListener(func(cfg *bigtablepb.ClientConfiguration, _ int64) {
+		cp := cfg.GetSessionConfiguration().GetChannelConfiguration()
+		if cp == nil {
+			cp = defaultClientConfig.GetSessionConfiguration().GetChannelConfiguration()
+		}
+		diffMu.Lock()
+		if hasPrev && proto.Equal(prev, cp) {
+			diffMu.Unlock()
+			return
+		}
+		hasPrev = true
+		prev = cp
+		diffMu.Unlock()
+		listener(cp)
+	})
+}
+
 // TODO(sushanb): plumb TelemetryConfiguration. The server-side
 // ClientConfiguration proto also carries a TelemetryConfiguration message
 // (see google/bigtable/v2/session.proto) that we currently ignore. Once the

--- a/bigtable/internal/transport/client_configuration_manager_test.go
+++ b/bigtable/internal/transport/client_configuration_manager_test.go
@@ -637,3 +637,90 @@ func TestManagerPoll_StopPollingFlagsCurrentConfig(t *testing.T) {
 // poll() cannot snapshot the listener map while addListener holds the
 // write lock, so the registration fire always lands before any poll
 // fire and listeners observe seq monotonically by construction.
+
+// TestAddChannelPoolConfigListener_FiresOnUpdate exercises the
+// bootstrap-fire + poll-driven-fire path for the channel-pool config
+// listener. Mirrors TestAddSessionPoolListener_SkipsOnUnchangedSlice's
+// shape: two polls whose ChannelPoolConfiguration is byte-identical must
+// only produce one poll-driven delivery, because the per-listener proto
+// diff suppresses the no-op second update.
+func TestAddChannelPoolConfigListener_FiresOnUpdate(t *testing.T) {
+	const (
+		minServers = 4
+		maxServers = 40
+		perServer  = 8
+	)
+	configs := []*bigtablepb.ClientConfiguration{
+		{
+			Polling: &bigtablepb.ClientConfiguration_PollingConfiguration_{
+				PollingConfiguration: &bigtablepb.ClientConfiguration_PollingConfiguration{
+					PollingInterval: durationpb.New(600 * time.Second),
+				},
+			},
+			SessionConfiguration: &bigtablepb.SessionClientConfiguration{
+				ChannelConfiguration: &bigtablepb.SessionClientConfiguration_ChannelPoolConfiguration{
+					MinServerCount:        minServers,
+					MaxServerCount:        maxServers,
+					PerServerSessionCount: perServer,
+				},
+			},
+		},
+		{
+			Polling: &bigtablepb.ClientConfiguration_PollingConfiguration_{
+				PollingConfiguration: &bigtablepb.ClientConfiguration_PollingConfiguration{
+					PollingInterval: durationpb.New(900 * time.Second),
+				},
+			},
+			SessionConfiguration: &bigtablepb.SessionClientConfiguration{
+				ChannelConfiguration: &bigtablepb.SessionClientConfiguration_ChannelPoolConfiguration{
+					MinServerCount:        minServers,
+					MaxServerCount:        maxServers,
+					PerServerSessionCount: perServer, // unchanged — must not fire
+				},
+			},
+		},
+	}
+	var idx int
+	var idxMu sync.Mutex
+	client := &mockBigtableClient{
+		getConfigFunc: func(ctx context.Context, req *bigtablepb.GetClientConfigurationRequest) (*bigtablepb.ClientConfiguration, error) {
+			idxMu.Lock()
+			defer idxMu.Unlock()
+			cfg := configs[idx]
+			if idx+1 < len(configs) {
+				idx++
+			}
+			return cfg, nil
+		},
+	}
+	manager := NewClientConfigurationManager(client, "instance", "profile", nil, nil)
+
+	var mu sync.Mutex
+	var deliveries []*bigtablepb.SessionClientConfiguration_ChannelPoolConfiguration
+	manager.AddChannelPoolConfigListener(func(cp *bigtablepb.SessionClientConfiguration_ChannelPoolConfiguration) {
+		mu.Lock()
+		deliveries = append(deliveries, cp)
+		mu.Unlock()
+	})
+
+	manager.poll(context.Background()) // default -> {4, 40, 8}: fires
+	manager.poll(context.Background()) // {4, 40, 8} -> {4, 40, 8}: must skip
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Expect 2 deliveries: bootstrap (default) + first poll (default ->
+	// {4, 40, 8}). The second poll changes the whole config but not the
+	// channel-pool tuple, so the per-listener diff must suppress that fire.
+	if len(deliveries) != 2 {
+		t.Fatalf("AddChannelPoolConfigListener fired %d times, want 2 (bootstrap + first poll only)", len(deliveries))
+	}
+	if got := deliveries[1].GetMinServerCount(); got != minServers {
+		t.Errorf("post-first-poll MinServerCount = %d, want %d", got, minServers)
+	}
+	if got := deliveries[1].GetMaxServerCount(); got != maxServers {
+		t.Errorf("post-first-poll MaxServerCount = %d, want %d", got, maxServers)
+	}
+	if got := deliveries[1].GetPerServerSessionCount(); got != perServer {
+		t.Errorf("post-first-poll PerServerSessionCount = %d, want %d", got, perServer)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `ClientConfigurationManager.AddChannelPoolConfigListener` —
sibling of the existing `AddSessionPoolListener`. Delivers the
server-driven `ChannelPoolConfiguration` (`MinServerCount` /
`MaxServerCount` / `PerServerSessionCount` / mode) to a registered
callback on every successful poll, plus an immediate fire at
registration so consumers don't need to seed themselves.

Dormant — no consumer wired yet.

## Motivation

Planned follow-up: a `SessionAwareDynamicChannelPool` policy sizes the
gRPC channel pool from live session count using the Java-parity formula
`target = ceil((sessions × 2) / softMax); clamp(min, max)`. `softMax`,
`min`, and `max` come from the `ChannelPoolConfiguration` proto — this
listener is the fanout that lets the policy react to server-driven
config changes without polling the manager itself.

The three fields already exist on
`bigtablepb.SessionClientConfiguration_ChannelPoolConfiguration`
(`session.pb.go:2958`) but nothing consumes them today.

## Design

Byte-for-byte the same shape as `AddSessionPoolListener` at
`client_configuration_manager.go:375`:

- Registers via the private `addListener` core, so it inherits the
  bootstrap fire + monotonic seq guarantees.
- Per-listener `proto.Equal` diff filter suppresses no-op updates so a
  channel-pool-only consumer doesn't get spurious wakes from unrelated
  `SessionPool` edits.
- `nil` `ChannelConfiguration` on the wire falls back to
  `defaultClientConfig`'s value, matching the SessionPool listener's
  null-handling and the `NewSessionPoolImpl` sizer bootstrap.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./internal/transport/` clean.
- [x] New `TestAddChannelPoolConfigListener_FiresOnUpdate` — mirrors
  `TestAddSessionPoolListener_SkipsOnUnchangedSlice`. Two polls with a
  byte-identical `ChannelPoolConfiguration` and only a
  `PollingInterval` change produce one bootstrap + one poll-driven fire
  (no third). Passes under `-race`.
- [x] Existing session-pool + session-load listener tests unaffected.
