### PR TITLE
fix(bigtable): panic recovery in startSlowMetricsLoop

### DIFF
--- a/bigtable/internal/transport/session_pool_lifecycle.go
+++ b/bigtable/internal/transport/session_pool_lifecycle.go
@@ -477,7 +477,10 @@ func (p *SessionPoolImpl) Start(ctx context.Context) {
 // startSlowMetricsLoop runs recordTimeSeries + sampleActiveUptimes
 // every slowMetricsInterval until ctx cancels. Decoupled from Tick so
 // Tick's per-second cadence doesn't drag ~60× extra OTel histogram
-// writes onto sessionUptime.
+// writes onto sessionUptime. Each fire is wrapped in the same
+// recover shape as tickOnce — a panic in either recorder (e.g. a
+// nil map deref during teardown races) must not tear the whole
+// process down.
 func (p *SessionPoolImpl) startSlowMetricsLoop(ctx context.Context) {
 	go func() {
 		ticker := time.NewTicker(slowMetricsInterval)
@@ -487,11 +490,25 @@ func (p *SessionPoolImpl) startSlowMetricsLoop(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				p.recordTimeSeries()
-				p.sampleActiveUptimes(ctx)
+				p.recordSlowMetricsOnce(ctx)
 			}
 		}
 	}()
+}
+
+// recordSlowMetricsOnce runs one slow-metrics recorder cycle with
+// panic recovery. Split out from startSlowMetricsLoop so the
+// recover() sits in its own frame — the deferred recover in the
+// enclosing goroutine would only fire once, killing the loop after a
+// single panic; a per-tick frame keeps the loop alive.
+func (p *SessionPoolImpl) recordSlowMetricsOnce(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			btopt.Debugf(nil, "POOL %s slow-metrics panic recovered: %v\n%s", p.poolName, r, debug.Stack())
+		}
+	}()
+	p.recordTimeSeries()
+	p.sampleActiveUptimes(ctx)
 }
 
 // tickOnce runs one Tick with panic recovery + a debounce gate. The


### PR DESCRIPTION
## Summary

- Wrap each fire of the 1-min slow-metrics loop (\`recordTimeSeries\` + \`sampleActiveUptimes\`) in a \`recoverSlowMetricsOnce\` helper with a defer/recover frame — matches \`tickOnce\`'s existing shape.
- Restores the safety net that existed when both recorders ran inside \`tickOnce\`; #20283 moved them out to a dedicated loop and inadvertently dropped the recover.

## Why

A panic in either recorder (e.g. nil map deref during a pool-teardown race) previously stayed contained inside \`tickOnce\`'s defer. On the new dedicated 1-min loop, an unrecovered panic would crash the entire process.

## Design detail

The recover lives in a per-tick helper, **not** on the enclosing goroutine's defer. A goroutine-level defer fires exactly once — the loop would die after a single panic. A fresh frame per fire keeps the loop alive across recovered panics, matching how \`tickOnce\` behaves under the same failure mode.

Log line format (\`POOL <name> slow-metrics panic recovered: <r>\\n<stack>\`) matches \`tickOnce\` so operators grepping for pool panics see one consistent shape.

## Test plan

- [x] \`go build ./...\` under \`bigtable/\` clean
- [x] \`go vet ./internal/transport/\` clean
- [x] \`go test -short -count=1 -run TestSessionPool -timeout=60s ./internal/transport/\` passes

## Credit

Flagged by gemini-code-assist on #20285 (already merged); this is the follow-up fix against \`main\`.