### PR TITLE
fix(bigtable): addConnections log — print delta added, not new total

### DIFF
--- a/bigtable/internal/transport/connpool.go
+++ b/bigtable/internal/transport/connpool.go
@@ -963,7 +963,7 @@ func (p *BigtableChannelPool) addConnections(increaseDelta, maxConns int) bool {
 	copy(combinedConns[numCurrent:], newEntries)
 	p.conns.Store(&combinedConns)
 
-	btopt.Debugf(p.logger, "bigtable_connpool: Added %d connections, new size: %d\n", numCurrent+len(newEntries), len(combinedConns))
+	btopt.Debugf(p.logger, "bigtable_connpool: Added %d connections, new size: %d\n", len(newEntries), len(combinedConns))
 	return true
 }
 


### PR DESCRIPTION
## Summary

\`bigtable/internal/transport/connpool.go:982\` formatted the first \`%d\` as \`numCurrent+len(newEntries)\` — the pool's new total, which is the same value already printed as the second \`%d\`. Both fields ended up identical, so the log read:

\`\`\`
bigtable_connpool: Added 22 connections, new size: 22
\`\`\`

on a call that actually added **1** connection to a pool of 21.

## Fix

Drop \`numCurrent\` from the first argument so it prints \`len(newEntries)\` — the actual delta added on this call.

Post-fix output on the same call:

\`\`\`
bigtable_connpool: Added 1 connections, new size: 22
\`\`\`

## Impact

Debug-only surface; no runtime behavior change. Caught while smoke-testing session-aware channel-pool sizing against a live sandbox — the sizer's decision log printed \`target=22 have=21\` (delta=1), which contradicted the \`addConnections\` log's \"Added 22\" and made the scale path look broken when it was actually working correctly.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go vet ./internal/transport/\` clean.
- [x] Existing pool-scaling tests unaffected (one-line format string change).