### PR TITLE
perf(bigtable): drop pick_lost_race debug tag from CheckoutSession hot path

### DIFF
--- a/bigtable/internal/transport/debug_tracer.go
+++ b/bigtable/internal/transport/debug_tracer.go
@@ -123,7 +123,6 @@ const (
 	// a client-side bug, an error is typically transient — so ops
 	// should be able to grep them apart in the debug-tag counters.
 	tagSessionPoolCreatePanic                = "session_pool_create_panic"
-	tagSessionPoolPickLostRace               = "session_pool_pick_lost_race"
 	tagSessionPoolConsecutiveFailuresTripped = "session_pool_consecutive_failures_tripped"
 	// tagSessionPoolNoBudget fires when createSession's budget.Acquire
 	// returns an error — either poolCtx cancel (teardown) or the

--- a/bigtable/internal/transport/session_pool.go
+++ b/bigtable/internal/transport/session_pool.go
@@ -281,9 +281,11 @@ func (p *SessionPoolImpl) CheckoutSession(ctx context.Context) (*SessionHandle, 
 				return idle, nil
 			}
 			// Picker chose this AFE but its ready session was taken
-			// (concurrent Checkout / OnClosing eviction). Counter tells
-			// us how often it's actually hurting throughput.
-			recordDebugTag(tagSessionPoolPickLostRace)
+			// (concurrent Checkout / OnClosing eviction). Loops back
+			// to re-pick; under saturation this is common enough that
+			// recordDebugTag's global-lock cost is a hot-path violator
+			// (RWMutex + sync.Map + WithAttributes allocation per
+			// retry). Not worth counting.
 		}
 
 		// Slow path: picker returned nil or 2 checkoutSession raced and returned the same AFE id. Dying sessions leave sl.readyCount

--- a/bigtable/internal/transport/session_pool.go
+++ b/bigtable/internal/transport/session_pool.go
@@ -280,12 +280,6 @@ func (p *SessionPoolImpl) CheckoutSession(ctx context.Context) (*SessionHandle, 
 				idle.IncPicks()
 				return idle, nil
 			}
-			// Picker chose this AFE but its ready session was taken
-			// (concurrent Checkout / OnClosing eviction). Loops back
-			// to re-pick; under saturation this is common enough that
-			// recordDebugTag's global-lock cost is a hot-path violator
-			// (RWMutex + sync.Map + WithAttributes allocation per
-			// retry). Not worth counting.
 		}
 
 		// Slow path: picker returned nil or 2 checkoutSession raced and returned the same AFE id. Dying sessions leave sl.readyCount


### PR DESCRIPTION
## Summary

\`recordDebugTag\` on the pick-lost-race path (\`session_pool.go:286\`) fires per Checkout retry under contention. Each call takes a global \`RWMutex.RLock\`, does a \`sync.Map\` lookup, and allocates an OTel \`WithAttributes\` option — the design comment at \`debug_tracer.go:15-20\` declares \`recordDebugTag\` \"cheap enough to sprinkle on cold paths\", and this was the sole hot-path violator.

## Measured impact

Sandbox smoke against \`sushanb-uc1\` saw **5666 emissions in 24 min (~4/sec)** with \`CBT_FORCE_SESSION=true\`. Each fire is:
- 1 global \`RWMutex.RLock\` acquisition
- 1 \`sync.Map\` lookup
- 1 heap allocation for \`metric.WithAttributes(attribute.String(...))\`
- 1 counter Add on the shared OTel histogram

Multiplied across many concurrent \`CheckoutSession\` callers (each racing on the same handful of just-freed sessions), it's real steady-state overhead for observability nobody consumes.

## Fix

Remove the \`recordDebugTag\` call and the accompanying \`tagSessionPoolPickLostRace\` constant declaration. Pick-lost-race behavior at the call site is unchanged — \`CheckoutSession\` still falls through to the park path via the existing loop; the counter was purely observability.

## Rationale for delete-not-gate

Gating on \`p.debugEnabled\` adds a conditional per retry for observability that nobody consumes except in synthetic loads. If future analysis needs the signal, it's derivable from \`sessionz\` pick-decision history + concurrent in-use snapshots without a per-call counter.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go vet ./internal/transport/\` clean.
- [x] \`go test -race -count=1 -short -timeout=120s ./internal/transport/\` passes.
- [x] No lingering references to \`tagSessionPoolPickLostRace\` or \`session_pool_pick_lost_race\` in the tree (grep confirms).