### PR TITLE
perf(bigtable): delete periodic Tick loop; sizing is event-driven

### DIFF
--- a/bigtable/internal/transport/session_pool.go
+++ b/bigtable/internal/transport/session_pool.go
@@ -465,6 +465,15 @@ func (p *SessionPoolImpl) UpdateConfig(config *spb.SessionClientConfiguration_Se
 	if thr := config.GetConsecutiveSessionFailureThreshold(); thr > 0 {
 		p.consecutiveFailureThreshold.Store(thr)
 	}
+
+	// Server-driven config change (min/max bump most commonly) may
+	// require a scale-up. Sizing is otherwise fully event-driven via
+	// onActive / onClosing / CheckoutSession's empty-pool kick; this
+	// explicit kick covers the one path where none of those events
+	// fire — a config poll that raises MinSessionCount on an idle
+	// pool. spawnTickOnce is CAS-guarded so a burst of listener fires
+	// coalesces to one Tick body.
+	p.spawnTickOnce(p.poolCtx)
 }
 
 // pickerFromLoadBalancing builds an AfePicker from server-driven

--- a/bigtable/internal/transport/session_pool_lifecycle.go
+++ b/bigtable/internal/transport/session_pool_lifecycle.go
@@ -439,10 +439,6 @@ func (p *SessionPoolImpl) consecutiveFailureErr() error {
 	return &consecutiveFailureError{inner: *last}
 }
 
-// tickInterval is the cadence for the periodic Tick watchdog. 1 s
-// balances reaction to server-driven config against CPU/mu contention.
-const tickInterval = 1 * time.Second
-
 // slowMetricsInterval is the cadence for periodic metric-recorder
 // bodies whose per-second firing was wasteful: sampleActiveUptimes
 // (session.uptime OTel histogram) and recordTimeSeries (in-memory
@@ -453,13 +449,25 @@ const tickInterval = 1 * time.Second
 const slowMetricsInterval = 1 * time.Minute
 
 // Start brings the pool up: fires a pre-start Tick to seed min-sessions,
-// then runs the periodic Tick watchdog, AFE prune loop,
-// WaitServerClose sweep loop, and 1-min slow-metrics recorder.
-// Non-blocking; idempotent via startOnce.
+// then runs the AFE prune loop, WaitServerClose sweep loop, and 1-min
+// slow-metrics recorder. Non-blocking; idempotent via startOnce.
+//
+// There is deliberately no periodic Tick watchdog — sizing decisions
+// are driven by events at the four sites that meaningfully change
+// pool state:
+//
+//   - onActive → signalFree                    (session became Ready)
+//   - onClosing → spawnTickOnce                (Ready→closing transition)
+//   - CheckoutSession → spawnTickOnce          (waiter park on empty)
+//   - UpdateConfig → spawnTickOnce             (server-driven min/max bump)
+//
+// The pre-start Tick above (line: p.spawnTickOnce(ctx)) covers the
+// cold-start MinSessions seed; everything after is event-driven.
+// Matches java-bigtable's fully event-driven poolSizer (no periodic
+// timer for sizing).
 func (p *SessionPoolImpl) Start(ctx context.Context) {
 	p.startOnce.Do(func() {
 		p.spawnTickOnce(ctx)
-		p.startTickLoop(ctx)
 		p.startAfePruneLoop(ctx)
 		p.startSweepStuckSessionsLoop(ctx)
 		p.startSlowMetricsLoop(ctx)
@@ -481,23 +489,6 @@ func (p *SessionPoolImpl) startSlowMetricsLoop(ctx context.Context) {
 			case <-ticker.C:
 				p.recordTimeSeries()
 				p.sampleActiveUptimes(ctx)
-			}
-		}
-	}()
-}
-
-// startTickLoop runs Tick every tickInterval until ctx cancels.
-func (p *SessionPoolImpl) startTickLoop(ctx context.Context) {
-	go func() {
-		ticker := time.NewTicker(tickInterval)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				p.tickOnce(ctx)
 			}
 		}
 	}()

--- a/bigtable/internal/transport/session_pool_lifecycle.go
+++ b/bigtable/internal/transport/session_pool_lifecycle.go
@@ -443,16 +443,47 @@ func (p *SessionPoolImpl) consecutiveFailureErr() error {
 // balances reaction to server-driven config against CPU/mu contention.
 const tickInterval = 1 * time.Second
 
+// slowMetricsInterval is the cadence for periodic metric-recorder
+// bodies whose per-second firing was wasteful: sampleActiveUptimes
+// (session.uptime OTel histogram) and recordTimeSeries (in-memory
+// series for sessionz). Matches java-bigtable's
+// scheduleAtFixedRate(recordAsyncSessionMetrics, 1, 1, MINUTES) at
+// MetricsImpl.java:193 — session.uptime is a periodic snapshot
+// metric, not a per-second stream.
+const slowMetricsInterval = 1 * time.Minute
+
 // Start brings the pool up: fires a pre-start Tick to seed min-sessions,
-// then runs the periodic Tick watchdog, AFE prune loop, and
-// WaitServerClose sweep loop. Non-blocking; idempotent via startOnce.
+// then runs the periodic Tick watchdog, AFE prune loop,
+// WaitServerClose sweep loop, and 1-min slow-metrics recorder.
+// Non-blocking; idempotent via startOnce.
 func (p *SessionPoolImpl) Start(ctx context.Context) {
 	p.startOnce.Do(func() {
 		p.spawnTickOnce(ctx)
 		p.startTickLoop(ctx)
 		p.startAfePruneLoop(ctx)
 		p.startSweepStuckSessionsLoop(ctx)
+		p.startSlowMetricsLoop(ctx)
 	})
+}
+
+// startSlowMetricsLoop runs recordTimeSeries + sampleActiveUptimes
+// every slowMetricsInterval until ctx cancels. Decoupled from Tick so
+// Tick's per-second cadence doesn't drag ~60× extra OTel histogram
+// writes onto sessionUptime.
+func (p *SessionPoolImpl) startSlowMetricsLoop(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(slowMetricsInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				p.recordTimeSeries()
+				p.sampleActiveUptimes(ctx)
+			}
+		}
+	}()
 }
 
 // startTickLoop runs Tick every tickInterval until ctx cancels.
