### PR TITLE
perf(bigtable): move recordTimeSeries + sampleActiveUptimes to a 1-min loop

### DIFF
--- a/bigtable/internal/transport/session_pool_lifecycle.go
+++ b/bigtable/internal/transport/session_pool_lifecycle.go
@@ -443,16 +443,47 @@ func (p *SessionPoolImpl) consecutiveFailureErr() error {
 // balances reaction to server-driven config against CPU/mu contention.
 const tickInterval = 1 * time.Second
 
+// slowMetricsInterval is the cadence for periodic metric-recorder
+// bodies whose per-second firing was wasteful: sampleActiveUptimes
+// (session.uptime OTel histogram) and recordTimeSeries (in-memory
+// series for sessionz). Matches java-bigtable's
+// scheduleAtFixedRate(recordAsyncSessionMetrics, 1, 1, MINUTES) at
+// MetricsImpl.java:193 — session.uptime is a periodic snapshot
+// metric, not a per-second stream.
+const slowMetricsInterval = 1 * time.Minute
+
 // Start brings the pool up: fires a pre-start Tick to seed min-sessions,
-// then runs the periodic Tick watchdog, AFE prune loop, and
-// WaitServerClose sweep loop. Non-blocking; idempotent via startOnce.
+// then runs the periodic Tick watchdog, AFE prune loop,
+// WaitServerClose sweep loop, and 1-min slow-metrics recorder.
+// Non-blocking; idempotent via startOnce.
 func (p *SessionPoolImpl) Start(ctx context.Context) {
 	p.startOnce.Do(func() {
 		p.spawnTickOnce(ctx)
 		p.startTickLoop(ctx)
 		p.startAfePruneLoop(ctx)
 		p.startSweepStuckSessionsLoop(ctx)
+		p.startSlowMetricsLoop(ctx)
 	})
+}
+
+// startSlowMetricsLoop runs recordTimeSeries + sampleActiveUptimes
+// every slowMetricsInterval until ctx cancels. Decoupled from Tick so
+// Tick's per-second cadence doesn't drag ~60× extra OTel histogram
+// writes onto sessionUptime.
+func (p *SessionPoolImpl) startSlowMetricsLoop(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(slowMetricsInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				p.recordTimeSeries()
+				p.sampleActiveUptimes(ctx)
+			}
+		}
+	}()
 }
 
 // startTickLoop runs Tick every tickInterval until ctx cancels.
@@ -474,9 +505,9 @@ func (p *SessionPoolImpl) startTickLoop(ctx context.Context) {
 
 // tickOnce runs one Tick with panic recovery + a debounce gate. The
 // tickPending CAS coalesces concurrent invocations to at most one
-// active Tick body — a burst of empty-pool kicks otherwise fires
-// redundant sampleActiveUptimes before the scalingInProgress gate
-// rejects them.
+// active Tick body so bursts of empty-pool kicks don't repeatedly
+// enter the sizer decision path before scalingInProgress rejects
+// them.
 func (p *SessionPoolImpl) tickOnce(ctx context.Context) {
 	if !p.tickPending.CompareAndSwap(false, true) {
 		return

--- a/bigtable/internal/transport/session_pool_scaling.go
+++ b/bigtable/internal/transport/session_pool_scaling.go
@@ -82,9 +82,6 @@ func (p *SessionPoolImpl) snapshotScalingHistory() []ScalingEvent {
 // Negative deltas are logged, not actioned. Stuck-session sweeping is
 // on its own loop (startSweepStuckSessionsLoop) at a coarser cadence.
 func (p *SessionPoolImpl) Tick(ctx context.Context) {
-	p.recordTimeSeries()
-	p.sampleActiveUptimes(ctx)
-
 	p.mu.Lock()
 	if p.closed || p.scalingInProgress {
 		p.mu.Unlock()


### PR DESCRIPTION
## Summary

Both \`recordTimeSeries\` and \`sampleActiveUptimes\` were running every \`Tick\` (1-second cadence), but they're periodic-snapshot metrics — nothing changes meaningfully at 1s granularity. \`sampleActiveUptimes\` calls \`sessionUptime.Record\` on every Ready session per Tick, so at 100 sessions this was **~6,000 OTel histogram writes / min** plus the accompanying \`toOtelMetricAttrs\` allocations (visible in heap profiles as multi-MB residence).

Matches **java-bigtable**'s \`session.uptime\` cadence at [\`MetricsImpl.java:193\`](https://github.com/googleapis/java-bigtable/blob/main/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/internal/csm/MetricsImpl.java): \`scheduleAtFixedRate(this::recordAsyncSessionMetrics, 1, 1, TimeUnit.MINUTES)\`.

## Changes

- **Drop the two calls from \`Tick\`'s body** (\`session_pool_scaling.go\`).
- **Add \`slowMetricsInterval = 1 * time.Minute\`** and \`startSlowMetricsLoop\`, mirroring the existing \`startSweepStuckSessionsLoop\` / \`startAfePruneLoop\` patterns — one dedicated goroutine per periodic concern.
- **Wire into \`Start()\`** alongside the other periodic loops.

\`Tick\` keeps its 1-s cadence for sizing decisions (still needed for reactive scale-up on burst arrivals — Java handles that via event-driven hooks, but Go's current shape uses Tick).

## Impact estimate

For a pool with N sessions:

| Metric | Before | After | Reduction |
|---|---|---|---|
| \`sessionUptime.Record\` calls / min | N × 60 | N | **60×** |
| \`recordTimeSeries\` calls / min | 60 | 1 | **60×** |
| \`toOtelMetricAttrs\` allocations / min | proportional to above | proportional to above | 60× |

At the 100-session sandbox pod: from ~6,000 histogram writes/min → 100. Heap-profile residency for \`toOtelMetricAttrs\` should drop correspondingly.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go vet ./internal/transport/\` clean.
- [x] \`go test -race -count=1 -short -timeout=120s ./internal/transport/\` passes.
- [x] Verified \`Tick\` no longer calls the two functions; new loop shape mirrors existing loops.

## Verification (post-merge)

- Heap profile: \`toOtelMetricAttrs\` cumulative should shrink.
- OTel export volume for \`session.uptime\` histogram drops ~60×.
- Sessionz time-series graph updates once per minute instead of once per second — visually the same for aggregate views; per-second granularity was already lost in downstream sampling.