### PR TITLE
feat(bigtable): SessionAwareScaleMonitor — size channel pool from live session count

### DIFF
--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -551,38 +551,18 @@ func (sc *sessionClient) OpenMaterializedView(view string) TableAPI {
 // updates. Skipped when the opt-out flag is set or when configManager
 // is nil (test-fake path).
 //
-// The session-count source is sc.totalSessionCount — sums Stats()
-// across every session pool this client currently owns, so the target
-// reflects total load on the shared channel pool.
+// The monitor reads its session-count signal directly from
+// BigtableChannelPool.TotalStreamCount — sessions are bidi streams
+// (one streamingLoad increment on the picked connEntry when they
+// open), so the pool already tracks the number without any
+// cross-package plumbing.
 func (sc *sessionClient) registerScaleMonitor(pool *btransport.BigtableChannelPool) {
 	if sc.cfg.DisableSessionAwareChannelPool || sc.configManager == nil || pool == nil {
 		return
 	}
-	sc.scaleMonitor = btransport.NewSessionAwareScaleMonitor(pool, sc.totalSessionCount)
+	sc.scaleMonitor = btransport.NewSessionAwareScaleMonitor(pool)
 	sc.scaleMonitorUnreg = sc.configManager.AddChannelPoolConfigListener(sc.scaleMonitor.OnConfig)
 	sc.scaleMonitor.Start(sc.cfg.BackgroundCtx)
-}
-
-// totalSessionCount sums Ready + Starting across every session pool
-// this client owns — the input SessionAwareScaleMonitor feeds into the
-// per-server-session-count clamp. Runs from the monitor's tick
-// goroutine only.
-func (sc *sessionClient) totalSessionCount() int {
-	sc.sessionPoolsMu.Lock()
-	pools := make([]*managedSessionPool, 0, len(sc.sessionPools))
-	for _, mp := range sc.sessionPools {
-		pools = append(pools, mp)
-	}
-	sc.sessionPoolsMu.Unlock()
-	total := 0
-	for _, mp := range pools {
-		if mp == nil || mp.pool == nil {
-			continue
-		}
-		s := mp.pool.Stats()
-		total += s.ReadyCount + s.StartingCount
-	}
-	return total
 }
 
 // Close tears down in a phased order that keeps late callbacks from

--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -124,6 +124,17 @@ type Config struct {
 	// off. The debug surface is otherwise unchanged; flipping the
 	// flag on or off requires rebuilding the client.
 	EnableDebug bool
+
+	// DisableSessionAwareChannelPool reverts to the classic RPC-load-
+	// driven DynamicScaleMonitor for channel-pool sizing. Default
+	// (false) is the recommended production behavior: session-count-
+	// driven sizing keeps per-channel session load under the server-
+	// specified soft cap (ChannelPoolConfiguration.PerServerSessionCount).
+	//
+	// Escape hatch — flip on if a deployment sees pathological churn
+	// under the session-aware policy and needs the classic behavior
+	// while root-cause is investigated.
+	DisableSessionAwareChannelPool bool
 }
 
 // managedSessionPool bundles a pool with its config-listener unregister
@@ -237,6 +248,15 @@ type sessionClient struct {
 	// managed.Pool == nil, so Close falls back to sc.channelPool.Close().
 	managedChannelPool btransport.ManagedChannelPool
 
+	// scaleMonitor sizes the shared channel pool from live session count
+	// instead of RPC load. Populated by NewClient when
+	// Config.DisableSessionAwareChannelPool is false (default). Nil on
+	// the test-only newSessionClientFromParts path and when the opt-out
+	// flag is set. Close() stops it before managed.Close so no scale
+	// tick races against pool teardown.
+	scaleMonitor       *btransport.SessionAwareScaleMonitor
+	scaleMonitorUnreg  func()
+
 	// enableDebug mirrors Config.EnableDebug. When false, pools this
 	// client mints short-circuit every allocating debug recorder and
 	// SessionDebug() returns nil so /debug/ renders a "not enabled"
@@ -340,11 +360,17 @@ func NewClient(
 	if err != nil {
 		return nil, fmt.Errorf("session.NewClient: NewBigtableChannelPool: %w", err)
 	}
-	dsm := btransport.NewDynamicScaleMonitor(btopt.DefaultDynamicChannelPoolConfig(), pool)
-	dsm.Start(ctx)
+	// DynamicScaleMonitor is skipped in favor of SessionAwareScaleMonitor
+	// (registered after sc.configManager exists — see below). The two
+	// policies can't share a pool: both would fight to add/remove
+	// connections on independent signals. Session-aware is the more
+	// informed signal for the session data plane; RPC-load stays
+	// available on the classic path (bigtable/internal/transport/
+	// channel_pool_factory.go). ManagedChannelPool.Close is nil-safe on
+	// Dsm so passing nil here doesn't break the teardown chain.
 	connRecycler := btransport.NewConnectionRecycler(btopt.DefaultConnectionRecycleConfig(), pool)
 	connRecycler.Start(ctx)
-	managed := btransport.NewManagedChannelPool(pool, dsm, connRecycler)
+	managed := btransport.NewManagedChannelPool(pool, nil, connRecycler)
 	stub := btpb.NewBigtableClient(pool)
 
 	backgroundCtx, cancel := context.WithCancel(context.Background())
@@ -366,6 +392,10 @@ func NewClient(
 	})
 	sc.backgroundCancel = cancel
 	sc.managedChannelPool = managed
+	// SessionAwareScaleMonitor is only meaningful once sc.configManager
+	// exists — newSessionClientFromParts constructs it inline. Register
+	// after that call so the config listener has something to hook.
+	sc.registerScaleMonitor(pool)
 	return sc, nil
 }
 
@@ -515,6 +545,46 @@ func (sc *sessionClient) OpenMaterializedView(view string) TableAPI {
 	return newSessionTable("", openRead, nil, closeRead, nil, btransport.READ_ROW_MAT_VIEW, nil, sc.perResourceMetadata(fullName, "materialized_view_name", fullName), sc.metricsFactory)
 }
 
+// registerScaleMonitor wires SessionAwareScaleMonitor to the shared
+// channel pool, hooking its OnConfig into ClientConfigurationManager
+// so the sizer reacts to server-driven min/max/perServerSessionCount
+// updates. Skipped when the opt-out flag is set or when configManager
+// is nil (test-fake path).
+//
+// The session-count source is sc.totalSessionCount — sums Stats()
+// across every session pool this client currently owns, so the target
+// reflects total load on the shared channel pool.
+func (sc *sessionClient) registerScaleMonitor(pool *btransport.BigtableChannelPool) {
+	if sc.cfg.DisableSessionAwareChannelPool || sc.configManager == nil || pool == nil {
+		return
+	}
+	sc.scaleMonitor = btransport.NewSessionAwareScaleMonitor(pool, sc.totalSessionCount)
+	sc.scaleMonitorUnreg = sc.configManager.AddChannelPoolConfigListener(sc.scaleMonitor.OnConfig)
+	sc.scaleMonitor.Start(sc.cfg.BackgroundCtx)
+}
+
+// totalSessionCount sums Ready + Starting across every session pool
+// this client owns — the input SessionAwareScaleMonitor feeds into the
+// per-server-session-count clamp. Runs from the monitor's tick
+// goroutine only.
+func (sc *sessionClient) totalSessionCount() int {
+	sc.sessionPoolsMu.Lock()
+	pools := make([]*managedSessionPool, 0, len(sc.sessionPools))
+	for _, mp := range sc.sessionPools {
+		pools = append(pools, mp)
+	}
+	sc.sessionPoolsMu.Unlock()
+	total := 0
+	for _, mp := range pools {
+		if mp == nil || mp.pool == nil {
+			continue
+		}
+		s := mp.pool.Stats()
+		total += s.ReadyCount + s.StartingCount
+	}
+	return total
+}
+
 // Close tears down in a phased order that keeps late callbacks from
 // firing against half-dead pools:
 //  1. Stop config polling — no more UpdateConfig can fire after.
@@ -542,8 +612,20 @@ func (sc *sessionClient) Close() error {
 	managed := sc.managedChannelPool
 	factory := sc.metricsFactory
 	cancel := sc.backgroundCancel
+	sam := sc.scaleMonitor
+	samUnreg := sc.scaleMonitorUnreg
 	sc.sessionPoolsMu.Unlock()
 
+	// Stop the scale monitor BEFORE mgr.Close so a mid-tick reconcile
+	// can't fire an addConnections into a channel pool that Phase 4
+	// is about to tear down. Order: unregister listener → Stop the
+	// monitor's goroutine → then unwind everything else.
+	if samUnreg != nil {
+		samUnreg()
+	}
+	if sam != nil {
+		sam.Stop()
+	}
 	if mgr != nil {
 		mgr.Close()
 	}

--- a/bigtable/internal/transport/client_configuration_manager.go
+++ b/bigtable/internal/transport/client_configuration_manager.go
@@ -395,6 +395,44 @@ func (m *ClientConfigurationManager) AddSessionPoolListener(listener func(*bigta
 	})
 }
 
+// AddChannelPoolConfigListener registers a callback that receives the
+// server-driven ChannelPoolConfiguration (min/max server count,
+// per-server session count, mode) on every configuration update from a
+// successful poll — plus an immediate fire at registration with the
+// current config (whatever bootstrapped) so consumers don't need to
+// seed themselves. Returns an unregister thunk.
+//
+// Sibling of AddSessionPoolListener at line 375. Same shape: proto
+// diff filters no-op updates so a listener that only cares about the
+// channel-pool tuple doesn't get spurious wakes from unrelated
+// SessionConfiguration edits.
+//
+// nil ChannelConfiguration on the wire falls back to the default from
+// defaultClientConfig — matches the SessionPool listener's behavior
+// and mirrors the sizer bootstrap in NewSessionPoolImpl.
+func (m *ClientConfigurationManager) AddChannelPoolConfigListener(listener func(*bigtablepb.SessionClientConfiguration_ChannelPoolConfiguration)) func() {
+	var (
+		diffMu  sync.Mutex
+		hasPrev bool
+		prev    *bigtablepb.SessionClientConfiguration_ChannelPoolConfiguration
+	)
+	return m.addListener(func(cfg *bigtablepb.ClientConfiguration, _ int64) {
+		cp := cfg.GetSessionConfiguration().GetChannelConfiguration()
+		if cp == nil {
+			cp = defaultClientConfig.GetSessionConfiguration().GetChannelConfiguration()
+		}
+		diffMu.Lock()
+		if hasPrev && proto.Equal(prev, cp) {
+			diffMu.Unlock()
+			return
+		}
+		hasPrev = true
+		prev = cp
+		diffMu.Unlock()
+		listener(cp)
+	})
+}
+
 // TODO(sushanb): plumb TelemetryConfiguration. The server-side
 // ClientConfiguration proto also carries a TelemetryConfiguration message
 // (see google/bigtable/v2/session.proto) that we currently ignore. Once the

--- a/bigtable/internal/transport/client_configuration_manager_test.go
+++ b/bigtable/internal/transport/client_configuration_manager_test.go
@@ -637,3 +637,90 @@ func TestManagerPoll_StopPollingFlagsCurrentConfig(t *testing.T) {
 // poll() cannot snapshot the listener map while addListener holds the
 // write lock, so the registration fire always lands before any poll
 // fire and listeners observe seq monotonically by construction.
+
+// TestAddChannelPoolConfigListener_FiresOnUpdate exercises the
+// bootstrap-fire + poll-driven-fire path for the channel-pool config
+// listener. Mirrors TestAddSessionPoolListener_SkipsOnUnchangedSlice's
+// shape: two polls whose ChannelPoolConfiguration is byte-identical must
+// only produce one poll-driven delivery, because the per-listener proto
+// diff suppresses the no-op second update.
+func TestAddChannelPoolConfigListener_FiresOnUpdate(t *testing.T) {
+	const (
+		minServers = 4
+		maxServers = 40
+		perServer  = 8
+	)
+	configs := []*bigtablepb.ClientConfiguration{
+		{
+			Polling: &bigtablepb.ClientConfiguration_PollingConfiguration_{
+				PollingConfiguration: &bigtablepb.ClientConfiguration_PollingConfiguration{
+					PollingInterval: durationpb.New(600 * time.Second),
+				},
+			},
+			SessionConfiguration: &bigtablepb.SessionClientConfiguration{
+				ChannelConfiguration: &bigtablepb.SessionClientConfiguration_ChannelPoolConfiguration{
+					MinServerCount:        minServers,
+					MaxServerCount:        maxServers,
+					PerServerSessionCount: perServer,
+				},
+			},
+		},
+		{
+			Polling: &bigtablepb.ClientConfiguration_PollingConfiguration_{
+				PollingConfiguration: &bigtablepb.ClientConfiguration_PollingConfiguration{
+					PollingInterval: durationpb.New(900 * time.Second),
+				},
+			},
+			SessionConfiguration: &bigtablepb.SessionClientConfiguration{
+				ChannelConfiguration: &bigtablepb.SessionClientConfiguration_ChannelPoolConfiguration{
+					MinServerCount:        minServers,
+					MaxServerCount:        maxServers,
+					PerServerSessionCount: perServer, // unchanged — must not fire
+				},
+			},
+		},
+	}
+	var idx int
+	var idxMu sync.Mutex
+	client := &mockBigtableClient{
+		getConfigFunc: func(ctx context.Context, req *bigtablepb.GetClientConfigurationRequest) (*bigtablepb.ClientConfiguration, error) {
+			idxMu.Lock()
+			defer idxMu.Unlock()
+			cfg := configs[idx]
+			if idx+1 < len(configs) {
+				idx++
+			}
+			return cfg, nil
+		},
+	}
+	manager := NewClientConfigurationManager(client, "instance", "profile", nil, nil)
+
+	var mu sync.Mutex
+	var deliveries []*bigtablepb.SessionClientConfiguration_ChannelPoolConfiguration
+	manager.AddChannelPoolConfigListener(func(cp *bigtablepb.SessionClientConfiguration_ChannelPoolConfiguration) {
+		mu.Lock()
+		deliveries = append(deliveries, cp)
+		mu.Unlock()
+	})
+
+	manager.poll(context.Background()) // default -> {4, 40, 8}: fires
+	manager.poll(context.Background()) // {4, 40, 8} -> {4, 40, 8}: must skip
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Expect 2 deliveries: bootstrap (default) + first poll (default ->
+	// {4, 40, 8}). The second poll changes the whole config but not the
+	// channel-pool tuple, so the per-listener diff must suppress that fire.
+	if len(deliveries) != 2 {
+		t.Fatalf("AddChannelPoolConfigListener fired %d times, want 2 (bootstrap + first poll only)", len(deliveries))
+	}
+	if got := deliveries[1].GetMinServerCount(); got != minServers {
+		t.Errorf("post-first-poll MinServerCount = %d, want %d", got, minServers)
+	}
+	if got := deliveries[1].GetMaxServerCount(); got != maxServers {
+		t.Errorf("post-first-poll MaxServerCount = %d, want %d", got, maxServers)
+	}
+	if got := deliveries[1].GetPerServerSessionCount(); got != perServer {
+		t.Errorf("post-first-poll PerServerSessionCount = %d, want %d", got, perServer)
+	}
+}

--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -660,6 +660,22 @@ func (p *BigtableChannelPool) Num() int {
 	return len(p.getConns())
 }
 
+// TotalStreamCount returns the total number of in-flight streaming RPCs
+// across every channel in the pool — the sum of each connEntry's
+// streamingLoad. Sessions are bidi streams (one streaming RPC per open
+// session), so on session-mode traffic this equals the total session
+// count riding on the pool. SessionAwareScaleMonitor uses this as its
+// input signal, avoiding the need to reach across the session pool
+// boundary to sum per-resource session counts.
+func (p *BigtableChannelPool) TotalStreamCount() int {
+	conns := p.getConns()
+	total := int32(0)
+	for _, entry := range conns {
+		total += entry.streamingLoad.Load()
+	}
+	return int(total)
+}
+
 // Close closes all connections in the pool.
 func (p *BigtableChannelPool) Close() error {
 	p.poolCancel() // Cancel the context for background tasks

--- a/bigtable/internal/transport/session_aware_scale_monitor.go
+++ b/bigtable/internal/transport/session_aware_scale_monitor.go
@@ -1,0 +1,211 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+)
+
+// SessionAwareHeadroom is the multiplier applied to per-channel session
+// capacity when picking the target channel count. Sessions are
+// long-lived bidi streams pinned to one channel — an AFE-side hiccup
+// affects every session on that channel, so oversizing the pool is
+// the correct safety-margin tradeoff. Kept as a named const rather
+// than an inline literal so the intent shows up at every callsite.
+const SessionAwareHeadroom = 2
+
+// SessionAwareTickInterval is the default cadence for target
+// recomputation. Sessions live minutes-to-hours; picking a shorter
+// interval only adds jitter, not signal. Exposed as a package-level
+// var (not const) so tests can override it — the timer runs off the
+// value at Start time.
+var SessionAwareTickInterval = 1 * time.Minute
+
+// SessionAwareScaleMonitor sizes a BigtableChannelPool from live
+// session count instead of RPC load. Complements (and, in the session
+// client, replaces) DynamicScaleMonitor. On each tick:
+//
+//   1. Read sessionCountFn() — the caller's summary of live sessions
+//      across every session pool sharing this channel pool.
+//   2. Read the latest ChannelPoolConfiguration snapshot fed via
+//      OnConfig (min/max/perServerSessionCount).
+//   3. Compute target = ceil((sessions × SessionAwareHeadroom) /
+//      perServerSessionCount), clamped to [min, max].
+//   4. Call pool.addConnections / removeConnections to reach target.
+//
+// Threading model:
+//   - OnConfig races with the tick — snapshot is stored atomically.
+//   - sessionCountFn is called from the tick goroutine only, so it
+//     doesn't need to be reentrant-safe.
+//   - Start / Stop are once-only; Stop blocks on the goroutine exit
+//     via the done channel so callers can rely on "no more mutations
+//     after Stop returns".
+//
+// Not thread-safe for concurrent Start / Stop — production callers
+// invoke each once from client construction / Close.
+type SessionAwareScaleMonitor struct {
+	pool            *BigtableChannelPool
+	sessionCountFn  func() int
+	config          atomic.Pointer[channelPoolConfigSnapshot]
+	tickInterval    time.Duration
+	cancel          context.CancelFunc
+	done            chan struct{}
+	// tickHook, when non-nil, replaces the ticker-driven loop with a
+	// manual-drive contract: tests call m.TickForTest() to invoke tick()
+	// once. Kept optional so production wiring stays timer-based.
+	tickHookEnabled bool
+}
+
+// channelPoolConfigSnapshot is the immutable triple loaded on every
+// tick. Kept together in a pointer so the tick reads the tuple
+// atomically — otherwise a config update mid-formula could feed a
+// half-old / half-new (min, max, softMax) into clamp and produce a
+// nonsense target.
+type channelPoolConfigSnapshot struct {
+	min, max, softMax int
+}
+
+// NewSessionAwareScaleMonitor constructs a monitor bound to pool.
+// sessionCountFn must return the current total session count across
+// every session pool that shares pool. Called from the tick goroutine
+// only.
+func NewSessionAwareScaleMonitor(pool *BigtableChannelPool, sessionCountFn func() int) *SessionAwareScaleMonitor {
+	return &SessionAwareScaleMonitor{
+		pool:           pool,
+		sessionCountFn: sessionCountFn,
+		tickInterval:   SessionAwareTickInterval,
+		done:           make(chan struct{}),
+	}
+}
+
+// OnConfig accepts a ChannelPoolConfiguration update — designed as
+// the callback registered with ClientConfigurationManager.
+// AddChannelPoolConfigListener. nil config is ignored. Non-positive
+// bounds fall through to the tick, which sees softMax<=0 and no-ops.
+func (m *SessionAwareScaleMonitor) OnConfig(cfg *spb.SessionClientConfiguration_ChannelPoolConfiguration) {
+	if cfg == nil {
+		return
+	}
+	m.config.Store(&channelPoolConfigSnapshot{
+		min:     int(cfg.GetMinServerCount()),
+		max:     int(cfg.GetMaxServerCount()),
+		softMax: int(cfg.GetPerServerSessionCount()),
+	})
+}
+
+// Start begins the tick loop under ctx. The goroutine exits when ctx
+// is cancelled or Stop is called (both routes close the done channel).
+// Safe to call at most once per monitor instance.
+func (m *SessionAwareScaleMonitor) Start(ctx context.Context) {
+	loopCtx, cancel := context.WithCancel(ctx)
+	m.cancel = cancel
+	if m.tickHookEnabled {
+		// Test mode: no timer, tests drive tick via TickForTest.
+		// Still spawn a small goroutine so Stop / cancel semantics stay
+		// uniform with the production path.
+		go func() {
+			<-loopCtx.Done()
+			close(m.done)
+		}()
+		return
+	}
+	go m.loop(loopCtx)
+}
+
+// Stop cancels the tick goroutine and blocks until it returns. Safe to
+// call more than once (subsequent calls are no-ops once cancel/done
+// have fired).
+func (m *SessionAwareScaleMonitor) Stop() {
+	if m.cancel != nil {
+		m.cancel()
+	}
+	<-m.done
+}
+
+// TickForTest runs one tick synchronously. Only meaningful for
+// instances constructed via NewSessionAwareScaleMonitorForTest — the
+// production Start path drives ticks off a timer.
+func (m *SessionAwareScaleMonitor) TickForTest() {
+	m.tick()
+}
+
+// NewSessionAwareScaleMonitorForTest is the test-only constructor that
+// disables the internal timer so tests can call TickForTest to drive
+// the loop deterministically. Production code should always use
+// NewSessionAwareScaleMonitor.
+func NewSessionAwareScaleMonitorForTest(pool *BigtableChannelPool, sessionCountFn func() int) *SessionAwareScaleMonitor {
+	m := NewSessionAwareScaleMonitor(pool, sessionCountFn)
+	m.tickHookEnabled = true
+	return m
+}
+
+// ComputeTarget is the pure sizing function extracted so tests can
+// assert the formula in isolation without wiring a real pool. Public
+// so external harnesses (e.g. simulators) can call it with the same
+// inputs the production monitor sees.
+//
+// target = ceil((sessions × SessionAwareHeadroom) / softMax)
+// target = clamp(target, min, max)
+//
+// softMax <= 0 returns 0 — signals "config not usable yet".
+func ComputeTarget(sessions, softMax, min, max int) int {
+	if softMax <= 0 {
+		return 0
+	}
+	target := (sessions*SessionAwareHeadroom + softMax - 1) / softMax
+	if target > max {
+		target = max
+	}
+	if target < min {
+		target = min
+	}
+	return target
+}
+
+func (m *SessionAwareScaleMonitor) loop(ctx context.Context) {
+	defer close(m.done)
+	ticker := time.NewTicker(m.tickInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.tick()
+		}
+	}
+}
+
+func (m *SessionAwareScaleMonitor) tick() {
+	cfg := m.config.Load()
+	if cfg == nil {
+		return // Config listener hasn't fired yet.
+	}
+	target := ComputeTarget(m.sessionCountFn(), cfg.softMax, cfg.min, cfg.max)
+	if target <= 0 {
+		return
+	}
+	have := m.pool.Num()
+	switch {
+	case target > have:
+		m.pool.addConnections(target-have, cfg.max)
+	case target < have:
+		m.pool.removeConnections(have-target, cfg.min, have-target)
+	}
+}

--- a/bigtable/internal/transport/session_aware_scale_monitor.go
+++ b/bigtable/internal/transport/session_aware_scale_monitor.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	btopt "cloud.google.com/go/bigtable/internal/option"
 )
 
 // SessionAwareHeadroom is the multiplier applied to per-channel session
@@ -38,11 +39,13 @@ const SessionAwareHeadroom = 2
 var SessionAwareTickInterval = 1 * time.Minute
 
 // SessionAwareScaleMonitor sizes a BigtableChannelPool from live
-// session count instead of RPC load. Complements (and, in the session
-// client, replaces) DynamicScaleMonitor. On each tick:
+// streaming-RPC count instead of RPC load. Complements (and, in the
+// session client, replaces) DynamicScaleMonitor. On each tick:
 //
-//   1. Read sessionCountFn() — the caller's summary of live sessions
-//      across every session pool sharing this channel pool.
+//   1. Read pool.TotalStreamCount() — sum of streamingLoad across
+//      every connEntry. Sessions are bidi streams (one streaming RPC
+//      per open session), so this equals the total session count
+//      riding on the pool without any cross-package plumbing.
 //   2. Read the latest ChannelPoolConfiguration snapshot fed via
 //      OnConfig (min/max/perServerSessionCount).
 //   3. Compute target = ceil((sessions × SessionAwareHeadroom) /
@@ -51,8 +54,7 @@ var SessionAwareTickInterval = 1 * time.Minute
 //
 // Threading model:
 //   - OnConfig races with the tick — snapshot is stored atomically.
-//   - sessionCountFn is called from the tick goroutine only, so it
-//     doesn't need to be reentrant-safe.
+//   - pool.TotalStreamCount is called from the tick goroutine only.
 //   - Start / Stop are once-only; Stop blocks on the goroutine exit
 //     via the done channel so callers can rely on "no more mutations
 //     after Stop returns".
@@ -60,12 +62,11 @@ var SessionAwareTickInterval = 1 * time.Minute
 // Not thread-safe for concurrent Start / Stop — production callers
 // invoke each once from client construction / Close.
 type SessionAwareScaleMonitor struct {
-	pool            *BigtableChannelPool
-	sessionCountFn  func() int
-	config          atomic.Pointer[channelPoolConfigSnapshot]
-	tickInterval    time.Duration
-	cancel          context.CancelFunc
-	done            chan struct{}
+	pool         *BigtableChannelPool
+	config       atomic.Pointer[channelPoolConfigSnapshot]
+	tickInterval time.Duration
+	cancel       context.CancelFunc
+	done         chan struct{}
 	// tickHook, when non-nil, replaces the ticker-driven loop with a
 	// manual-drive contract: tests call m.TickForTest() to invoke tick()
 	// once. Kept optional so production wiring stays timer-based.
@@ -82,15 +83,15 @@ type channelPoolConfigSnapshot struct {
 }
 
 // NewSessionAwareScaleMonitor constructs a monitor bound to pool.
-// sessionCountFn must return the current total session count across
-// every session pool that shares pool. Called from the tick goroutine
-// only.
-func NewSessionAwareScaleMonitor(pool *BigtableChannelPool, sessionCountFn func() int) *SessionAwareScaleMonitor {
+// Reads pool.TotalStreamCount() on every tick — no cross-package
+// closure needed because sessions register as streaming RPCs on the
+// pool naturally when they open (bidi stream = one streamingLoad
+// increment on the picked connEntry).
+func NewSessionAwareScaleMonitor(pool *BigtableChannelPool) *SessionAwareScaleMonitor {
 	return &SessionAwareScaleMonitor{
-		pool:           pool,
-		sessionCountFn: sessionCountFn,
-		tickInterval:   SessionAwareTickInterval,
-		done:           make(chan struct{}),
+		pool:         pool,
+		tickInterval: SessionAwareTickInterval,
+		done:         make(chan struct{}),
 	}
 }
 
@@ -149,8 +150,8 @@ func (m *SessionAwareScaleMonitor) TickForTest() {
 // disables the internal timer so tests can call TickForTest to drive
 // the loop deterministically. Production code should always use
 // NewSessionAwareScaleMonitor.
-func NewSessionAwareScaleMonitorForTest(pool *BigtableChannelPool, sessionCountFn func() int) *SessionAwareScaleMonitor {
-	m := NewSessionAwareScaleMonitor(pool, sessionCountFn)
+func NewSessionAwareScaleMonitorForTest(pool *BigtableChannelPool) *SessionAwareScaleMonitor {
+	m := NewSessionAwareScaleMonitor(pool)
 	m.tickHookEnabled = true
 	return m
 }
@@ -195,13 +196,26 @@ func (m *SessionAwareScaleMonitor) loop(ctx context.Context) {
 func (m *SessionAwareScaleMonitor) tick() {
 	cfg := m.config.Load()
 	if cfg == nil {
-		return // Config listener hasn't fired yet.
+		btopt.Debugf(nil, "bigtable_connpool: SessionAwareScaleMonitor tick: no config yet, skip\n")
+		return
 	}
-	target := ComputeTarget(m.sessionCountFn(), cfg.softMax, cfg.min, cfg.max)
+	sessions := m.pool.TotalStreamCount()
+	target := ComputeTarget(sessions, cfg.softMax, cfg.min, cfg.max)
+	have := m.pool.Num()
+	// One line per tick: inputs + decision. Operators tailing the debug
+	// log see the sizer's reasoning without a separate metric.
+	action := "no-op"
+	switch {
+	case target > have:
+		action = "grow"
+	case target < have:
+		action = "shrink"
+	}
+	btopt.Debugf(nil, "bigtable_connpool: SessionAwareScaleMonitor tick: streams=%d softMax=%d min=%d max=%d target=%d have=%d action=%s\n",
+		sessions, cfg.softMax, cfg.min, cfg.max, target, have, action)
 	if target <= 0 {
 		return
 	}
-	have := m.pool.Num()
 	switch {
 	case target > have:
 		m.pool.addConnections(target-have, cfg.max)

--- a/bigtable/internal/transport/session_aware_scale_monitor_test.go
+++ b/bigtable/internal/transport/session_aware_scale_monitor_test.go
@@ -172,7 +172,7 @@ func TestSessionAwareScaleMonitor_ConfigUpdateResizes(t *testing.T) {
 // every field. Runs against a real monitor instance so any drift in
 // the OnConfig↔tick contract is caught.
 func TestSessionAwareScaleMonitor_OnConfigStoresSnapshot(t *testing.T) {
-	m := NewSessionAwareScaleMonitor(nil, func() int { return 0 })
+	m := NewSessionAwareScaleMonitor(nil)
 
 	// Nil config is ignored — no snapshot stored, no panic.
 	m.OnConfig(nil)
@@ -207,7 +207,7 @@ func TestSessionAwareScaleMonitor_StartStopExitsCleanly(t *testing.T) {
 	SessionAwareTickInterval = 10 * time.Millisecond
 	t.Cleanup(func() { SessionAwareTickInterval = prevInterval })
 
-	m := NewSessionAwareScaleMonitor(nil, func() int { return 0 })
+	m := NewSessionAwareScaleMonitor(nil)
 	// No config set — tick short-circuits, so a nil pool is safe.
 	m.Start(context.Background())
 
@@ -234,19 +234,15 @@ func TestSessionAwareScaleMonitor_StartStopExitsCleanly(t *testing.T) {
 // TestSessionAwareScaleMonitor_TickForTest_NoConfigIsNoOp asserts the
 // tick short-circuits before touching the pool when no config has been
 // received. Uses the test-only constructor so the ticker is disabled
-// and we can drive tick manually.
+// and we can drive tick manually. A nil pool must be safe here —
+// tick() returns before calling pool.TotalStreamCount, so no panic.
 func TestSessionAwareScaleMonitor_TickForTest_NoConfigIsNoOp(t *testing.T) {
-	called := false
-	m := NewSessionAwareScaleMonitorForTest(nil, func() int {
-		called = true
-		return 0
-	})
+	m := NewSessionAwareScaleMonitorForTest(nil)
 	m.Start(context.Background())
 	defer m.Stop()
 
+	// If tick didn't short-circuit on nil config, this would panic on
+	// pool.TotalStreamCount(). The test passing means short-circuit
+	// works.
 	m.TickForTest()
-
-	if called {
-		t.Error("sessionCountFn called before OnConfig — tick should short-circuit")
-	}
 }

--- a/bigtable/internal/transport/session_aware_scale_monitor_test.go
+++ b/bigtable/internal/transport/session_aware_scale_monitor_test.go
@@ -1,0 +1,252 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+)
+
+// TestComputeTarget_FormulaAndClamps exercises the pure sizing function
+// across the corner cases the monitor relies on: cold-start (0 sessions
+// → min), typical scale-up (crosses softMax boundary), overflow clamp
+// (target > max), and softMax<=0 (config not usable).
+func TestComputeTarget_FormulaAndClamps(t *testing.T) {
+	cases := []struct {
+		name                   string
+		sessions               int
+		softMax, min, max      int
+		want                   int
+	}{
+		{"cold-start-min", 0, 4, 2, 8, 2},
+		{"one-session-min", 1, 4, 2, 8, 2},
+		{"headroom-boundary", 4, 4, 2, 8, 2},
+		{"crosses-softmax", 8, 4, 2, 8, 4},
+		{"grows-to-mid", 12, 4, 2, 8, 6},
+		{"clamps-at-max", 32, 4, 2, 8, 8},
+		{"clamps-at-max-way-over", 1000, 4, 2, 8, 8},
+		{"softmax-zero-returns-zero", 100, 0, 2, 8, 0},
+		{"softmax-negative-returns-zero", 100, -1, 2, 8, 0},
+		{"softmax-one-headroom-scales", 3, 1, 1, 10, 6},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ComputeTarget(tc.sessions, tc.softMax, tc.min, tc.max)
+			if got != tc.want {
+				t.Errorf("ComputeTarget(sessions=%d, softMax=%d, min=%d, max=%d) = %d, want %d",
+					tc.sessions, tc.softMax, tc.min, tc.max, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestComputeTarget_HeadroomMatchesConstant guards against a silent
+// change to SessionAwareHeadroom — the sizing behavior is documented
+// as HEADROOM=2 across languages, so any bump needs to be intentional
+// (and this test forces it into the PR).
+func TestComputeTarget_HeadroomMatchesConstant(t *testing.T) {
+	if got := SessionAwareHeadroom; got != 2 {
+		t.Errorf("SessionAwareHeadroom = %d, want 2 (cross-language contract)", got)
+	}
+}
+
+// fakeScaleTarget captures addConnections / removeConnections calls in
+// place of a real BigtableChannelPool. The monitor's real methods take
+// a *BigtableChannelPool so we can't hand it a fake directly — instead
+// the tick-level integration tests below run against
+// scaleDecisionRecorder which mirrors the monitor's tick() logic
+// without the pool dependency, letting us assert the decisions the
+// monitor would take.
+
+// scaleDecisionRecorder is a stand-in for the pool's mutation side.
+// It exposes the same "have vs target → grow/shrink delta" contract
+// the monitor drives, but records the decision instead of dialing.
+type scaleDecisionRecorder struct {
+	have     atomic.Int32
+	adds     atomic.Int32
+	removes  atomic.Int32
+	lastAdd  atomic.Int32
+	lastRem  atomic.Int32
+}
+
+// reconcile mirrors SessionAwareScaleMonitor.tick's grow/shrink branch
+// so we can assert what the monitor would drive without wiring a
+// real pool. Reads ComputeTarget for the pure formula.
+func (r *scaleDecisionRecorder) reconcile(sessions, softMax, min, max int) {
+	target := ComputeTarget(sessions, softMax, min, max)
+	if target <= 0 {
+		return
+	}
+	have := int(r.have.Load())
+	switch {
+	case target > have:
+		delta := target - have
+		r.adds.Add(1)
+		r.lastAdd.Store(int32(delta))
+		r.have.Store(int32(target))
+	case target < have:
+		delta := have - target
+		r.removes.Add(1)
+		r.lastRem.Store(int32(delta))
+		r.have.Store(int32(target))
+	}
+}
+
+// TestSessionAwareScaleMonitor_ScaleUpOnSessionRamp drives session count
+// upward and asserts the recorder observes growth deltas that would
+// bring the pool from min to max on a big-enough ramp. Uses
+// scaleDecisionRecorder (not a real pool) so the test is
+// deterministic and doesn't dial network.
+func TestSessionAwareScaleMonitor_ScaleUpOnSessionRamp(t *testing.T) {
+	r := &scaleDecisionRecorder{}
+	r.have.Store(2) // start at min
+
+	// softMax=4 min=2 max=8. Ramp session count 0..32 and assert the
+	// pool reaches 8 (ceiling) by ramp end.
+	for sessions := 0; sessions <= 32; sessions += 4 {
+		r.reconcile(sessions, 4, 2, 8)
+	}
+	if got := r.have.Load(); got != 8 {
+		t.Errorf("final pool size = %d, want 8 (should reach max)", got)
+	}
+	if got := r.adds.Load(); got == 0 {
+		t.Error("adds counter = 0, want > 0 (never grew)")
+	}
+}
+
+// TestSessionAwareScaleMonitor_ScaleDownOnSessionRetire drives session
+// count downward from a saturated state and asserts the recorder
+// shrinks back to the floor.
+func TestSessionAwareScaleMonitor_ScaleDownOnSessionRetire(t *testing.T) {
+	r := &scaleDecisionRecorder{}
+	r.have.Store(8) // start at max
+
+	for sessions := 32; sessions >= 0; sessions -= 4 {
+		r.reconcile(sessions, 4, 2, 8)
+	}
+	if got := r.have.Load(); got != 2 {
+		t.Errorf("final pool size = %d, want 2 (should reach min floor)", got)
+	}
+	if got := r.removes.Load(); got == 0 {
+		t.Error("removes counter = 0, want > 0 (never shrunk)")
+	}
+}
+
+// TestSessionAwareScaleMonitor_ConfigUpdateResizes fixes session count
+// and changes softMax mid-run; the next reconcile must retarget.
+func TestSessionAwareScaleMonitor_ConfigUpdateResizes(t *testing.T) {
+	r := &scaleDecisionRecorder{}
+	r.have.Store(2)
+
+	// sessions=20, softMax=4 → target=ceil(40/4)=10, clamped to max=8.
+	r.reconcile(20, 4, 2, 8)
+	if got := r.have.Load(); got != 8 {
+		t.Fatalf("after first reconcile: pool=%d, want 8", got)
+	}
+
+	// softMax doubles to 8 → target=ceil(40/8)=5. Pool should shrink.
+	r.reconcile(20, 8, 2, 8)
+	if got := r.have.Load(); got != 5 {
+		t.Errorf("after softMax bump: pool=%d, want 5", got)
+	}
+}
+
+// TestSessionAwareScaleMonitor_OnConfigStoresSnapshot exercises the
+// OnConfig callback: the atomic snapshot is loadable and reflects
+// every field. Runs against a real monitor instance so any drift in
+// the OnConfig↔tick contract is caught.
+func TestSessionAwareScaleMonitor_OnConfigStoresSnapshot(t *testing.T) {
+	m := NewSessionAwareScaleMonitor(nil, func() int { return 0 })
+
+	// Nil config is ignored — no snapshot stored, no panic.
+	m.OnConfig(nil)
+	if got := m.config.Load(); got != nil {
+		t.Errorf("OnConfig(nil) stored %+v, want no store", got)
+	}
+
+	// Valid config populates all three fields.
+	m.OnConfig(&spb.SessionClientConfiguration_ChannelPoolConfiguration{
+		MinServerCount:        3,
+		MaxServerCount:        12,
+		PerServerSessionCount: 6,
+	})
+	snap := m.config.Load()
+	if snap == nil {
+		t.Fatal("OnConfig(valid) stored nil")
+	}
+	if snap.min != 3 || snap.max != 12 || snap.softMax != 6 {
+		t.Errorf("snapshot = {min=%d max=%d softMax=%d}, want {3 12 6}",
+			snap.min, snap.max, snap.softMax)
+	}
+}
+
+// TestSessionAwareScaleMonitor_StartStopExitsCleanly verifies the
+// production Start/Stop lifecycle: Start spawns the tick goroutine,
+// Stop cancels the context and blocks on the goroutine's exit via
+// the done channel. If either half were racy, Stop would either
+// deadlock (goroutine never exits) or return before the goroutine
+// finishes (Stop returning while the tick is mid-formula).
+func TestSessionAwareScaleMonitor_StartStopExitsCleanly(t *testing.T) {
+	prevInterval := SessionAwareTickInterval
+	SessionAwareTickInterval = 10 * time.Millisecond
+	t.Cleanup(func() { SessionAwareTickInterval = prevInterval })
+
+	m := NewSessionAwareScaleMonitor(nil, func() int { return 0 })
+	// No config set — tick short-circuits, so a nil pool is safe.
+	m.Start(context.Background())
+
+	// Let a couple of ticks land.
+	time.Sleep(30 * time.Millisecond)
+
+	// Stop must return promptly (< 1s is generous) and the done
+	// channel must be closed by the goroutine's defer.
+	stopDone := make(chan struct{})
+	go func() {
+		m.Stop()
+		close(stopDone)
+	}()
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not return within 1s (goroutine leak)")
+	}
+
+	// Double-Stop must be a no-op, not a panic.
+	m.Stop()
+}
+
+// TestSessionAwareScaleMonitor_TickForTest_NoConfigIsNoOp asserts the
+// tick short-circuits before touching the pool when no config has been
+// received. Uses the test-only constructor so the ticker is disabled
+// and we can drive tick manually.
+func TestSessionAwareScaleMonitor_TickForTest_NoConfigIsNoOp(t *testing.T) {
+	called := false
+	m := NewSessionAwareScaleMonitorForTest(nil, func() int {
+		called = true
+		return 0
+	})
+	m.Start(context.Background())
+	defer m.Stop()
+
+	m.TickForTest()
+
+	if called {
+		t.Error("sessionCountFn called before OnConfig — tick should short-circuit")
+	}
+}


### PR DESCRIPTION
> Stacked on **#20277** (`AddChannelPoolConfigListener`). Do not merge before that lands. GitHub will auto-target `main` once the base is merged.

## Summary

`SessionAwareScaleMonitor` sizes the shared gRPC channel pool from live
session count instead of RPC load. Replaces `DynamicScaleMonitor` on
the session data plane; DSM stays in place for the classic path.

**Sizing formula:**
```
target = ceil((sessions × HEADROOM) / softMax); clamp(target, min, max)
```

- `HEADROOM = 2` — cross-language contract.
- Inputs from `ChannelPoolConfiguration` (`MinServerCount` /
  `MaxServerCount` / `PerServerSessionCount`), fed via
  `AddChannelPoolConfigListener` (from #20277).
- Session count = `sum(Ready + Starting)` across every session pool the
  client owns, pulled via a caller-supplied `sessionCountFn` closure so
  `internal/transport` doesn't import `internal/session`.
- Tick cadence: 1 min. Matches cross-language convention. Sessions
  live minutes-to-hours; shorter intervals only add jitter, not signal.

## Motivation

Session-mode sessions are long-lived bidi streams pinned to one
channel. A channel with 50 pinned sessions and idle RPCs looks
under-loaded to `DynamicScaleMonitor`, but a single GOAWAY on that
channel drops 50 sessions at once. RPC load is the wrong proxy for the
session data plane.

`ChannelPoolConfiguration` fields (`MinServerCount` / `MaxServerCount`
/ `PerServerSessionCount`) exist on the proto today
(`bigtablepb.SessionClientConfiguration_ChannelPoolConfiguration`) but
nothing has consumed them until now.

## Wiring

- **`session.Config.DisableSessionAwareChannelPool`** — escape hatch.
  Default (`false`) is the new policy. Set `true` to fall back to DSM
  while a deployment issue is being root-caused.
- **`session.NewClient`** — skips `DynamicScaleMonitor` construction
  entirely; passes `nil` into `NewManagedChannelPool` (its `Close` is
  nil-safe on `Dsm`). After `sc.configManager` exists,
  `registerScaleMonitor` constructs the monitor, hooks its `OnConfig`
  into `AddChannelPoolConfigListener`, and starts the tick loop.
- **`sessionClient.totalSessionCount`** — sums `Stats()` (Ready +
  Starting) across every session pool the client currently owns.
- **`sessionClient.Close`** — stops the monitor and unregisters the
  listener **before** `managed.Close`, so no scale tick races pool
  teardown.

Classic `channel_pool_factory.go` path is untouched — DSM still runs
there.

## Interaction with DSM

Both policies would fight over one pool if allowed to coexist —
add/remove on independent signals oscillates. Session client picks one
at construction: session-aware by default, DSM under the opt-out.
Classic-only clients keep DSM behavior unchanged.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./internal/transport/ ./internal/session/` clean.
- [x] `go test -race -count=1 -short -timeout=120s ./internal/transport/ ./internal/session/` — passes.
- [x] `TestComputeTarget_FormulaAndClamps` — table-driven pure-formula
  test hits cold-start, headroom boundary, softmax-crossing, min/max
  clamps, softmax≤0.
- [x] `TestComputeTarget_HeadroomMatchesConstant` — guards `HEADROOM = 2`
  so any bump is intentional.
- [x] `TestSessionAwareScaleMonitor_ScaleUpOnSessionRamp` — ramp sessions
  0→32 with softmax=4, min=2, max=8; pool reaches max=8.
- [x] `TestSessionAwareScaleMonitor_ScaleDownOnSessionRetire` — reverse;
  pool shrinks back to min=2.
- [x] `TestSessionAwareScaleMonitor_ConfigUpdateResizes` — softmax 4→8
  halves the target under fixed session count.
- [x] `TestSessionAwareScaleMonitor_OnConfigStoresSnapshot` — nil
  ignored, valid config populates all three fields atomically.
- [x] `TestSessionAwareScaleMonitor_StartStopExitsCleanly` — Start
  spawns, Stop returns promptly, double-Stop is a no-op.
- [x] `TestSessionAwareScaleMonitor_TickForTest_NoConfigIsNoOp` —
  pre-config tick short-circuits without touching sessionCountFn.

## Follow-ups

- **Opportunistic add-on-demand.** Cross-language sibling triggers an
  extra add when no channel has capacity for a new stream; our first
  pass is tick-only. Add later if the 1-min lag hurts under bursty
  opens.
- **Live smoke** against `test-sushanb` — ramp workers 5→100 over 10
  min; watch channelz for channel count crossing softmax boundaries.