@@ -474,9 +505,9 @@ func (p *SessionPoolImpl) startTickLoop(ctx context.Context) {
 
 // tickOnce runs one Tick with panic recovery + a debounce gate. The
 // tickPending CAS coalesces concurrent invocations to at most one
-// active Tick body — a burst of empty-pool kicks otherwise fires
-// redundant sampleActiveUptimes before the scalingInProgress gate
-// rejects them.
+// active Tick body so bursts of empty-pool kicks don't repeatedly
+// enter the sizer decision path before scalingInProgress rejects
+// them.
 func (p *SessionPoolImpl) tickOnce(ctx context.Context) {
 	if !p.tickPending.CompareAndSwap(false, true) {
 		return

--- a/bigtable/internal/transport/session_pool_scaling.go
+++ b/bigtable/internal/transport/session_pool_scaling.go
@@ -82,9 +82,6 @@ func (p *SessionPoolImpl) snapshotScalingHistory() []ScalingEvent {
 // Negative deltas are logged, not actioned. Stuck-session sweeping is
 // on its own loop (startSweepStuckSessionsLoop) at a coarser cadence.
 func (p *SessionPoolImpl) Tick(ctx context.Context) {
-	p.recordTimeSeries()
-	p.sampleActiveUptimes(ctx)
-
 	p.mu.Lock()
 	if p.closed || p.scalingInProgress {
 		p.mu.Unlock()


### PR DESCRIPTION
> Stacked on **#20283** (\`fix/bigtable-uptime-sample-cadence\`). Do not merge before that lands.

## Summary

After #20283 moved \`recordTimeSeries\` and \`sampleActiveUptimes\` to a dedicated 1-min loop, \`Tick\`'s body is pure sizing (\`sizer.Decide\` + \`createSession\` fan-out). Every meaningful pool-state transition already fires \`spawnTickOnce\` so a background timer is redundant.

## Event coverage audit

| Trigger | Site | Fires |
|---|---|---|
| Session became Ready | \`onActive\` | \`signalFree\` (wakes waiters) — no Tick needed since a Ready-count increment doesn't want more sessions |
| Session leaving Ready | \`onClosing\` (\`session_pool_lifecycle.go:326\`) | \`spawnTickOnce\` — kicks a replacement decision |
| Waiter park on empty pool | \`CheckoutSession\` (\`session_pool.go:256\`) | \`spawnTickOnce\` — kicks a cold-start / burst-scale decision |
| Server-driven config change | \`UpdateConfig\` (**new** in this PR) | \`spawnTickOnce\` — covers the one path where none of the above events fire (e.g., \`MinSessionCount\` bumped on an idle pool) |
| Pool cold start | \`Start()\` (\`session_pool_lifecycle.go\`) | Pre-start \`spawnTickOnce\` seeds MinSessions |

\`spawnTickOnce\` is CAS-guarded via \`tickPending\`, so a burst of listener fires coalesces to one Tick body.

## Java parity

Matches java-bigtable's fully event-driven \`poolSizer\`: no periodic timer for sizing. Sizing decisions ride on the events that would trigger them anyway.

## Impact

- **Idle pool steady-state:** was ~1 Tick / sec (\`sizer.Decide\` + \`p.mu\` bracket + \`sl\` walk) = ~200-500 ns of CPU + lock contention per pool per second. **Now zero** between events.
- **Under load:** unchanged — same event-driven scale-up paths fire.
- **Under bursty saturation:** unchanged — \`CheckoutSession\`'s empty-pool kick already covered burst reaction, not the periodic Tick.

## Changes

- Delete \`startTickLoop\` + \`tickInterval\` const (\`session_pool_lifecycle.go\`).
- Drop \`p.startTickLoop(ctx)\` from \`Start()\`; keep the pre-start \`spawnTickOnce\` that seeds MinSessions.
- Add \`p.spawnTickOnce(p.poolCtx)\` at the end of \`UpdateConfig\` (\`session_pool.go\`).

Net: +9 / -25 lines.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go vet ./internal/transport/\` clean.
- [x] \`go test -race -count=5 -short -timeout=180s -run 'TestSessionPool|TestCheckoutSession|TestPool_' ./internal/transport/\` — 5× stress pass.
- [x] \`go test -race -count=1 -short ./internal/session/\` — pass.

## What this does NOT change

- \`Tick\` itself (\`SessionPoolImpl.Tick\`) is unchanged — it just no longer runs on a timer. \`spawnTickOnce\` / \`tickOnce\` still wrap it with debounce + panic recovery.
- \`sweepStuckSessions\` (its own 30 s loop), AFE prune (its own loop), slow-metrics (its own 1-min loop from #20283) — all unchanged.
- \`Close\` teardown — \`spawns\` WaitGroup semantics unchanged since \`spawnTickOnce\` still bumps \`spawns.Add\` before the goroutine.