### PR TITLE
refactor(bigtable): hardcode FeatureFlags.RetryInfo=true; drop DISABLE_RETRY_INFO plumbing

### DIFF
--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -74,13 +74,11 @@ var (
 		Max:        2 * time.Second,
 		Multiplier: 1.2,
 	}
-	clientOnlyRetryOption             = newRetryOption(clientOnlyRetry, true)
-	clientOnlyExecuteQueryRetryOption = newRetryOption(clientOnlyExecuteQueryRetry, true)
-	defaultRetryOption                = newRetryOption(clientOnlyRetry, false)
-	defaultExecuteQueryRetryOption    = newRetryOption(clientOnlyExecuteQueryRetry, false)
+	defaultRetryOption             = newRetryOption(clientOnlyRetry)
+	defaultExecuteQueryRetryOption = newRetryOption(clientOnlyExecuteQueryRetry)
 )
 
-func newRetryOption(retryFn func(*gax.Backoff, error) (time.Duration, bool), disableRetryInfo bool) gax.CallOption {
+func newRetryOption(retryFn func(*gax.Backoff, error) (time.Duration, bool)) gax.CallOption {
 	return gax.WithRetry(func() gax.Retryer {
 		// Create a new Backoff instance for each retryer to ensure independent state.
 		newBackoffInstance := gax.Backoff{
@@ -89,9 +87,8 @@ func newRetryOption(retryFn func(*gax.Backoff, error) (time.Duration, bool), dis
 			Multiplier: defaultBackoff.Multiplier,
 		}
 		return &bigtableRetryer{
-			baseRetryFn:      retryFn,
-			backoff:          newBackoffInstance,
-			disableRetryInfo: disableRetryInfo,
+			baseRetryFn: retryFn,
+			backoff:     newBackoffInstance,
 		}
 	})
 }
@@ -112,37 +109,34 @@ func clientOnlyRetry(backoff *gax.Backoff, err error) (time.Duration, bool) {
 	return 0, false
 }
 
-// bigtableRetryer implements the gax.Retryer interface. It manages retry decisions,
-// incorporating server-sent RetryInfo if enabled, and client-side exponential backoff.
-// It specifically handles reseting the client-side backoff to its initial state if
-// RetryInfo was previously used for an operation and then stops being provided.
+// bigtableRetryer implements the gax.Retryer interface. It always
+// consumes server-sent RetryInfo when present and falls back to a
+// per-instance exponential backoff otherwise. If a prior attempt used
+// a RetryInfo-driven delay and the current error carries none, the
+// backoff is reset so we don't reuse a stale multiplier.
 type bigtableRetryer struct {
 	baseRetryFn               func(*gax.Backoff, error) (time.Duration, bool)
 	backoff                   gax.Backoff
-	disableRetryInfo          bool // If true, this retryer will process server-sent RetryInfo.
 	wasLastDelayFromRetryInfo bool // true if the previous retry delay for this operation was from RetryInfo.
-
 }
 
 // Retry determines if an operation should be retried and for how long to wait.
 func (r *bigtableRetryer) Retry(err error) (time.Duration, bool) {
-	if !r.disableRetryInfo {
-		apiErr, ok := apierror.FromError(err)
-		if ok && apiErr != nil && apiErr.Details().RetryInfo != nil {
-			// RetryInfo is present in the current error. Use its delay.
-			r.wasLastDelayFromRetryInfo = true
-			return apiErr.Details().RetryInfo.GetRetryDelay().AsDuration(), true
-		}
-
-		if r.wasLastDelayFromRetryInfo {
-			r.backoff = gax.Backoff{
-				Initial:    r.backoff.Initial,
-				Max:        r.backoff.Max,
-				Multiplier: r.backoff.Multiplier,
-			}
-		}
-		r.wasLastDelayFromRetryInfo = false
+	apiErr, ok := apierror.FromError(err)
+	if ok && apiErr != nil && apiErr.Details().RetryInfo != nil {
+		// RetryInfo is present in the current error. Use its delay.
+		r.wasLastDelayFromRetryInfo = true
+		return apiErr.Details().RetryInfo.GetRetryDelay().AsDuration(), true
 	}
+
+	if r.wasLastDelayFromRetryInfo {
+		r.backoff = gax.Backoff{
+			Initial:    r.backoff.Initial,
+			Max:        r.backoff.Max,
+			Multiplier: r.backoff.Multiplier,
+		}
+	}
+	r.wasLastDelayFromRetryInfo = false
 
 	return r.baseRetryFn(&r.backoff, err)
 }

--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -18,7 +18,6 @@ package bigtable // import "cloud.google.com/go/bigtable"
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"hash/crc32"
@@ -43,7 +42,6 @@ const (
 	// UNIVERSE_DOMAIN placeholder is replaced by the UniverseDomain from DialSettings while creating GRPC connection/dial pool.
 	prodAddr                    = "bigtable.UNIVERSE_DOMAIN:443"
 	mtlsProdAddr                = "bigtable.mtls.googleapis.com:443"
-	featureFlagsHeaderKey       = "bigtable-features"
 	methodNameReadRows          = "ReadRows"
 	defaultBigtableConnPoolSize = 10
 
@@ -171,34 +169,6 @@ func mergeOutgoingMetadata(ctx context.Context, mds ...metadata.MD) context.Cont
 	// The ordering matters, hence why ctxMD comes first.
 	allMDs := append([]metadata.MD{ctxMD}, mds...)
 	return metadata.NewOutgoingContext(ctx, metadata.Join(allMDs...))
-}
-
-// createFeatureFlagsMD creates the metadata for the `bigtable-features` header.
-// This header is sent on each request and includes all features supported and
-// enabled on the client.
-func createFeatureFlagsMD(clientSideMetricsEnabled, disableRetryInfo, enableDirectAccess bool) metadata.MD {
-	ff := btpb.FeatureFlags{
-		RoutingCookie:            true,
-		ReverseScans:             true,
-		LastScannedRowResponses:  true,
-		ClientSideMetricsEnabled: clientSideMetricsEnabled,
-		RetryInfo:                !disableRetryInfo,
-		TrafficDirectorEnabled:   enableDirectAccess,
-		DirectAccessRequested:    enableDirectAccess,
-		// PeerInfo tells the server it may send the bigtable-peer-info
-		// sideband metadata that populates attempt_latencies2's
-		// transport_type/region/zone/subzone labels. Extracted from
-		// header/trailer MD by the tracer's extractPeerInfo.
-		PeerInfo: true,
-	}
-
-	val := ""
-	b, err := proto.Marshal(&ff)
-	if err == nil {
-		val = base64.URLEncoding.EncodeToString(b)
-	}
-
-	return metadata.Pairs(featureFlagsHeaderKey, val)
 }
 
 // TODO(dsymonds): Read method that returns a sequence of ReadItems.

--- a/bigtable/client.go
+++ b/bigtable/client.go
@@ -195,7 +195,11 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 	// and we evaluate the directAccess option after that.
 
 	allowDirectAccess := isDirectAccessEnabled(config)
-	directAccessMD := createFeatureFlagsMD(metricsTracerFactory.Enabled, disableRetryInfo, allowDirectAccess)
+	directAccessMD := btransport.MarshalFeatureFlagsMD(btransport.NewFeatureFlagsProto(btransport.FeatureFlagsInput{
+		ClientSideMetricsEnabled: metricsTracerFactory.Enabled,
+		DisableRetryInfo:         disableRetryInfo,
+		EnableDirectAccess:       allowDirectAccess,
+	}))
 
 	var mPool btransport.ManagedChannelPool
 	enableBigtableConnPool := btopt.EnableBigtableConnectionPool()

--- a/bigtable/client.go
+++ b/bigtable/client.go
@@ -180,14 +180,16 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 	retryOption := defaultRetryOption
 	executeQueryRetryOption := defaultExecuteQueryRetryOption
 
-	// Single source of truth for the DirectAccess bit — same value
-	// feeds the bigtable-features header, the session client's own
-	// header + envelope, and the dial-time DirectPath switch below.
-	allowDirectAccess := isDirectAccessEnabled(config)
-	directAccessMD := btransport.MarshalFeatureFlagsMD(btransport.NewFeatureFlagsProto(btransport.FeatureFlagsInput{
+	// Build feature-flags proto + header MD ONCE. Both are threaded
+	// into session.NewClient below so classic and session ship
+	// byte-identical bigtable-features headers AND session's
+	// OpenSessionRequest.Flags reuses the same proto reference —
+	// zero drift by construction, no re-marshal in session.
+	featureFlagsProto := btransport.NewFeatureFlagsProto(btransport.FeatureFlagsInput{
 		ClientSideMetricsEnabled: metricsTracerFactory.Enabled,
-		EnableDirectAccess:       allowDirectAccess,
-	}))
+		EnableDirectAccess:       isDirectAccessEnabled(config),
+	})
+	directAccessMD := btransport.MarshalFeatureFlagsMD(featureFlagsProto)
 
 	var mPool btransport.ManagedChannelPool
 	enableBigtableConnPool := btopt.EnableBigtableConnectionPool()
@@ -283,7 +285,7 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 		// in (endpoint, scopes, user-agent, interceptors) — passing
 		// bare opts leaves the resolver target empty and the dial
 		// aborts with "passthrough: received empty target in Build()".
-		sc, sessionErr := session.NewClient(ctx, project, instance, config.AppProfile, metricsProvider, allowDirectAccess, o...)
+		sc, sessionErr := session.NewClient(ctx, project, instance, config.AppProfile, metricsProvider, featureFlagsProto, o...)
 		if sessionErr != nil {
 			// Best-effort cleanup of the classic pool since we won't
 			// return c to the caller. Go through the ManagedChannelPool

--- a/bigtable/client.go
+++ b/bigtable/client.go
@@ -48,7 +48,6 @@ type Client struct {
 	project, instance       string
 	appProfile              string
 	metricsTracerFactory    *metrics.Factory
-	disableRetryInfo        bool
 	retryOption             gax.CallOption
 	executeQueryRetryOption gax.CallOption
 	featureFlagsMD          metadata.MD // Pre-computed feature flags metadata to be sent with each request.
@@ -176,17 +175,10 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 	o = append(o, internaloption.EnableNewAuthLibrary())
 	o = append(o, internaloption.EnableJwtWithScope())
 
-	disableRetryInfo := false
-
-	// If DISABLE_RETRY_INFO=1, library does not base retry decision and back off time on server returned RetryInfo value.
-	disableRetryInfoEnv := os.Getenv("DISABLE_RETRY_INFO")
-	disableRetryInfo = disableRetryInfoEnv == "1"
+	// RetryInfo is unconditionally on; retryer + on-wire flag agree via
+	// NewFeatureFlagsProto (feature_flags.go) and defaultRetryOption.
 	retryOption := defaultRetryOption
 	executeQueryRetryOption := defaultExecuteQueryRetryOption
-	if disableRetryInfo {
-		retryOption = clientOnlyRetryOption
-		executeQueryRetryOption = clientOnlyExecuteQueryRetryOption
-	}
 
 	// Create the feature flags metadata with direct access enabled
 	// setting feature flags for direct access is good
@@ -197,7 +189,6 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 	allowDirectAccess := isDirectAccessEnabled(config)
 	directAccessMD := btransport.MarshalFeatureFlagsMD(btransport.NewFeatureFlagsProto(btransport.FeatureFlagsInput{
 		ClientSideMetricsEnabled: metricsTracerFactory.Enabled,
-		DisableRetryInfo:         disableRetryInfo,
 		EnableDirectAccess:       allowDirectAccess,
 	}))
 
@@ -248,7 +239,6 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 		instance:                instance,
 		appProfile:              config.AppProfile,
 		metricsTracerFactory:    metricsTracerFactory,
-		disableRetryInfo:        disableRetryInfo,
 		retryOption:             retryOption,
 		executeQueryRetryOption: executeQueryRetryOption,
 		featureFlagsMD:          directAccessMD,

--- a/bigtable/client.go
+++ b/bigtable/client.go
@@ -415,4 +415,3 @@ func isDirectAccessEnabled(config ClientConfig) bool {
 	res, _ := strconv.ParseBool(os.Getenv(directAccessEnvVar))
 	return res
 }
-

--- a/bigtable/client.go
+++ b/bigtable/client.go
@@ -180,12 +180,9 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 	retryOption := defaultRetryOption
 	executeQueryRetryOption := defaultExecuteQueryRetryOption
 
-	// Create the feature flags metadata with direct access enabled
-	// setting feature flags for direct access is good
-	// as CFE/GFE will call RLS with gslb target type
-	// only TD calls the RLS with grpc target type
-	// and we evaluate the directAccess option after that.
-
+	// Single source of truth for the DirectAccess bit — same value
+	// feeds the bigtable-features header, the session client's own
+	// header + envelope, and the dial-time DirectPath switch below.
 	allowDirectAccess := isDirectAccessEnabled(config)
 	directAccessMD := btransport.MarshalFeatureFlagsMD(btransport.NewFeatureFlagsProto(btransport.FeatureFlagsInput{
 		ClientSideMetricsEnabled: metricsTracerFactory.Enabled,
@@ -286,7 +283,7 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 		// in (endpoint, scopes, user-agent, interceptors) — passing
 		// bare opts leaves the resolver target empty and the dial
 		// aborts with "passthrough: received empty target in Build()".
-		sc, sessionErr := session.NewClient(ctx, project, instance, config.AppProfile, metricsProvider, o...)
+		sc, sessionErr := session.NewClient(ctx, project, instance, config.AppProfile, metricsProvider, allowDirectAccess, o...)
 		if sessionErr != nil {
 			// Best-effort cleanup of the classic pool since we won't
 			// return c to the caller. Go through the ManagedChannelPool
@@ -402,6 +399,13 @@ func (c *Client) newBuiltinMetricsTracer(ctx context.Context, table string, isSt
 	return c.metricsTracerFactory.CreateTracer(ctx, table, isStreaming)
 }
 
+// isDirectAccessEnabled resolves whether this client advertises
+// DirectAccess capability on the wire AND dials DirectPath. Single
+// source of truth threaded into both the classic and session
+// FeatureFlags builders so header bits stay in lockstep with the
+// dial-time switch. CBT_ENABLE_DIRECTPATH overrides
+// ClientConfig.DisableDirectAccess when set; unset falls back to
+// the config default.
 func isDirectAccessEnabled(config ClientConfig) bool {
 	if os.Getenv(directAccessEnvVar) == "" {
 		return !config.DisableDirectAccess
@@ -409,3 +413,4 @@ func isDirectAccessEnabled(config ClientConfig) bool {
 	res, _ := strconv.ParseBool(os.Getenv(directAccessEnvVar))
 	return res
 }
+

--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -83,11 +83,9 @@ type Config struct {
 	// GetClientConfiguration polls — instance-scoped headers.
 	ConfigMD metadata.MD
 
-	// MetricsEnabled / DisableRetryInfo mirror the SessionManager
-	// booleans of the same name; both propagate into FeatureFlags on
-	// every OpenSessionRequest.
-	MetricsEnabled   bool
-	DisableRetryInfo bool
+	// MetricsEnabled mirrors the SessionManager boolean of the same
+	// name; propagates into FeatureFlags on every OpenSessionRequest.
+	MetricsEnabled bool
 
 	// SessionLoadListener is invoked whenever the server-driven
 	// ClientConfigurationManager reports a new session-load ratio. The
@@ -281,7 +279,6 @@ func NewClient(
 	// INVALID_ARGUMENT if they disagree on session-mode flags).
 	featureFlagsProto := btransport.NewFeatureFlagsProto(btransport.FeatureFlagsInput{
 		ClientSideMetricsEnabled: factory.Enabled,
-		DisableRetryInfo:         false,
 		EnableDirectAccess:       true,
 	})
 	directAccessMD := btransport.MarshalFeatureFlagsMD(featureFlagsProto)
@@ -355,14 +352,13 @@ func NewClient(
 	backgroundCtx, cancel := context.WithCancel(context.Background())
 
 	sc := newSessionClientFromParts(pool, stub, factory, Config{
-		Project:          project,
-		Instance:         instance,
-		AppProfile:       appProfile,
-		FeatureFlagsMD:   directAccessMD,
-		ConfigMD:         configMD,
-		MetricsEnabled:   factory.Enabled,
-		DisableRetryInfo: false,
-		BackgroundCtx:    backgroundCtx,
+		Project:        project,
+		Instance:       instance,
+		AppProfile:     appProfile,
+		FeatureFlagsMD: directAccessMD,
+		ConfigMD:       configMD,
+		MetricsEnabled: factory.Enabled,
+		BackgroundCtx:  backgroundCtx,
 		// EnableDebug intentionally left at zero (false): NewClient has
 		// no external caller upstream today, so exposing a positional
 		// bool on the constructor would ship a dead knob. When the
@@ -394,7 +390,6 @@ func newSessionClientFromParts(channelPool ChannelPool, stub btpb.BigtableClient
 		// back-to-back so the header and this envelope-side proto agree).
 		featureFlagsProto: btransport.NewFeatureFlagsProto(btransport.FeatureFlagsInput{
 			ClientSideMetricsEnabled: cfg.MetricsEnabled,
-			DisableRetryInfo:         cfg.DisableRetryInfo,
 			EnableDirectAccess:       true,
 		}),
 		sessionPools: make(map[poolKey]*managedSessionPool),

--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -273,6 +273,7 @@ func NewClient(
 	ctx context.Context,
 	project, instance, appProfile string,
 	metricsProvider metrics.MetricsProvider,
+	enableDirectAccess bool,
 	opts ...option.ClientOption,
 ) (Client, error) {
 	factory, err := metrics.NewFactory(ctx, project, instance, appProfile, metricsProvider)
@@ -286,7 +287,7 @@ func NewClient(
 	// INVALID_ARGUMENT if they disagree on session-mode flags).
 	featureFlagsProto := btransport.NewFeatureFlagsProto(btransport.FeatureFlagsInput{
 		ClientSideMetricsEnabled: factory.Enabled,
-		EnableDirectAccess:       true,
+		EnableDirectAccess:       enableDirectAccess,
 	})
 	directAccessMD := btransport.MarshalFeatureFlagsMD(featureFlagsProto)
 

--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -16,12 +16,9 @@ package session
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"net/url"
-	"os"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -61,11 +58,6 @@ const (
 // non-backwards-compatible change to the request/response shape or the
 // vRPC descriptor set.
 const sessionProtocolVersion = 1
-
-// featureFlagsHeaderKey mirrors the bigtable package constant of the
-// same name — duplicated because internal/session can't import
-// bigtable (import cycle).
-const featureFlagsHeaderKey = "bigtable-features"
 
 // ChannelPool is the narrow surface sessionClient needs from the
 // managed channel pool it owns. Satisfied by
@@ -243,6 +235,13 @@ type sessionClient struct {
 	// panel. Immutable after construction — no atomic needed.
 	enableDebug bool
 
+	// featureFlagsProto is the FeatureFlags proto stamped on every
+	// OpenSessionRequest.Flags. Built once at NewClient time so it
+	// stays byte-identical with the bigtable-features header — the
+	// server rejects OpenSession with INVALID_ARGUMENT when the two
+	// disagree on session-mode flags.
+	featureFlagsProto *btpb.FeatureFlags
+
 	sessionPoolsMu sync.Mutex
 	sessionPools   map[poolKey]*managedSessionPool
 	nextPoolID     atomic.Uint64
@@ -276,10 +275,16 @@ func NewClient(
 		return nil, fmt.Errorf("session.NewClient: metrics.NewFactory: %w", err)
 	}
 
-	// Feature-flag metadata carried on every Prime + GetClientConfiguration
-	// invocation. Mirrors bigtable.createFeatureFlagsMD(true, false, true) —
-	// duplicated to avoid an import cycle back into the bigtable package.
-	directAccessMD := buildFeatureFlagsMD(factory.Enabled, false /* disableRetryInfo */, true /* enableDirectAccess */)
+	// Feature-flag proto shared by the bigtable-features header AND
+	// OpenSessionRequest.Flags — build once so the header and the
+	// envelope byte-match (server rejects OpenSession with
+	// INVALID_ARGUMENT if they disagree on session-mode flags).
+	featureFlagsProto := btransport.NewFeatureFlagsProto(btransport.FeatureFlagsInput{
+		ClientSideMetricsEnabled: factory.Enabled,
+		DisableRetryInfo:         false,
+		EnableDirectAccess:       true,
+	})
+	directAccessMD := btransport.MarshalFeatureFlagsMD(featureFlagsProto)
 
 	fullInstance := fmt.Sprintf("projects/%s/instances/%s", project, instance)
 
@@ -383,7 +388,16 @@ func newSessionClientFromParts(channelPool ChannelPool, stub btpb.BigtableClient
 		stub:           stub,
 		metricsFactory: metricsFactory,
 		enableDebug:    cfg.EnableDebug,
-		sessionPools:   make(map[poolKey]*managedSessionPool),
+		// Same input as the bigtable-features header built in NewClient;
+		// same inputs → identical proto (deterministic modulo the
+		// CBT_FORCE_SESSION env var, which is read at both call sites
+		// back-to-back so the header and this envelope-side proto agree).
+		featureFlagsProto: btransport.NewFeatureFlagsProto(btransport.FeatureFlagsInput{
+			ClientSideMetricsEnabled: cfg.MetricsEnabled,
+			DisableRetryInfo:         cfg.DisableRetryInfo,
+			EnableDirectAccess:       true,
+		}),
+		sessionPools: make(map[poolKey]*managedSessionPool),
 	}
 	// stub == nil only happens on the test-only newSessionClientFromParts
 	// path (unit tests wiring a fake ChannelPool without a real gRPC stub).
@@ -402,39 +416,6 @@ func newSessionClientFromParts(channelPool ChannelPool, stub btpb.BigtableClient
 		}
 	}
 	return sc
-}
-
-// buildFeatureFlagsMD mirrors bigtable.createFeatureFlagsMD. Duplicated
-// (rather than exported+imported) to keep the internal/session package
-// free of a back-reference to the bigtable package.
-func buildFeatureFlagsMD(clientSideMetricsEnabled, disableRetryInfo, enableDirectAccess bool) metadata.MD {
-	// CBT_FORCE_SESSION tri-state — Google-internal only, gated
-	// server-side. See bigtable.createFeatureFlagsMD for the semantic
-	// (kept in sync intentionally; internal/session can't import
-	// bigtable due to the import-cycle boundary).
-	sessionsCompatible, sessionsRequired := true, false
-	if v, ok := os.LookupEnv("CBT_FORCE_SESSION"); ok {
-		if b, err := strconv.ParseBool(v); err == nil {
-			sessionsCompatible, sessionsRequired = b, b
-		}
-	}
-	ff := btpb.FeatureFlags{
-		RoutingCookie:            true,
-		ReverseScans:             true,
-		LastScannedRowResponses:  true,
-		ClientSideMetricsEnabled: clientSideMetricsEnabled,
-		RetryInfo:                !disableRetryInfo,
-		TrafficDirectorEnabled:   enableDirectAccess,
-		DirectAccessRequested:    enableDirectAccess,
-		SessionsCompatible:       sessionsCompatible,
-		SessionsRequired:         sessionsRequired,
-		PeerInfo:                 true,
-	}
-	val := ""
-	if b, err := proto.Marshal(&ff); err == nil {
-		val = base64.URLEncoding.EncodeToString(b)
-	}
-	return metadata.Pairs(featureFlagsHeaderKey, val)
 }
 
 func (sc *sessionClient) MeterProvider() otelmetric.MeterProvider {
@@ -765,36 +746,13 @@ func (sc *sessionClient) getOrCreateSessionPool(
 	return pool
 }
 
-// featureFlags builds the OpenSessionRequest.Flags proto from
-// sessionClient config. SessionsCompatible / SessionsRequired MUST
-// match the values in bigtable-features metadata header (built by
-// buildFeatureFlagsMD) — the server rejects OpenSession with
-// INVALID_ARGUMENT when the proto and header disagree on session-mode
-// flags. See bigtable.createFeatureFlagsMD for the tri-state semantic.
-//
-// TODO(sushanb): CBT_FORCE_SESSION is re-read here on every pool open
-// but buildFeatureFlagsMD reads it once at NewClient. If the
-// env flips mid-process the header + proto disagree and the server
-// rejects. Resolve once at construction and stash on Config.
+// featureFlags returns the FeatureFlags proto stamped onto every
+// OpenSessionRequest.Flags. Constructed once at NewClient time from
+// the same input as the bigtable-features gRPC header so the two are
+// byte-identical — the server rejects OpenSession with INVALID_ARGUMENT
+// when they disagree on session-mode flags.
 func (sc *sessionClient) featureFlags() *btpb.FeatureFlags {
-	sessionsCompatible, sessionsRequired := true, false
-	if v, ok := os.LookupEnv("CBT_FORCE_SESSION"); ok {
-		if b, err := strconv.ParseBool(v); err == nil {
-			sessionsCompatible, sessionsRequired = b, b
-		}
-	}
-	return &btpb.FeatureFlags{
-		RoutingCookie:            true,
-		ReverseScans:             true,
-		LastScannedRowResponses:  true,
-		ClientSideMetricsEnabled: sc.cfg.MetricsEnabled,
-		RetryInfo:                !sc.cfg.DisableRetryInfo,
-		TrafficDirectorEnabled:   true,
-		DirectAccessRequested:    true,
-		SessionsCompatible:       sessionsCompatible,
-		SessionsRequired:         sessionsRequired,
-		PeerInfo:                 true,
-	}
+	return sc.featureFlagsProto
 }
 
 // perResourceMetadata builds the per-vRPC context metadata: the pair

--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -87,6 +87,16 @@ type Config struct {
 	// name; propagates into FeatureFlags on every OpenSessionRequest.
 	MetricsEnabled bool
 
+	// FeatureFlagsProto is the pre-built FeatureFlags proto stamped
+	// onto every OpenSessionRequest.Flags. When non-nil,
+	// newSessionClientFromParts stashes it directly rather than
+	// rebuilding — this is the byte-identical guarantee against the
+	// bigtable-features header (the server rejects OpenSession with
+	// INVALID_ARGUMENT if header and envelope disagree on session-mode
+	// flags). Left nil by the test-only newSessionClientFromParts
+	// callers, which fall back to reconstruction from MetricsEnabled.
+	FeatureFlagsProto *btpb.FeatureFlags
+
 	// SessionLoadListener is invoked whenever the server-driven
 	// ClientConfigurationManager reports a new session-load ratio. The
 	// bigtable Client wires this to Diverter.SetSessionLoad so the
@@ -352,13 +362,14 @@ func NewClient(
 	backgroundCtx, cancel := context.WithCancel(context.Background())
 
 	sc := newSessionClientFromParts(pool, stub, factory, Config{
-		Project:        project,
-		Instance:       instance,
-		AppProfile:     appProfile,
-		FeatureFlagsMD: directAccessMD,
-		ConfigMD:       configMD,
-		MetricsEnabled: factory.Enabled,
-		BackgroundCtx:  backgroundCtx,
+		Project:           project,
+		Instance:          instance,
+		AppProfile:        appProfile,
+		FeatureFlagsMD:    directAccessMD,
+		FeatureFlagsProto: featureFlagsProto,
+		ConfigMD:          configMD,
+		MetricsEnabled:    factory.Enabled,
+		BackgroundCtx:     backgroundCtx,
 		// EnableDebug intentionally left at zero (false): NewClient has
 		// no external caller upstream today, so exposing a positional
 		// bool on the constructor would ship a dead knob. When the
@@ -378,21 +389,26 @@ func newSessionClientFromParts(channelPool ChannelPool, stub btpb.BigtableClient
 	if cfg.MetricsEnabled && metricsFactory != nil {
 		_ = btransport.InitializeSessionMetrics(metricsFactory.OtelMeterProvider)
 	}
-	sc := &sessionClient{
-		cfg:            cfg,
-		channelPool:    channelPool,
-		stub:           stub,
-		metricsFactory: metricsFactory,
-		enableDebug:    cfg.EnableDebug,
-		// Same input as the bigtable-features header built in NewClient;
-		// same inputs → identical proto (deterministic modulo the
-		// CBT_FORCE_SESSION env var, which is read at both call sites
-		// back-to-back so the header and this envelope-side proto agree).
-		featureFlagsProto: btransport.NewFeatureFlagsProto(btransport.FeatureFlagsInput{
+	// Reuse the proto NewClient built for the bigtable-features header
+	// when the caller supplied one — byte-identical header + envelope
+	// is a hard invariant (server rejects OpenSession on mismatch).
+	// Fall back to a fresh build only for the test-only entry that
+	// doesn't route through NewClient.
+	ffProto := cfg.FeatureFlagsProto
+	if ffProto == nil {
+		ffProto = btransport.NewFeatureFlagsProto(btransport.FeatureFlagsInput{
 			ClientSideMetricsEnabled: cfg.MetricsEnabled,
 			EnableDirectAccess:       true,
-		}),
-		sessionPools: make(map[poolKey]*managedSessionPool),
+		})
+	}
+	sc := &sessionClient{
+		cfg:               cfg,
+		channelPool:       channelPool,
+		stub:              stub,
+		metricsFactory:    metricsFactory,
+		enableDebug:       cfg.EnableDebug,
+		featureFlagsProto: ffProto,
+		sessionPools:      make(map[poolKey]*managedSessionPool),
 	}
 	// stub == nil only happens on the test-only newSessionClientFromParts
 	// path (unit tests wiring a fake ChannelPool without a real gRPC stub).

--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -88,13 +88,10 @@ type Config struct {
 	MetricsEnabled bool
 
 	// FeatureFlagsProto is the pre-built FeatureFlags proto stamped
-	// onto every OpenSessionRequest.Flags. When non-nil,
-	// newSessionClientFromParts stashes it directly rather than
-	// rebuilding — this is the byte-identical guarantee against the
-	// bigtable-features header (the server rejects OpenSession with
-	// INVALID_ARGUMENT if header and envelope disagree on session-mode
-	// flags). Left nil by the test-only newSessionClientFromParts
-	// callers, which fall back to reconstruction from MetricsEnabled.
+	// onto every OpenSessionRequest.Flags. Required — callers MUST
+	// populate this with the same proto they marshaled into
+	// FeatureFlagsMD so header and envelope are byte-identical (the
+	// server rejects OpenSession with INVALID_ARGUMENT on mismatch).
 	FeatureFlagsProto *btpb.FeatureFlags
 
 	// SessionLoadListener is invoked whenever the server-driven
@@ -389,25 +386,13 @@ func newSessionClientFromParts(channelPool ChannelPool, stub btpb.BigtableClient
 	if cfg.MetricsEnabled && metricsFactory != nil {
 		_ = btransport.InitializeSessionMetrics(metricsFactory.OtelMeterProvider)
 	}
-	// Reuse the proto NewClient built for the bigtable-features header
-	// when the caller supplied one — byte-identical header + envelope
-	// is a hard invariant (server rejects OpenSession on mismatch).
-	// Fall back to a fresh build only for the test-only entry that
-	// doesn't route through NewClient.
-	ffProto := cfg.FeatureFlagsProto
-	if ffProto == nil {
-		ffProto = btransport.NewFeatureFlagsProto(btransport.FeatureFlagsInput{
-			ClientSideMetricsEnabled: cfg.MetricsEnabled,
-			EnableDirectAccess:       true,
-		})
-	}
 	sc := &sessionClient{
 		cfg:               cfg,
 		channelPool:       channelPool,
 		stub:              stub,
 		metricsFactory:    metricsFactory,
 		enableDebug:       cfg.EnableDebug,
-		featureFlagsProto: ffProto,
+		featureFlagsProto: cfg.FeatureFlagsProto,
 		sessionPools:      make(map[poolKey]*managedSessionPool),
 	}
 	// stub == nil only happens on the test-only newSessionClientFromParts

--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -273,7 +273,7 @@ func NewClient(
 	ctx context.Context,
 	project, instance, appProfile string,
 	metricsProvider metrics.MetricsProvider,
-	enableDirectAccess bool,
+	featureFlagsProto *btpb.FeatureFlags,
 	opts ...option.ClientOption,
 ) (Client, error) {
 	factory, err := metrics.NewFactory(ctx, project, instance, appProfile, metricsProvider)
@@ -281,14 +281,9 @@ func NewClient(
 		return nil, fmt.Errorf("session.NewClient: metrics.NewFactory: %w", err)
 	}
 
-	// Feature-flag proto shared by the bigtable-features header AND
-	// OpenSessionRequest.Flags — build once so the header and the
-	// envelope byte-match (server rejects OpenSession with
-	// INVALID_ARGUMENT if they disagree on session-mode flags).
-	featureFlagsProto := btransport.NewFeatureFlagsProto(btransport.FeatureFlagsInput{
-		ClientSideMetricsEnabled: factory.Enabled,
-		EnableDirectAccess:       enableDirectAccess,
-	})
+	// featureFlagsProto comes pre-built from the classic client so
+	// header and envelope both derive from the same proto reference.
+	// Marshal once here for the bigtable-features header.
 	directAccessMD := btransport.MarshalFeatureFlagsMD(featureFlagsProto)
 
 	fullInstance := fmt.Sprintf("projects/%s/instances/%s", project, instance)

--- a/bigtable/internal/session/client_test.go
+++ b/bigtable/internal/session/client_test.go
@@ -82,9 +82,9 @@ func newTestClient(t *testing.T, pool ChannelPool, cfg Config) *sessionClient {
 // FeatureFlags struct — mirrors what the server does on the wire.
 func decodeFeatureFlags(t *testing.T, md metadata.MD) *btpb.FeatureFlags {
 	t.Helper()
-	vals := md.Get(featureFlagsHeaderKey)
+	vals := md.Get(btransport.FeatureFlagsHeader)
 	if len(vals) != 1 {
-		t.Fatalf("md[%q] = %v, want exactly one value", featureFlagsHeaderKey, vals)
+		t.Fatalf("md[%q] = %v, want exactly one value", btransport.FeatureFlagsHeader, vals)
 	}
 	raw, err := base64.URLEncoding.DecodeString(vals[0])
 	if err != nil {
@@ -102,7 +102,7 @@ func decodeFeatureFlags(t *testing.T, md metadata.MD) *btpb.FeatureFlags {
 // server-visible flag needs to move, break this test on purpose so
 // reviewers notice.
 func TestBuildFeatureFlagsMD_AlwaysOnBits(t *testing.T) {
-	md := buildFeatureFlagsMD(false, false, false)
+	md := btransport.MarshalFeatureFlagsMD(btransport.NewFeatureFlagsProto(btransport.FeatureFlagsInput{}))
 	ff := decodeFeatureFlags(t, md)
 	if !ff.RoutingCookie || !ff.ReverseScans || !ff.LastScannedRowResponses || !ff.SessionsCompatible || !ff.PeerInfo {
 		t.Errorf("always-on flags missing: %+v", ff)
@@ -129,7 +129,11 @@ func TestBuildFeatureFlagsMD_ReflectsToggles(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ff := decodeFeatureFlags(t, buildFeatureFlagsMD(tc.metricsEnabled, tc.disableRetryInfo, tc.directAccess))
+			ff := decodeFeatureFlags(t, btransport.MarshalFeatureFlagsMD(btransport.NewFeatureFlagsProto(btransport.FeatureFlagsInput{
+				ClientSideMetricsEnabled: tc.metricsEnabled,
+				DisableRetryInfo:         tc.disableRetryInfo,
+				EnableDirectAccess:       tc.directAccess,
+			})))
 			if ff.ClientSideMetricsEnabled != tc.wantMetrics {
 				t.Errorf("ClientSideMetricsEnabled = %v, want %v", ff.ClientSideMetricsEnabled, tc.wantMetrics)
 			}
@@ -171,7 +175,11 @@ func TestSessionClient_NameFormatters(t *testing.T) {
 // metadata: resource-prefix + request-params (with URL-escaped values +
 // app_profile_id) + merged FeatureFlagsMD.
 func TestSessionClient_PerResourceMetadata(t *testing.T) {
-	ffMD := buildFeatureFlagsMD(true, false, true)
+	ffMD := btransport.MarshalFeatureFlagsMD(btransport.NewFeatureFlagsProto(btransport.FeatureFlagsInput{
+		ClientSideMetricsEnabled: true,
+		DisableRetryInfo:         false,
+		EnableDirectAccess:       true,
+	}))
 	sc := newTestClient(t, nil, Config{
 		Project: "p", Instance: "i", AppProfile: "profile with spaces",
 		FeatureFlagsMD: ffMD,
@@ -193,7 +201,7 @@ func TestSessionClient_PerResourceMetadata(t *testing.T) {
 	if params[0] != wantParam {
 		t.Errorf("%s = %q, want %q", requestParamsHeader, params[0], wantParam)
 	}
-	if len(md.Get(featureFlagsHeaderKey)) != 1 {
+	if len(md.Get(btransport.FeatureFlagsHeader)) != 1 {
 		t.Errorf("feature-flags header missing from perResourceMetadata output: %v", md)
 	}
 }

--- a/bigtable/internal/session/client_test.go
+++ b/bigtable/internal/session/client_test.go
@@ -109,36 +109,35 @@ func TestBuildFeatureFlagsMD_AlwaysOnBits(t *testing.T) {
 	}
 }
 
-// TestBuildFeatureFlagsMD_ReflectsToggles walks the three toggle inputs
-// and asserts each maps to the right proto field, including RetryInfo's
-// inversion (input=disableRetryInfo, wire=RetryInfo).
+// TestBuildFeatureFlagsMD_ReflectsToggles walks the caller-driven
+// inputs and asserts each maps to the right proto field. RetryInfo
+// is not in the input set — it's unconditionally true on the wire.
 func TestBuildFeatureFlagsMD_ReflectsToggles(t *testing.T) {
 	tests := []struct {
-		name             string
-		metricsEnabled   bool
-		disableRetryInfo bool
-		directAccess     bool
-		wantMetrics      bool
-		wantRetryInfo    bool
-		wantDirect       bool
+		name           string
+		metricsEnabled bool
+		directAccess   bool
+		wantMetrics    bool
+		wantDirect     bool
 	}{
-		{"all-off", false, false, false, false, true /* !disable */, false},
-		{"all-on", true, true, true, true, false /* !disable */, true},
-		{"metrics-only", true, false, false, true, true, false},
-		{"direct-only", false, false, true, false, true, true},
+		{"all-off", false, false, false, false},
+		{"all-on", true, true, true, true},
+		{"metrics-only", true, false, true, false},
+		{"direct-only", false, true, false, true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ff := decodeFeatureFlags(t, btransport.MarshalFeatureFlagsMD(btransport.NewFeatureFlagsProto(btransport.FeatureFlagsInput{
 				ClientSideMetricsEnabled: tc.metricsEnabled,
-				DisableRetryInfo:         tc.disableRetryInfo,
 				EnableDirectAccess:       tc.directAccess,
 			})))
 			if ff.ClientSideMetricsEnabled != tc.wantMetrics {
 				t.Errorf("ClientSideMetricsEnabled = %v, want %v", ff.ClientSideMetricsEnabled, tc.wantMetrics)
 			}
-			if ff.RetryInfo != tc.wantRetryInfo {
-				t.Errorf("RetryInfo = %v, want %v (input disableRetryInfo=%v)", ff.RetryInfo, tc.wantRetryInfo, tc.disableRetryInfo)
+			// RetryInfo is unconditionally true — this client always
+			// honors server-attached retry hints.
+			if !ff.RetryInfo {
+				t.Errorf("RetryInfo = false, want true (unconditional)")
 			}
 			if ff.DirectAccessRequested != tc.wantDirect {
 				t.Errorf("DirectAccessRequested = %v, want %v", ff.DirectAccessRequested, tc.wantDirect)
@@ -177,7 +176,6 @@ func TestSessionClient_NameFormatters(t *testing.T) {
 func TestSessionClient_PerResourceMetadata(t *testing.T) {
 	ffMD := btransport.MarshalFeatureFlagsMD(btransport.NewFeatureFlagsProto(btransport.FeatureFlagsInput{
 		ClientSideMetricsEnabled: true,
-		DisableRetryInfo:         false,
 		EnableDirectAccess:       true,
 	}))
 	sc := newTestClient(t, nil, Config{
@@ -207,20 +205,20 @@ func TestSessionClient_PerResourceMetadata(t *testing.T) {
 }
 
 // TestSessionClient_FeatureFlags asserts featureFlags() (used to build
-// each OpenSessionRequest.Flags) reflects the config booleans, with
-// RetryInfo inverted from DisableRetryInfo.
+// each OpenSessionRequest.Flags) reflects the config booleans and
+// always ships RetryInfo=true (single source of truth in
+// NewFeatureFlagsProto).
 func TestSessionClient_FeatureFlags(t *testing.T) {
-	sc := newTestClient(t, nil, Config{MetricsEnabled: true, DisableRetryInfo: true})
+	sc := newTestClient(t, nil, Config{MetricsEnabled: true})
 	defer sc.Close()
 
 	ff := sc.featureFlags()
 	if !ff.ClientSideMetricsEnabled {
 		t.Error("ClientSideMetricsEnabled = false, want true (MetricsEnabled=true)")
 	}
-	if ff.RetryInfo {
-		t.Error("RetryInfo = true, want false (DisableRetryInfo=true)")
+	if !ff.RetryInfo {
+		t.Error("RetryInfo = false, want true (unconditional)")
 	}
-	// Always-on bits — same invariant list as buildFeatureFlagsMD.
 	if !ff.RoutingCookie || !ff.ReverseScans || !ff.LastScannedRowResponses ||
 		!ff.SessionsCompatible || !ff.PeerInfo || !ff.TrafficDirectorEnabled || !ff.DirectAccessRequested {
 		t.Errorf("always-on bits missing: %+v", ff)

--- a/bigtable/internal/session/client_test.go
+++ b/bigtable/internal/session/client_test.go
@@ -74,6 +74,12 @@ func newTestClient(t *testing.T, pool ChannelPool, cfg Config) *sessionClient {
 	if cfg.AppProfile == "" {
 		cfg.AppProfile = "test-profile"
 	}
+	if cfg.FeatureFlagsProto == nil {
+		cfg.FeatureFlagsProto = btransport.NewFeatureFlagsProto(btransport.FeatureFlagsInput{
+			ClientSideMetricsEnabled: cfg.MetricsEnabled,
+			EnableDirectAccess:       true,
+		})
+	}
 	return newSessionClientFromParts(pool, nil, newTestFactory(t), cfg)
 }
 

--- a/bigtable/internal/transport/feature_flags.go
+++ b/bigtable/internal/transport/feature_flags.go
@@ -63,10 +63,9 @@ func NewFeatureFlagsProto(in FeatureFlagsInput) *btpb.FeatureFlags {
 		ReverseScans:             true,
 		LastScannedRowResponses:  true,
 		ClientSideMetricsEnabled: in.ClientSideMetricsEnabled,
-		// RetryInfo is unconditionally advertised — this client
-		// always honors server-attached retry hints; classic and
-		// session both ship the same fixed value here so they cannot
-		// drift.
+		// RetryInfo is unconditionally advertised — this client always
+		// honors server-attached retry hints; classic and session both
+		// ship the same fixed value.
 		RetryInfo:              true,
 		TrafficDirectorEnabled: in.EnableDirectAccess,
 		DirectAccessRequested:  in.EnableDirectAccess,

--- a/bigtable/internal/transport/feature_flags.go
+++ b/bigtable/internal/transport/feature_flags.go
@@ -36,7 +36,6 @@ const FeatureFlagsHeader = "bigtable-features"
 // the two paths cannot drift.
 type FeatureFlagsInput struct {
 	ClientSideMetricsEnabled bool
-	DisableRetryInfo         bool
 	EnableDirectAccess       bool
 }
 
@@ -64,11 +63,15 @@ func NewFeatureFlagsProto(in FeatureFlagsInput) *btpb.FeatureFlags {
 		ReverseScans:             true,
 		LastScannedRowResponses:  true,
 		ClientSideMetricsEnabled: in.ClientSideMetricsEnabled,
-		RetryInfo:                !in.DisableRetryInfo,
-		TrafficDirectorEnabled:   in.EnableDirectAccess,
-		DirectAccessRequested:    in.EnableDirectAccess,
-		SessionsCompatible:       sessionsCompatible,
-		SessionsRequired:         sessionsRequired,
+		// RetryInfo is unconditionally advertised — this client
+		// always honors server-attached retry hints; classic and
+		// session both ship the same fixed value here so they cannot
+		// drift.
+		RetryInfo:              true,
+		TrafficDirectorEnabled: in.EnableDirectAccess,
+		DirectAccessRequested:  in.EnableDirectAccess,
+		SessionsCompatible:     sessionsCompatible,
+		SessionsRequired:       sessionsRequired,
 		// PeerInfo asks the server to send bigtable-peer-info sideband
 		// metadata that populates transport_type/region/zone/subzone
 		// on the per-attempt tracer.

--- a/bigtable/internal/transport/feature_flags.go
+++ b/bigtable/internal/transport/feature_flags.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"encoding/base64"
+	"os"
+	"strconv"
+
+	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
+)
+
+// FeatureFlagsHeader is the gRPC metadata key that carries the
+// base64-encoded FeatureFlags proto to the Bigtable service on every
+// request.
+const FeatureFlagsHeader = "bigtable-features"
+
+// FeatureFlagsInput bundles the per-client-path knobs used to
+// construct the FeatureFlags proto and matching bigtable-features
+// header. Both the classic and session data paths populate this
+// struct and call NewFeatureFlagsProto — single source of truth so
+// the two paths cannot drift.
+type FeatureFlagsInput struct {
+	ClientSideMetricsEnabled bool
+	DisableRetryInfo         bool
+	EnableDirectAccess       bool
+}
+
+// NewFeatureFlagsProto builds the on-wire FeatureFlags proto used by
+// both the bigtable-features gRPC header and (on the session path)
+// OpenSessionRequest.Flags. The server rejects OpenSession with
+// INVALID_ARGUMENT when the two disagree, so both must derive from
+// the same proto instance — call this once at construction and
+// share the result.
+//
+// SessionsCompatible / SessionsRequired are driven off the
+// CBT_FORCE_SESSION env var (Google-internal tri-state; server gates
+// the actual capability): unset → (true, false); "true" → (true, true);
+// "false" → (false, false). Applied uniformly across classic and
+// session paths so the header stays byte-identical on both.
+func NewFeatureFlagsProto(in FeatureFlagsInput) *btpb.FeatureFlags {
+	sessionsCompatible, sessionsRequired := true, false
+	if v, ok := os.LookupEnv("CBT_FORCE_SESSION"); ok {
+		if b, err := strconv.ParseBool(v); err == nil {
+			sessionsCompatible, sessionsRequired = b, b
+		}
+	}
+	return &btpb.FeatureFlags{
+		RoutingCookie:            true,
+		ReverseScans:             true,
+		LastScannedRowResponses:  true,
+		ClientSideMetricsEnabled: in.ClientSideMetricsEnabled,
+		RetryInfo:                !in.DisableRetryInfo,
+		TrafficDirectorEnabled:   in.EnableDirectAccess,
+		DirectAccessRequested:    in.EnableDirectAccess,
+		SessionsCompatible:       sessionsCompatible,
+		SessionsRequired:         sessionsRequired,
+		// PeerInfo asks the server to send bigtable-peer-info sideband
+		// metadata that populates transport_type/region/zone/subzone
+		// on the per-attempt tracer.
+		PeerInfo: true,
+	}
+}
+
+// MarshalFeatureFlagsMD serializes a FeatureFlags proto into the
+// base64 bigtable-features gRPC metadata attached to every RPC.
+// A marshal failure produces an empty header value — the server
+// treats that as "no client-side feature support" rather than a
+// hard error.
+func MarshalFeatureFlagsMD(ff *btpb.FeatureFlags) metadata.MD {
+	val := ""
+	if b, err := proto.Marshal(ff); err == nil {
+		val = base64.URLEncoding.EncodeToString(b)
+	}
+	return metadata.Pairs(FeatureFlagsHeader, val)
+}

--- a/bigtable/metrics_test.go
+++ b/bigtable/metrics_test.go
@@ -34,6 +34,7 @@ import (
 	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
 	metrics "cloud.google.com/go/bigtable/internal/metrics"
 	"cloud.google.com/go/bigtable/internal/metricstest"
+	btransport "cloud.google.com/go/bigtable/internal/transport"
 	"cloud.google.com/go/internal/testutil"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.opentelemetry.io/otel"
@@ -381,7 +382,7 @@ func TestNewBuiltinMetricsTracerFactory(t *testing.T) {
 			}
 
 			// Check feature flags
-			ffStrs := receivedHeader.Get(featureFlagsHeaderKey)
+			ffStrs := receivedHeader.Get(btransport.FeatureFlagsHeader)
 			if len(ffStrs) < 1 {
 				t.Errorf("Feature flags not sent by client")
 			}

--- a/bigtable/retry_test.go
+++ b/bigtable/retry_test.go
@@ -619,38 +619,6 @@ func TestRetryReverseReadRows(t *testing.T) {
 	}
 }
 
-func TestRetryOptionSelection(t *testing.T) {
-	t.Setenv("CBT_BIGTABLE_CONN_POOL", "false")
-	ctx := context.Background()
-	project := "test-project"
-	instance := "test-instance"
-
-	t.Run("DefaultRetryLogic", func(t *testing.T) {
-		client, err := NewClientWithConfig(ctx, project, instance, disableMetricsConfig)
-		if err != nil {
-			t.Fatalf("NewClientWithConfig: %v", err)
-		}
-		defer client.Close()
-
-		if client.disableRetryInfo {
-			t.Errorf("client.disableRetryInfo got: true, want: false")
-		}
-	})
-
-	t.Run("ClientOnlyRetryLogic", func(t *testing.T) {
-		t.Setenv("DISABLE_RETRY_INFO", "1")
-
-		client, err := NewClientWithConfig(ctx, project, instance, disableMetricsConfig)
-		if err != nil {
-			t.Fatalf("NewClientWithConfig: %v", err)
-		}
-		defer client.Close()
-
-		if !client.disableRetryInfo {
-			t.Errorf("client.disableRetryInfo got: false, want: true")
-		}
-	})
-}
 
 func writeReadRowsResponse(ss grpc.ServerStream, rowKeys ...string) error {
 	var chunks []*btpb.ReadRowsResponse_CellChunk

--- a/bigtable/retry_test.go
+++ b/bigtable/retry_test.go
@@ -619,7 +619,6 @@ func TestRetryReverseReadRows(t *testing.T) {
 	}
 }
 
-
 func writeReadRowsResponse(ss grpc.ServerStream, rowKeys ...string) error {
 	var chunks []*btpb.ReadRowsResponse_CellChunk
 	for _, key := range rowKeys {


### PR DESCRIPTION
> Stacked on **#20288** (\`feat/bigtable-unified-feature-flags\`). Do not merge before that lands.

## Summary

- \`NewFeatureFlagsProto\` drops the \`DisableRetryInfo\` input and hardcodes \`RetryInfo: true\` — one source of truth for both classic and session.
- Classic path (\`bigtable/client.go\`) no longer reads \`DISABLE_RETRY_INFO\`; the retry-option swap and \`Client.disableRetryInfo\` field are gone.
- Session path (\`bigtable/internal/session/client.go\`) loses \`Config.DisableRetryInfo\` and every hardcoded \`false\` at call sites.
- Classic retryer machinery is collapsed: \`clientOnlyRetryOption\` / \`clientOnlyExecuteQueryRetryOption\` deleted, \`newRetryOption\` no longer takes \`disableRetryInfo\`, \`bigtableRetryer\` no longer carries the field. \`Retry\` always consumes server-attached RetryInfo.

## Motivation

Three parallel copies of the disable-RetryInfo path drifted:
1. \`bigtable/client.go\` read \`DISABLE_RETRY_INFO=1\` from the env → \`Client.disableRetryInfo\` → \`clientOnlyRetryOption\` swap.
2. \`bigtable/internal/session/client.go\` \`Config.DisableRetryInfo\` field, hardcoded \`false\` everywhere.
3. \`NewFeatureFlagsProto\` \`DisableRetryInfo\` input threaded through to the on-wire proto.

Nothing outside the classic env-var read ever set \`disableRetryInfo=true\`. Session ignored the env — so a user opting out via \`DISABLE_RETRY_INFO=1\` still shipped \`RetryInfo=true\` from session traffic. Silent drift. Consolidating to one hardcoded \`true\` removes the drift and the dead configuration paths.

## Behavior change

Setting \`DISABLE_RETRY_INFO=1\` in the environment no longer disables RetryInfo consumption or advertising on the classic path. The client always honors server retry hints. Session behavior was already unconditionally on; classic now matches.

## Test plan

- [x] \`go build ./...\` under \`bigtable/\` clean
- [x] \`go vet ./...\` under \`bigtable/\` clean
- [x] \`go test -short -count=1 -timeout=90s ./internal/transport/ ./internal/session/\` passes
- [x] \`go test -short -count=1 -timeout=60s -run TestIntegration_SessionVRpc ./\` passes
- [x] Grep confirms no residual \`disableRetryInfo\` / \`DisableRetryInfo\` / \`clientOnlyRetryOption\` / \`DISABLE_RETRY_INFO\` references in prod or test code