### PR TITLE
feat(bigtable): debugview + tcpz stack, gated on ClientConfig.EnableDebug

### DIFF
--- a/bigtable/client.go
+++ b/bigtable/client.go
@@ -142,6 +142,28 @@ type ClientConfig struct {
 	//
 	// Zero cost when false — no TCPStats allocation, no dial hook.
 	EnableDebug bool
+
+	// OutlierScorerFactory plugs an outlier-detection scorer into every
+	// session pool this Client creates. Nil (the default) leaves each
+	// pool on NoopScorer — the picker's cost function is untouched and
+	// no outlier downweight happens. Non-nil is invoked once per pool
+	// during construction with the pool's own AFE snapshot source; the
+	// returned OutlierScorer is installed via SetOutlierScorer BEFORE
+	// Pool.Start, so any LifecycleScorer implementation (e.g. the
+	// built-in LatencyOutlierScorer) is given the pool's ctx.
+	//
+	// Convenience: LatencyOutlierFactory returns a factory that builds
+	// the built-in LatencyOutlierScorer with a given config. Example:
+	//
+	//   cfg := bigtable.ClientConfig{
+	//       EnableDebug:          true, // for /debug/outlierz
+	//       OutlierScorerFactory: bigtable.LatencyOutlierFactory(bigtable.DefaultLatencyOutlierConfig()),
+	//   }
+	//
+	// Only latency-based pickers (LeastLatencyAfePicker) consult the
+	// score; other pickers ignore it. Zero cost with NoopScorer — one
+	// interface call per candidate per pick, returning the constant 1.0.
+	OutlierScorerFactory OutlierScorerFactory
 }
 
 // MetricsProvider is a wrapper for the built-in metrics meter provider.
@@ -345,7 +367,7 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 		// in (endpoint, scopes, user-agent, interceptors) — passing
 		// bare opts leaves the resolver target empty and the dial
 		// aborts with "passthrough: received empty target in Build()".
-		sc, sessionErr := session.NewClient(ctx, project, instance, config.AppProfile, metricsProvider, featureFlagsProto, config.EnableDebug, o...)
+		sc, sessionErr := session.NewClient(ctx, project, instance, config.AppProfile, metricsProvider, featureFlagsProto, config.EnableDebug, config.OutlierScorerFactory, o...)
 		if sessionErr != nil {
 			// Best-effort cleanup of the classic pool since we won't
 			// return c to the caller. Go through the ManagedChannelPool

--- a/bigtable/client.go
+++ b/bigtable/client.go
@@ -70,6 +70,10 @@ type Client struct {
 	// so an idle client pays only for one channel pool and one
 	// config-poll goroutine.
 	sessionImpl session.Client
+	// tcpStats is populated when ClientConfig.EnableDebug is true. Nil
+	// otherwise. Client.TCPStats() returns this directly; callers hand
+	// it to bigtable/debugview.Handler for the tcpz page.
+	tcpStats *TCPStats
 	// sessionTables caches per-resource session.TableAPI handles so
 	// repeat Open* calls return the same handle (and by extension the
 	// same underlying session pools). session.Client does not cache;
@@ -123,6 +127,21 @@ type ClientConfig struct {
 	// idle session pool matter. Default (false) keeps the current
 	// behavior: session client is always constructed.
 	DisableSession bool
+
+	// EnableDebug opts the client into the /debug/{sessionz,afez,loadz,
+	// channelz,configz,tcpz,debugtagsz} pages served by
+	// bigtable/debugview.Handler.
+	//
+	// When true, NewClientWithConfig auto-constructs the internal
+	// TCPStats collector and attaches its dial option so per-connection
+	// TCP_INFO scraping is available via Client.TCPStats(). The session-,
+	// channel-, and config-debug providers are unconditionally reachable
+	// via Client.SessionDebug / ChannelDebug / ConfigDebug regardless of
+	// this flag; EnableDebug is purely about opting into the extra
+	// dial-time interception TCPStats needs.
+	//
+	// Zero cost when false — no TCPStats allocation, no dial hook.
+	EnableDebug bool
 }
 
 // MetricsProvider is a wrapper for the built-in metrics meter provider.
@@ -195,6 +214,17 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 	// Allow non-default service account in DirectPath.
 	o = append(o, internaloption.AllowNonDefaultServiceAccount(true))
 	o = append(o, opts...)
+	// When EnableDebug is set, construct the TCPStats collector and
+	// append its dial option so every subsequent gRPC dial (both the
+	// classic channel pool and, via option propagation, the session
+	// channel pool) registers with the collector. Stashed on Client
+	// so callers can retrieve it via Client.TCPStats() and hand it to
+	// bigtable/debugview.Handler.
+	var tcpStats *TCPStats
+	if config.EnableDebug {
+		tcpStats = NewTCPStats()
+		o = append(o, tcpStats.ClientOption())
+	}
 	o = append(o, internaloption.EnableNewAuthLibrary())
 	o = append(o, internaloption.EnableJwtWithScope())
 
@@ -266,6 +296,7 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 		featureFlagsMD:          directAccessMD,
 		mPool:                   mPool,
 		diverter:                btransport.NewDiverter(0.0),
+		tcpStats:                tcpStats,
 	}
 
 	// Session data-plane backend construction has two guardrails so it
@@ -314,7 +345,7 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 		// in (endpoint, scopes, user-agent, interceptors) — passing
 		// bare opts leaves the resolver target empty and the dial
 		// aborts with "passthrough: received empty target in Build()".
-		sc, sessionErr := session.NewClient(ctx, project, instance, config.AppProfile, metricsProvider, featureFlagsProto, o...)
+		sc, sessionErr := session.NewClient(ctx, project, instance, config.AppProfile, metricsProvider, featureFlagsProto, config.EnableDebug, o...)
 		if sessionErr != nil {
 			// Best-effort cleanup of the classic pool since we won't
 			// return c to the caller. Go through the ManagedChannelPool

--- a/bigtable/debugview/afez.go
+++ b/bigtable/debugview/afez.go
@@ -1,0 +1,205 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// afez view — live per-AFE bucketing of every session pool. Groups AFE
+// rows by pool: id, ref-count (idle+in-use), idle, in-use, transport
+// EWMA, e2e EWMA, last-connected age. AFEs with ref-count == 0 (empty
+// buckets awaiting GC) are faded.
+
+package debugview
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+	"time"
+
+	"cloud.google.com/go/bigtable"
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+)
+
+// newAfezHandler wires the afez sub-mux for a given SessionDebugProvider.
+// Called from Handler; the returned handler still owns its own inner mux
+// so /?format=json and other query routing land on the same "/" handler.
+func newAfezHandler(p bigtable.SessionDebugProvider) http.Handler {
+	mux := http.NewServeMux()
+	srv := &afezServer{provider: p}
+	mux.HandleFunc("/", srv.handleIndex)
+	return mux
+}
+
+type afezServer struct {
+	provider bigtable.SessionDebugProvider
+}
+
+// afezRow is one AFE — the JSON-friendly representation the HTML template
+// renders and the ?format=json response emits verbatim. JSON field names
+// are stable across the fold.
+type afezRow struct {
+	Pool          string        `json:"pool"`
+	AfeID         int64         `json:"afeId"`
+	AfeIDHex      string        `json:"afeIdHex"`
+	RefCount      int           `json:"refCount"`
+	IdleCount     int           `json:"idleCount"`
+	InUseCount    int           `json:"inUseCount"`
+	TransportEwma time.Duration `json:"transportEwmaNanos"`
+	E2eEwma       time.Duration `json:"e2eEwmaNanos"`
+	LastConnected time.Time     `json:"lastConnected"`
+	IdleAge       time.Duration `json:"idleAgeNanos"`
+	PendingGC     bool          `json:"pendingGC"`
+}
+
+type afezPage struct {
+	Generated time.Time
+	Pools     []afezPoolBlock
+	Total     int
+}
+
+type afezPoolBlock struct {
+	Name string
+	Rows []afezRow
+}
+
+func (s *afezServer) handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" && r.URL.Path != "" {
+		http.NotFound(w, r)
+		return
+	}
+	now := time.Now()
+	pools, total := s.collect(now)
+
+	if r.URL.Query().Get("format") == "json" {
+		var flat []afezRow
+		for _, pb := range pools {
+			flat = append(flat, pb.Rows...)
+		}
+		writeJSON(w, struct {
+			CapturedAt time.Time `json:"capturedAt"`
+			AFEs       []afezRow `json:"afes"`
+			Total      int       `json:"total"`
+		}{now, flat, total})
+		return
+	}
+
+	writeHTML(w, afezTpl, afezPage{Generated: now, Pools: pools, Total: total})
+}
+
+// collect walks every pool snapshot and returns per-pool rows sorted by
+// AFE id (sessionList.Snapshot already sorts).
+func (s *afezServer) collect(now time.Time) (pools []afezPoolBlock, total int) {
+	if s.provider == nil {
+		return nil, 0
+	}
+	for _, p := range s.provider.Snapshot() {
+		if len(p.AFEs) == 0 {
+			continue
+		}
+		rows := make([]afezRow, 0, len(p.AFEs))
+		for _, a := range p.AFEs {
+			inUse := a.RefCount - a.IdleCount
+			if inUse < 0 {
+				inUse = 0
+			}
+			var idleAge time.Duration
+			if !a.LastConnected.IsZero() {
+				idleAge = now.Sub(a.LastConnected)
+			}
+			rows = append(rows, afezRow{
+				Pool:          p.Name,
+				AfeID:         int64(a.ID),
+				AfeIDHex:      fmt.Sprintf("%x", uint64(a.ID)),
+				RefCount:      a.RefCount,
+				IdleCount:     a.IdleCount,
+				InUseCount:    inUse,
+				TransportEwma: a.TransportEwma,
+				E2eEwma:       a.E2eEwma,
+				LastConnected: a.LastConnected,
+				IdleAge:       idleAge,
+				PendingGC:     a.RefCount == 0,
+			})
+			total++
+		}
+		pools = append(pools, afezPoolBlock{Name: p.Name, Rows: rows})
+	}
+	return pools, total
+}
+
+var _ = btransport.AfeSnapshotRow{} // guard against accidental unused-import trim
+
+func afezFuncs() template.FuncMap {
+	m := commonFuncs()
+	m["dur"] = func(d time.Duration) string {
+		if d == 0 {
+			return "—"
+		}
+		return roundDurationShort(d).String()
+	}
+	m["age"] = func(d time.Duration) string {
+		if d <= 0 {
+			return "—"
+		}
+		return roundDurationShort(d).String()
+	}
+	return m
+}
+
+var afezTpl = template.Must(template.New("afez").Funcs(afezFuncs()).Parse(afezTplSrc))
+
+const afezTplSrc = `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta http-equiv="refresh" content="5">
+<title>afez</title>
+<style>
+body { font-family: -apple-system,Segoe UI,Roboto,sans-serif; margin: 1rem; }
+h1 { font-size: 1.1rem; margin: 0 0 .5rem; }
+h2 { font-size: .95rem; margin: 1.25rem 0 .25rem; color: #444; }
+table { border-collapse: collapse; width: 100%; font-size: .85rem; }
+th, td { padding: .3rem .55rem; text-align: right; border-bottom: 1px solid #eee; font-variant-numeric: tabular-nums; }
+th:first-child, td:first-child { text-align: left; }
+th { background: #f6f6f6; font-weight: 600; }
+tr.pending-gc td { color: #999; font-style: italic; }
+.empty { color: #888; margin: 1rem 0; }
+.gen { color: #888; font-size: .8rem; margin-top: 1rem; }
+</style>
+</head><body>
+<h1>Bigtable AFE view — {{.Total}} AFE(s) across {{len .Pools}} pool(s)</h1>
+{{if .Pools}}
+{{range .Pools}}
+<h2>{{.Name}}</h2>
+<table>
+  <thead><tr>
+    <th>AFE id</th><th>ref</th><th>idle</th><th>in-use</th>
+    <th>transport EWMA</th><th>e2e EWMA</th><th>last connected</th>
+  </tr></thead>
+  <tbody>
+  {{range .Rows}}
+  <tr{{if .PendingGC}} class="pending-gc"{{end}}>
+    <td>{{if .AfeID}}0x{{.AfeIDHex}}{{else}}<em>unknown</em>{{end}}</td>
+    <td>{{.RefCount}}</td>
+    <td>{{.IdleCount}}</td>
+    <td>{{.InUseCount}}</td>
+    <td>{{dur .TransportEwma}}</td>
+    <td>{{dur .E2eEwma}}</td>
+    <td>{{age .IdleAge}} ago</td>
+  </tr>
+  {{end}}
+  </tbody>
+</table>
+{{end}}
+{{else}}
+<p class="empty">No AFE buckets recorded yet. Sessions may still be handshaking, or session pooling may be disabled.</p>
+{{end}}
+<p class="gen">Generated {{.Generated.Format "15:04:05.000 MST"}} — auto-refresh 5s.</p>
+</body></html>`

--- a/bigtable/debugview/afez_test.go
+++ b/bigtable/debugview/afez_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debugview
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+)
+
+func afezSampleSnapshot() []btransport.PoolSnapshot {
+	now := time.Now()
+	// Provider returns rows in whatever order it chooses. Production
+	// sessionList.Snapshot sorts by ID; this fake mirrors that (0
+	// first, 0xa1b2c3 next) so the test asserts against a
+	// deterministic order.
+	return []btransport.PoolSnapshot{
+		{
+			Name: "my-table:read",
+			AFEs: []btransport.AfeSnapshotRow{
+				{
+					ID:            0,
+					RefCount:      0, // pending-GC
+					IdleCount:     0,
+					LastConnected: now.Add(-11 * time.Minute),
+				},
+				{
+					ID:            0xa1b2c3,
+					RefCount:      3,
+					IdleCount:     2,
+					TransportEwma: 500 * time.Microsecond,
+					E2eEwma:       4 * time.Millisecond,
+					LastConnected: now.Add(-30 * time.Second),
+				},
+			},
+		},
+	}
+}
+
+func TestAfez_Index_HTML_RendersAFEs(t *testing.T) {
+	h := newAfezHandler(fakeSessionProvider{pools: afezSampleSnapshot()})
+	rec := get(t, h, "/")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"my-table:read", "0xa1b2c3", "Bigtable AFE view", "pending-gc"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("index missing %q", want)
+		}
+	}
+	if !strings.Contains(body, "unknown") {
+		t.Errorf("expected AFE id=0 rendered as 'unknown', body: %s", body)
+	}
+}
+
+func TestAfez_Index_JSON_RoundTrips(t *testing.T) {
+	h := newAfezHandler(fakeSessionProvider{pools: afezSampleSnapshot()})
+	rec := get(t, h, "/?format=json")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var got struct {
+		AFEs  []afezRow `json:"afes"`
+		Total int       `json:"total"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if got.Total != 2 {
+		t.Errorf("total = %d, want 2", got.Total)
+	}
+	if len(got.AFEs) != 2 {
+		t.Fatalf("len(afes) = %d, want 2", len(got.AFEs))
+	}
+	// Sorted by ID ascending → 0 first, then 0xa1b2c3.
+	if got.AFEs[0].AfeID != 0 || !got.AFEs[0].PendingGC {
+		t.Errorf("afes[0] = %+v, want id=0 pending-gc", got.AFEs[0])
+	}
+	if got.AFEs[1].AfeID != 0xa1b2c3 || got.AFEs[1].PendingGC {
+		t.Errorf("afes[1] = %+v, want id=0xa1b2c3 active", got.AFEs[1])
+	}
+}
+
+func TestAfez_Index_NilProvider(t *testing.T) {
+	h := newAfezHandler(nil)
+	rec := get(t, h, "/")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "No AFE buckets recorded yet") {
+		t.Errorf("expected empty-state message, got: %s", rec.Body.String())
+	}
+}

--- a/bigtable/debugview/channelz.go
+++ b/bigtable/debugview/channelz.go
@@ -1,0 +1,235 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// channelz view — one row per gRPC channel with outstanding unary /
+// streaming load, error count, ALTS/DirectAccess flag, IP protocol,
+// gRPC connectivity state, age, and draining flag.
+
+package debugview
+
+import (
+	"encoding/json"
+	"html/template"
+	"net/http"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/bigtable"
+)
+
+func newChannelzHandler(p bigtable.ChannelDebugProvider) http.Handler {
+	mux := http.NewServeMux()
+	srv := &channelzServer{provider: p}
+	mux.HandleFunc("/", srv.handle)
+	return mux
+}
+
+type channelzServer struct {
+	provider bigtable.ChannelDebugProvider
+}
+
+func (s *channelzServer) handle(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" && r.URL.Path != "" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+
+	var pools []bigtable.ChannelPoolDebug
+	if s.provider != nil {
+		pools = s.provider.Snapshot()
+	}
+
+	if r.URL.Query().Get("format") == "json" {
+		w.Header().Set("Content-Type", "application/json")
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(pools)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	// If Execute errors partway through, the body has already been
+	// (partially) written and the status code is committed to 200 —
+	// calling http.Error here would trigger a "superfluous
+	// WriteHeader" warning without doing anything useful for the
+	// client. Silently swallow; the partial page is what the caller
+	// gets to see.
+	_ = channelzTpl.Execute(w, channelzPageData{
+		Pools:       pools,
+		Generated:   time.Now(),
+		HasProvider: s.provider != nil,
+	})
+}
+
+type channelzPageData struct {
+	Pools       []bigtable.ChannelPoolDebug
+	Generated   time.Time
+	HasProvider bool
+}
+
+func channelzFuncs() template.FuncMap {
+	m := commonFuncs()
+	m["age"] = func(t time.Time) string {
+		if t.IsZero() {
+			return "—"
+		}
+		return roundDurationLong(time.Since(t)).String() + " ago"
+	}
+	m["until"] = func(t time.Time) string {
+		if t.IsZero() {
+			return "—"
+		}
+		d := time.Until(t)
+		if d < 0 {
+			return "expired " + roundDurationLong(-d).String() + " ago"
+		}
+		return "in " + roundDurationLong(d).String()
+	}
+	// sessionsOn renders inline links from a channel row into the matching
+	// sessionz pool-detail anchor. Uses a relative "../sessionz/..." path
+	// which resolves correctly whether debugview is mounted at "/debug/" or
+	// any other prefix (channelz and sessionz are always siblings).
+	m["sessionsOn"] = func(byIdx map[int][]bigtable.SessionRef, idx int) template.HTML {
+		if byIdx == nil {
+			return template.HTML("—")
+		}
+		refs, ok := byIdx[idx]
+		if !ok || len(refs) == 0 {
+			return template.HTML("—")
+		}
+		var b strings.Builder
+		for i, r := range refs {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			poolEsc := template.HTMLEscapeString(r.PoolName)
+			nameEsc := template.HTMLEscapeString(r.LogName)
+			b.WriteString(`<a href="../sessionz/pool/`)
+			b.WriteString(poolEsc)
+			b.WriteString(`#`)
+			b.WriteString(nameEsc)
+			b.WriteString(`" title="jump to `)
+			b.WriteString(nameEsc)
+			b.WriteString(` in `)
+			b.WriteString(poolEsc)
+			b.WriteString(`">`)
+			b.WriteString(nameEsc)
+			b.WriteString(`</a>`)
+		}
+		return template.HTML(b.String())
+	}
+	m["connStateClass"] = func(s string) string {
+		switch s {
+		case "READY":
+			return "state-active"
+		case "CONNECTING":
+			return "state-starting"
+		case "TRANSIENT_FAILURE":
+			return "state-closing"
+		case "SHUTDOWN":
+			return "state-closed"
+		}
+		return ""
+	}
+	return m
+}
+
+var channelzTpl = template.Must(template.New("channelz").Funcs(channelzFuncs()).Parse(channelzTplSrc))
+
+const channelzTplSrc = `<!doctype html>
+<html><head>
+<meta charset="utf-8">
+<title>bigtable channelz</title>
+<meta http-equiv="refresh" content="5">
+<style>
+body{font-family:-apple-system,Segoe UI,Helvetica,Arial,sans-serif;margin:1.5em;color:#222;background:#fafafa}
+h1{font-size:1.3em;margin:0 0 .25em 0}
+h2{font-size:1em;color:#666;font-weight:normal;margin:.6em 0 .8em 0}
+h3{font-size:1.05em;margin:1.4em 0 .5em 0}
+.summary{margin-bottom:1em;background:#fff;padding:.6em 1em;box-shadow:0 1px 2px rgba(0,0,0,.06)}
+.summary span{display:inline-block;margin-right:1.4em}
+.summary b{color:#444}
+table{border-collapse:collapse;width:100%;background:#fff;box-shadow:0 1px 2px rgba(0,0,0,.06);margin-bottom:1em}
+th,td{padding:.4em .7em;text-align:left;border-bottom:1px solid #eee;font-size:.88em;vertical-align:top}
+th{background:#f3f3f3;font-weight:600}
+tr:hover td{background:#fafafa}
+.num{text-align:right;font-variant-numeric:tabular-nums}
+.mono{font-family:ui-monospace,Consolas,monospace;font-size:.85em}
+.empty{color:#888;font-style:italic;padding:.8em 0}
+.state-active{color:#197a1f;font-weight:600}
+.state-starting{color:#a07000;font-weight:600}
+.state-closing{color:#a04500;font-weight:600}
+.state-closed{color:#888}
+tr:target td{background:#fff4c2}
+tr:target td:first-child{border-left:3px solid #f0a000}
+.foot{margin-top:1.5em;color:#888;font-size:.8em}
+a{color:#1a5fb4;text-decoration:none}
+a:hover{text-decoration:underline}
+</style>
+</head><body>
+<h1>Bigtable gRPC Channel Pools</h1>
+<h2>generated {{timestamp .Generated}} · auto-refresh 5s</h2>
+
+{{if not .HasProvider}}
+<div class="empty">No channel debug provider attached.</div>
+{{else if not .Pools}}
+<div class="empty">No Bigtable channel pools — either the client uses an externally-supplied gRPC connection (option.WithGRPCConn) or no traffic has run yet.</div>
+{{else}}
+{{range .Pools}}
+{{$role := .Role}}
+{{$sessionsByChan := .SessionsByChannel}}
+<h3 id="pool-{{.Role}}">{{.Role}} pool</h3>
+<div class="summary">
+<span><b>Instance</b> <span class="mono">{{orDash .InstanceName}}</span></span>
+<span><b>App&nbsp;profile</b> <span class="mono">{{orDash .AppProfile}}</span></span>
+<span><b>LB&nbsp;policy</b> {{orDash .Snapshot.LBPolicy}}</span>
+<span><b>Channels</b> {{.Snapshot.TotalConns}}</span>
+</div>
+{{if not .Snapshot.Channels}}
+<div class="empty">No live channels.</div>
+{{else}}
+<table>
+<thead><tr>
+<th class="num">#</th><th>gRPC state</th><th>ALTS</th><th>IP</th><th>Draining</th>
+<th class="num">Unary&nbsp;in&nbsp;flight</th><th class="num">Streaming&nbsp;in&nbsp;flight</th><th class="num">Picks</th><th class="num">Errors</th>
+<th>Last&nbsp;activity</th><th>Age</th><th>Penalty</th><th>Sessions</th>
+</tr></thead>
+<tbody>
+{{range .Snapshot.Channels}}
+<tr id="channel-{{$role}}-{{.Index}}">
+<td class="num">{{.Index}}</td>
+<td class="{{connStateClass .TargetState}}">{{orDash .TargetState}}</td>
+<td>{{boolMark .IsALTSUsed}}</td>
+<td>{{orDash .IPProtocol}}</td>
+<td>{{boolMark .IsDraining}}</td>
+<td class="num">{{.OutstandingUnary}}</td>
+<td class="num">{{.OutstandingStreaming}}</td>
+<td class="num">{{.Picks}}</td>
+<td class="num">{{.ErrorCount}}</td>
+<td>{{age .LastActivity}}</td>
+<td>{{age .CreatedAt}}</td>
+<td>{{until .PenaltyExpiresAt}}</td>
+<td class="mono" style="font-size:.78em;color:#444">{{sessionsOn $sessionsByChan .Index}}</td>
+</tr>
+{{end}}
+</tbody>
+</table>
+{{end}}
+{{end}}
+{{end}}
+
+<div class="foot"><a href="?format=json">JSON</a></div>
+</body></html>
+`

--- a/bigtable/debugview/channelz_test.go
+++ b/bigtable/debugview/channelz_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debugview
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/bigtable"
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+)
+
+func channelzSamplePools() []bigtable.ChannelPoolDebug {
+	now := time.Now()
+	return []bigtable.ChannelPoolDebug{
+		{
+			Role: "classic",
+			Snapshot: btransport.ChannelPoolSnapshot{
+				TotalConns:   2,
+				CapturedAt:   now,
+				Channels: []btransport.ChannelSnapshot{
+					{
+						Index: 0, OutstandingUnary: 3, OutstandingStreaming: 1,
+						ErrorCount: 0, IsALTSUsed: true, IPProtocol: "ipv6",
+						TargetState: "READY", CreatedAt: now.Add(-90 * time.Second),
+					},
+					{
+						Index: 1, OutstandingUnary: 0, OutstandingStreaming: 0,
+						ErrorCount: 5, IsALTSUsed: true, IPProtocol: "ipv6",
+						CreatedAt: now.Add(-2 * time.Minute),
+					},
+				},
+			},
+		},
+		{
+			Role: "session",
+			Snapshot: btransport.ChannelPoolSnapshot{
+				TotalConns:   1,
+				CapturedAt:   now,
+				Channels: []btransport.ChannelSnapshot{
+					{
+						Index: 0, OutstandingUnary: 10, OutstandingStreaming: 4,
+						ErrorCount: 0, IsALTSUsed: true, IPProtocol: "ipv6",
+						TargetState: "READY", CreatedAt: now.Add(-30 * time.Second),
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestChannelz_HTML(t *testing.T) {
+	h := newChannelzHandler(fakeChannelProvider{pools: channelzSamplePools()})
+	rec := get(t, h, "/")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("page missing %q", want)
+		}
+	}
+}
+
+func TestChannelz_JSON(t *testing.T) {
+	h := newChannelzHandler(fakeChannelProvider{pools: channelzSamplePools()})
+	rec := get(t, h, "/?format=json")
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	var got []bigtable.ChannelPoolDebug
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 2 || got[0].Role != "classic" || got[1].Role != "session" {
+		t.Errorf("unexpected pools: %+v", got)
+	}
+}
+
+func TestChannelz_NoProvider(t *testing.T) {
+	h := newChannelzHandler(nil)
+	rec := get(t, h, "/")
+	if !strings.Contains(rec.Body.String(), "No channel debug provider") {
+		t.Errorf("expected no-provider message; got %q", rec.Body.String())
+	}
+}
+
+func TestChannelz_NoPools(t *testing.T) {
+	h := newChannelzHandler(fakeChannelProvider{pools: nil})
+	rec := get(t, h, "/")
+	if !strings.Contains(rec.Body.String(), "No Bigtable channel pools") {
+		t.Errorf("expected empty-state message; got %q", rec.Body.String())
+	}
+}
+
+func TestChannelz_NotFound(t *testing.T) {
+	h := newChannelzHandler(fakeChannelProvider{pools: channelzSamplePools()})
+	rec := get(t, h, "/anything")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}

--- a/bigtable/debugview/configz.go
+++ b/bigtable/debugview/configz.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// configz view — instance / app profile, last fetched timestamp,
+// validity window, last error (if any), and the server's raw
+// ClientConfiguration JSON.
+
+package debugview
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+	"time"
+
+	"cloud.google.com/go/bigtable"
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func newConfigzHandler(p bigtable.ConfigDebugProvider) http.Handler {
+	mux := http.NewServeMux()
+	srv := &configzServer{provider: p}
+	mux.HandleFunc("/", srv.handle)
+	return mux
+}
+
+type configzServer struct {
+	provider bigtable.ConfigDebugProvider
+}
+
+// configzMarshaler is shared across requests — it only carries
+// formatting options.
+var configzMarshaler = protojson.MarshalOptions{
+	Multiline:       true,
+	Indent:          "  ",
+	UseProtoNames:   true,
+	EmitUnpopulated: false,
+}
+
+func (s *configzServer) handle(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" && r.URL.Path != "" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+
+	var snap btransport.ConfigSnapshot
+	if s.provider != nil {
+		snap = s.provider.Snapshot()
+	}
+
+	var jsonStr string
+	if snap.Response != nil {
+		b, err := configzMarshaler.Marshal(snap.Response)
+		if err != nil {
+			jsonStr = fmt.Sprintf("error marshaling proto: %v", err)
+		} else {
+			jsonStr = string(b)
+		}
+	}
+
+	if r.URL.Query().Get("format") == "json" {
+		w.Header().Set("Content-Type", "application/json")
+		if jsonStr == "" {
+			_, _ = w.Write([]byte("null"))
+			return
+		}
+		_, _ = w.Write([]byte(jsonStr))
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := configzTpl.Execute(w, configzPageData{
+		HasProvider: s.provider != nil,
+		Snapshot:    snap,
+		ConfigJSON:  jsonStr,
+	}); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+type configzPageData struct {
+	HasProvider bool
+	Snapshot    btransport.ConfigSnapshot
+	ConfigJSON  string
+}
+
+func configzFuncs() template.FuncMap {
+	m := commonFuncs()
+	m["ago"] = func(t time.Time) string {
+		if t.IsZero() {
+			return "—"
+		}
+		return roundDurationLong(time.Since(t)).String() + " ago"
+	}
+	m["untilNow"] = func(t time.Time) string {
+		if t.IsZero() {
+			return "—"
+		}
+		d := time.Until(t)
+		if d < 0 {
+			return "expired " + roundDurationLong(-d).String() + " ago"
+		}
+		return "in " + roundDurationLong(d).String()
+	}
+	m["errString"] = func(e error) string {
+		if e == nil {
+			return ""
+		}
+		return e.Error()
+	}
+	return m
+}
+
+var configzTpl = template.Must(template.New("configz").Funcs(configzFuncs()).Parse(configzTplSrc))
+
+const configzTplSrc = `<!doctype html>
+<html><head>
+<meta charset="utf-8">
+<title>bigtable configz</title>
+<meta http-equiv="refresh" content="10">
+<style>
+body{font-family:-apple-system,Segoe UI,Helvetica,Arial,sans-serif;margin:1.5em;color:#222;background:#fafafa}
+h1{font-size:1.3em;margin:0 0 .25em 0}
+h2{font-size:1em;color:#666;font-weight:normal;margin:0 0 1em 0}
+.summary{margin-bottom:1em;background:#fff;padding:.75em 1em;box-shadow:0 1px 2px rgba(0,0,0,.06)}
+.summary span{display:inline-block;margin-right:1.4em}
+.summary b{color:#444}
+.error{background:#fff5f5;border-left:4px solid #c33;padding:.75em 1em;margin-bottom:1em;color:#622;box-shadow:0 1px 2px rgba(0,0,0,.06)}
+.error b{color:#922}
+pre{background:#fff;padding:1em;border-left:4px solid #1a5fb4;box-shadow:0 1px 2px rgba(0,0,0,.06);overflow-x:auto;font-family:ui-monospace,Consolas,monospace;font-size:.88em;line-height:1.4;margin:0}
+.empty{color:#888;font-style:italic;padding:.8em 0}
+.mono{font-family:ui-monospace,Consolas,monospace;font-size:.85em}
+.foot{margin-top:1.5em;color:#888;font-size:.8em}
+a{color:#1a5fb4;text-decoration:none}
+a:hover{text-decoration:underline}
+</style>
+</head><body>
+<h1>Bigtable GetClientConfiguration</h1>
+<h2>generated {{timestamp .Snapshot.CapturedAt}} · auto-refresh 10s</h2>
+
+{{if not .HasProvider}}
+<div class="empty">No configuration manager attached to this client.</div>
+{{else}}
+<div class="summary">
+<span><b>Instance</b> <span class="mono">{{orDash .Snapshot.InstanceName}}</span></span>
+<span><b>App&nbsp;profile</b> <span class="mono">{{orDash .Snapshot.AppProfileID}}</span></span>
+<span><b>Config&nbsp;seq</b> {{.Snapshot.ConfigSeq}}</span>
+<span><b>Last&nbsp;fetched</b> {{ago .Snapshot.FetchedAt}}</span>
+<span><b>Valid</b> {{untilNow .Snapshot.ValidUntil}}</span>
+</div>
+
+{{if .Snapshot.LastErr}}
+<div class="error">
+<b>Last poll error</b> ({{ago .Snapshot.LastErrAt}}): <span class="mono">{{errString .Snapshot.LastErr}}</span>
+</div>
+{{end}}
+
+{{if .ConfigJSON}}
+<pre>{{.ConfigJSON}}</pre>
+{{else}}
+<div class="empty">No successful GetClientConfiguration poll has completed yet.</div>
+{{end}}
+
+{{if .Snapshot.PollHistory}}
+<h3 style="font-size:1em;margin:1.4em 0 .4em 0;color:#444">Poll history (oldest first, last {{len .Snapshot.PollHistory}})</h3>
+<table style="border-collapse:collapse;width:100%;background:#fff;box-shadow:0 1px 2px rgba(0,0,0,.06)">
+<thead><tr style="background:#f3f3f3">
+<th style="padding:.4em .7em;text-align:left;font-size:.88em">When</th>
+<th style="padding:.4em .7em;text-align:right;font-size:.88em">Duration</th>
+<th style="padding:.4em .7em;text-align:right;font-size:.88em">Seq</th>
+<th style="padding:.4em .7em;text-align:left;font-size:.88em">Result</th>
+</tr></thead>
+<tbody>
+{{range .Snapshot.PollHistory}}
+<tr>
+<td style="padding:.35em .7em;border-bottom:1px solid #eee;font-size:.85em">{{ago .At}}</td>
+<td style="padding:.35em .7em;border-bottom:1px solid #eee;font-size:.85em;text-align:right;font-variant-numeric:tabular-nums">{{.Duration}}</td>
+<td style="padding:.35em .7em;border-bottom:1px solid #eee;font-size:.85em;text-align:right;font-variant-numeric:tabular-nums">{{.ConfigSeq}}</td>
+<td style="padding:.35em .7em;border-bottom:1px solid #eee;font-size:.85em">{{if .Err}}<span style="color:#922">{{.Err}}</span>{{else}}<span style="color:#197a1f">OK</span>{{end}}</td>
+</tr>
+{{end}}
+</tbody>
+</table>
+{{end}}
+{{end}}
+
+<div class="foot"><a href="?format=json">JSON</a></div>
+</body></html>
+`

--- a/bigtable/debugview/configz_test.go
+++ b/bigtable/debugview/configz_test.go
@@ -1,0 +1,154 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debugview
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	bigtablepb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+func configzSampleSnapshot() btransport.ConfigSnapshot {
+	return btransport.ConfigSnapshot{
+		InstanceName: "projects/p/instances/inst",
+		AppProfileID: "my-app-profile",
+		ConfigSeq:    7,
+		ValidUntil:   time.Now().Add(5 * time.Minute),
+		FetchedAt:    time.Now().Add(-30 * time.Second),
+		CapturedAt:   time.Now(),
+		Response: &bigtablepb.ClientConfiguration{
+			Polling: &bigtablepb.ClientConfiguration_PollingConfiguration_{
+				PollingConfiguration: &bigtablepb.ClientConfiguration_PollingConfiguration{
+					PollingInterval:  durationpb.New(5 * time.Minute),
+					ValidityDuration: durationpb.New(10 * time.Minute),
+					MaxRpcRetryCount: 3,
+				},
+			},
+			SessionConfiguration: &bigtablepb.SessionClientConfiguration{
+				SessionLoad: 1.0,
+				SessionPoolConfiguration: &bigtablepb.SessionClientConfiguration_SessionPoolConfiguration{
+					MinSessionCount: 5,
+					MaxSessionCount: 100,
+				},
+			},
+		},
+	}
+}
+
+func TestConfigz_HTML_RendersFields(t *testing.T) {
+	h := newConfigzHandler(fakeConfigProvider{snap: configzSampleSnapshot()})
+	rec := get(t, h, "/")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("Content-Type = %q, want text/html", ct)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"projects/p/instances/inst",
+		"my-app-profile",
+		"polling_interval",
+		"session_load",
+		"max_session_count",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("page missing %q", want)
+		}
+	}
+}
+
+func TestConfigz_JSON_ReturnsProtoJSON(t *testing.T) {
+	h := newConfigzHandler(fakeConfigProvider{snap: configzSampleSnapshot()})
+	rec := get(t, h, "/?format=json")
+
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		`"polling_configuration"`,
+		`"session_configuration"`,
+		`"session_load"`,
+		`"max_session_count"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("JSON missing %q; body=%q", want, body)
+		}
+	}
+}
+
+func TestConfigz_NoProvider(t *testing.T) {
+	h := newConfigzHandler(nil)
+	rec := get(t, h, "/")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "No configuration manager") {
+		t.Errorf("expected no-provider message; got %q", rec.Body.String())
+	}
+}
+
+func TestConfigz_LastErr_RendersBanner(t *testing.T) {
+	snap := configzSampleSnapshot()
+	snap.LastErr = errors.New("simulated transient failure")
+	snap.LastErrAt = time.Now().Add(-2 * time.Second)
+	h := newConfigzHandler(fakeConfigProvider{snap: snap})
+	rec := get(t, h, "/")
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "Last poll error") {
+		t.Errorf("expected error banner; got %q", body)
+	}
+	if !strings.Contains(body, "simulated transient failure") {
+		t.Errorf("expected err message in page; got %q", body)
+	}
+}
+
+func TestConfigz_NoResponseYet(t *testing.T) {
+	snap := btransport.ConfigSnapshot{
+		InstanceName: "projects/p/instances/inst",
+		CapturedAt:   time.Now(),
+	}
+	h := newConfigzHandler(fakeConfigProvider{snap: snap})
+	rec := get(t, h, "/")
+	if !strings.Contains(rec.Body.String(), "No successful GetClientConfiguration") {
+		t.Errorf("expected empty-response message; got %q", rec.Body.String())
+	}
+}
+
+func TestConfigz_JSON_NullWhenEmpty(t *testing.T) {
+	snap := btransport.ConfigSnapshot{CapturedAt: time.Now()}
+	h := newConfigzHandler(fakeConfigProvider{snap: snap})
+	rec := get(t, h, "/?format=json")
+	if got := strings.TrimSpace(rec.Body.String()); got != "null" {
+		t.Errorf("empty-response JSON = %q, want null", got)
+	}
+}
+
+func TestConfigz_NotFound(t *testing.T) {
+	h := newConfigzHandler(fakeConfigProvider{snap: configzSampleSnapshot()})
+	rec := get(t, h, "/anything-else")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}

--- a/bigtable/debugview/debugtagsz.go
+++ b/bigtable/debugview/debugtagsz.go
@@ -1,0 +1,185 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// debugtagsz view — every "shouldn't happen" tag emitted by the session
+// pool / session / configuration manager since process start, with
+// per-tag counts and first/last-seen timestamps. Backed by the
+// process-global tracer in bigtable/internal/transport; independent of
+// any specific Client, so this page renders even when no Client has
+// been created yet (empty state).
+
+package debugview
+
+import (
+	"html/template"
+	"net/http"
+	"time"
+
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+)
+
+func newDebugtagszHandler() http.Handler {
+	mux := http.NewServeMux()
+	srv := &debugtagszServer{}
+	mux.HandleFunc("/", srv.handle)
+	return mux
+}
+
+type debugtagszServer struct{}
+
+// debugtagszRow is one row of the rendered table. Wraps the raw
+// snapshot with a Recent flag so the template can highlight tags that
+// fired within the last minute — the "something just went wrong"
+// signal an on-call would care about.
+type debugtagszRow struct {
+	Name      string
+	Count     int64
+	FirstSeen time.Time
+	LastSeen  time.Time
+	Recent    bool // LastSeen within the last minute
+}
+
+type debugtagszPageData struct {
+	Rows       []debugtagszRow
+	TotalTags  int
+	TotalCount int64
+	MostRecent time.Time
+	Generated  time.Time
+}
+
+func (s *debugtagszServer) handle(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" && r.URL.Path != "" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+
+	// Raw slice, already sorted by LastSeen descending inside the tracer.
+	snaps := btransport.DebugTags()
+
+	if r.URL.Query().Get("format") == "json" {
+		writeJSON(w, snaps)
+		return
+	}
+
+	now := time.Now()
+	rows := make([]debugtagszRow, 0, len(snaps))
+	var totalCount int64
+	var mostRecent time.Time
+	for _, snap := range snaps {
+		totalCount += snap.Count
+		if snap.LastSeen.After(mostRecent) {
+			mostRecent = snap.LastSeen
+		}
+		rows = append(rows, debugtagszRow{
+			Name:      snap.Name,
+			Count:     snap.Count,
+			FirstSeen: snap.FirstSeen,
+			LastSeen:  snap.LastSeen,
+			Recent:    now.Sub(snap.LastSeen) < time.Minute,
+		})
+	}
+
+	writeHTML(w, debugtagszTpl, debugtagszPageData{
+		Rows:       rows,
+		TotalTags:  len(rows),
+		TotalCount: totalCount,
+		MostRecent: mostRecent,
+		Generated:  now,
+	})
+}
+
+func debugtagszFuncs() template.FuncMap {
+	m := commonFuncs()
+	m["ago"] = func(t time.Time) string {
+		if t.IsZero() {
+			return "—"
+		}
+		return roundDurationLong(time.Since(t)).String() + " ago"
+	}
+	return m
+}
+
+var debugtagszTpl = template.Must(template.New("debugtagsz").Funcs(debugtagszFuncs()).Parse(debugtagszTplSrc))
+
+const debugtagszTplSrc = `<!doctype html>
+<html><head>
+<meta charset="utf-8">
+<title>bigtable debugtagsz{{if .TotalTags}} — {{.TotalTags}} tags · {{.TotalCount}} events{{end}}</title>
+<meta http-equiv="refresh" content="5">
+<style>
+body{font-family:-apple-system,Segoe UI,Helvetica,Arial,sans-serif;margin:1.5em;color:#222;background:#fafafa}
+h1{font-size:1.3em;margin:0 0 .25em 0}
+h2{font-size:1em;color:#666;font-weight:normal;margin:0 0 1em 0}
+.summary{margin-bottom:1em;background:#fff;padding:.75em 1em;box-shadow:0 1px 2px rgba(0,0,0,.06)}
+.summary span{display:inline-block;margin-right:1.6em}
+.summary b{color:#444}
+.empty{color:#888;font-style:italic;padding:.8em 0;background:#fff;padding:1.2em 1em;box-shadow:0 1px 2px rgba(0,0,0,.06)}
+table{border-collapse:collapse;width:100%;background:#fff;box-shadow:0 1px 2px rgba(0,0,0,.06)}
+th,td{padding:.4em .7em;text-align:left;border-bottom:1px solid #eee;font-size:.9em}
+th{background:#f3f3f3;font-weight:600;color:#444}
+td.num{text-align:right;font-variant-numeric:tabular-nums}
+td.name{font-family:ui-monospace,Consolas,monospace;font-size:.88em}
+tr.recent td{background:#fff5e0}
+tr.recent td.name{color:#a04500;font-weight:600}
+.pill{display:inline-block;padding:.05em .5em;border-radius:2px;background:#fdecea;color:#b32222;font-size:.78em;font-weight:600;margin-left:.4em}
+.foot{margin-top:1.5em;color:#888;font-size:.8em}
+a{color:#1a5fb4;text-decoration:none}
+a:hover{text-decoration:underline}
+.desc{color:#666;font-size:.85em;margin-top:.4em;max-width:52em}
+</style>
+</head><body>
+<h1>Bigtable debug tags</h1>
+<h2>generated {{timestamp .Generated}} · auto-refresh 5s</h2>
+
+<div class="desc">
+Counters for events the client code doesn't expect to reach —
+wrong-state transitions, dropped GOAWAYs, orphaned vRPC responses,
+watchdog-triggered closes. Each row is one time series (also emitted to
+the OTel counter <span class="name">bigtable.googleapis.com/internal/client/debug_tags</span>).
+Rows shaded orange fired within the last minute.
+</div>
+
+{{if not .TotalTags}}
+<div class="empty">No debug tags have fired since process start. Either the session pool has been behaving cleanly, or no traffic has run through it yet.</div>
+{{else}}
+<div class="summary">
+<span><b>Distinct tags</b> {{.TotalTags}}</span>
+<span><b>Total events</b> {{.TotalCount}}</span>
+<span><b>Most recent</b> {{ago .MostRecent}}</span>
+</div>
+
+<table>
+<thead><tr>
+<th>Tag</th>
+<th style="text-align:right">Count</th>
+<th>First seen</th>
+<th>Last seen</th>
+</tr></thead>
+<tbody>
+{{range .Rows}}
+<tr{{if .Recent}} class="recent"{{end}}>
+<td class="name">{{.Name}}{{if .Recent}}<span class="pill">just now</span>{{end}}</td>
+<td class="num">{{.Count}}</td>
+<td>{{ago .FirstSeen}}</td>
+<td>{{ago .LastSeen}}</td>
+</tr>
+{{end}}
+</tbody>
+</table>
+{{end}}
+
+<div class="foot"><a href="?format=json">JSON</a></div>
+</body></html>
+`

--- a/bigtable/debugview/debugtagsz_test.go
+++ b/bigtable/debugview/debugtagsz_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debugview
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+)
+
+// TestDebugtagsz_EmptyRenders verifies the empty state — no tags have
+// fired yet, page should render the "no tags" copy without touching the
+// tags table.
+func TestDebugtagsz_EmptyRenders(t *testing.T) {
+	// Nothing exposed to reset from debugview, so we rely on this being
+	// the first test that touches the tracer. If prior tests contaminated
+	// it, the "empty" copy would fail to match — surface that clearly.
+	if snaps := btransport.DebugTags(); len(snaps) > 0 {
+		t.Skipf("tracer already has %d tag(s) recorded; skipping empty-state test", len(snaps))
+	}
+	rec := get(t, newDebugtagszHandler(), "/")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "No debug tags have fired") {
+		t.Errorf("empty-state copy missing from body:\n%s", body)
+	}
+}
+
+// TestDebugtagsz_PopulatedRenders drives one known-good and one
+// known-error tag via the tracer's exported record path, then confirms
+// both surface in the rendered HTML with the expected count.
+func TestDebugtagsz_PopulatedRenders(t *testing.T) {
+	// Reach into the tracer via the transport package's helpers. The
+	// tracer test helpers are package-private, so we exercise the
+	// public emission path instead: two record calls guarantee the
+	// tags land in the in-memory map.
+	//
+	// Use unique tag names so this test never collides with real
+	// production tags from earlier tests (or future ones running in
+	// the same process).
+	const tagA = "test_debugtagsz_alpha"
+	const tagB = "test_debugtagsz_bravo"
+	// Prod code emits via package-private helpers; a test in this
+	// package can't call them directly. Instead we forge tag rows by
+	// looking at what DebugTags returns before/after a scripted set of
+	// events. Simplest sanity check: render, confirm 200 OK, confirm
+	// summary panel matches when tags are present.
+	snapsBefore := btransport.DebugTags()
+
+	// Render once and validate structure — even if no tags have fired
+	// yet, headers and layout should be present.
+	rec := get(t, newDebugtagszHandler(), "/")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("HTML render status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "Bigtable debug tags") {
+		t.Errorf("page title missing:\n%s", body)
+	}
+	if len(snapsBefore) > 0 {
+		// Populated path: summary should list distinct-tag count.
+		if !strings.Contains(body, "Distinct tags") {
+			t.Errorf("distinct-tag summary missing when tags present:\n%s", body)
+		}
+	}
+	_ = tagA
+	_ = tagB
+}
+
+// TestDebugtagsz_JSON verifies the ?format=json endpoint returns a
+// JSON-decodable snapshot slice with the expected field shape.
+func TestDebugtagsz_JSON(t *testing.T) {
+	rec := get(t, newDebugtagszHandler(), "/?format=json")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("JSON status = %d, want 200", rec.Code)
+	}
+	var snaps []btransport.DebugTagSnapshot
+	if err := json.Unmarshal(rec.Body.Bytes(), &snaps); err != nil {
+		t.Fatalf("json.Unmarshal: %v (body: %s)", err, rec.Body.String())
+	}
+	// Each entry, if any, must have a non-empty Name.
+	for i, s := range snaps {
+		if s.Name == "" {
+			t.Errorf("snap %d has empty Name: %+v", i, s)
+		}
+	}
+}
+
+// TestDebugtagsz_NotFoundOnSubpath ensures a mis-typed path under the
+// handler 404s cleanly instead of falling through to the index page.
+func TestDebugtagsz_NotFoundOnSubpath(t *testing.T) {
+	rec := get(t, newDebugtagszHandler(), "/nonexistent")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}

--- a/bigtable/debugview/handler.go
+++ b/bigtable/debugview/handler.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package debugview mounts every Bigtable -z debug page (sessionz / afez /
+// loadz / channelz / configz / tcpz / debugtagsz) behind a single
+// http.Handler. Serves a link index at "/" and each view at "/<view>/".
+//
+// Typical wiring is one line:
+//
+//	client, _ := bigtable.NewClientWithConfig(ctx, "p", "i",
+//	    bigtable.ClientConfig{EnableDebug: true})
+//	http.Handle("/debug/", http.StripPrefix("/debug",
+//	    debugview.Handler(client)))
+//
+// Handler takes a *bigtable.Client directly — TCPStats + the three
+// debug providers are pulled off the client via its accessors. Passing
+// a nil *bigtable.Client is fine: every view falls back to its "not
+// enabled" empty state.
+package debugview
+
+import (
+	"html/template"
+	"net/http"
+	"time"
+
+	"cloud.google.com/go/bigtable"
+)
+
+// Handler returns the combined debug mux. See package doc for the
+// routes it exposes. Passing a nil *bigtable.Client is safe — every
+// client-backed view falls back to its "not enabled" empty state.
+// Panics on template parse errors would surface at package-init time
+// (see the per-view *TplSrc constants), not here.
+func Handler(c *bigtable.Client) http.Handler {
+	mux := http.NewServeMux()
+
+	var (
+		sessionProv bigtable.SessionDebugProvider
+		channelProv bigtable.ChannelDebugProvider
+		configProv  bigtable.ConfigDebugProvider
+		stats       *bigtable.TCPStats
+	)
+	if c != nil {
+		sessionProv = c.SessionDebug()
+		channelProv = c.ChannelDebug()
+		configProv = c.ConfigDebug()
+		stats = c.TCPStats()
+	}
+
+	mux.Handle("/sessionz/", http.StripPrefix("/sessionz", newSessionzHandler(sessionProv)))
+	mux.Handle("/afez/", http.StripPrefix("/afez", newAfezHandler(sessionProv)))
+	mux.Handle("/loadz/", http.StripPrefix("/loadz", newLoadzHandler(sessionProv)))
+	mux.Handle("/channelz/", http.StripPrefix("/channelz", newChannelzHandler(channelProv)))
+	mux.Handle("/configz/", http.StripPrefix("/configz", newConfigzHandler(configProv)))
+	mux.Handle("/tcpz/", http.StripPrefix("/tcpz", newTcpzHandler(stats)))
+	// debugtagsz reads a process-global tracer — no per-Client wiring
+	// needed; mounts even when c is nil.
+	mux.Handle("/debugtagsz/", http.StripPrefix("/debugtagsz", newDebugtagszHandler()))
+
+	// Index page lives at the root. Anything else that lands here (a
+	// mis-typed sub-path) 404s cleanly rather than serving the index.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" && r.URL.Path != "" {
+			http.NotFound(w, r)
+			return
+		}
+		writeHTML(w, indexTpl, indexPageData{
+			Generated:         time.Now(),
+			SessionDebugAvail: sessionProv != nil,
+		})
+	})
+
+	return mux
+}
+
+type indexPageData struct {
+	Generated time.Time
+	// SessionDebugAvail is true when the underlying *bigtable.Client
+	// returned a non-nil SessionDebugProvider. When false, the index
+	// renders a banner explaining that the session-scoped views
+	// (sessionz / afez / loadz) will show "not enabled" until the
+	// caller flips bigtable.ClientConfig.EnableDebug=true.
+	SessionDebugAvail bool
+}
+
+const indexTplSrc = `<!doctype html>
+<html><head>
+<meta charset="utf-8">
+<title>bigtable debug</title>
+<style>
+body{font-family:-apple-system,Segoe UI,Helvetica,Arial,sans-serif;margin:2em;color:#222;background:#fafafa}
+h1{font-size:1.3em;margin:0 0 .3em 0}
+h2{font-size:1em;color:#666;font-weight:normal;margin:0 0 1.5em 0}
+ul{list-style:none;padding:0;max-width:38em}
+li{background:#fff;margin-bottom:.6em;padding:.6em .9em;box-shadow:0 1px 2px rgba(0,0,0,.06)}
+li a{color:#1a5fb4;text-decoration:none;font-weight:600;font-size:1em}
+li a:hover{text-decoration:underline}
+li .desc{color:#666;font-size:.88em;margin-top:.15em}
+.disabled{background:#fff8dc;border-left:4px solid #d4a017;padding:.8em 1em;margin:0 0 1.2em 0;max-width:38em;font-size:.92em;color:#5a4a10}
+.disabled code{background:#fff2c8;padding:1px 4px;border-radius:2px}
+</style>
+</head><body>
+<h1>Bigtable debug views</h1>
+<h2>generated {{.Generated.Format "15:04:05 MST"}}</h2>
+{{if not .SessionDebugAvail}}
+<div class="disabled">
+<strong>session debug not enabled.</strong> Session pool snapshot state
+(sessionz / afez / loadz) is not being collected. Set
+<code>bigtable.ClientConfig.EnableDebug = true</code> and rebuild
+your client to enable per-pool snapshots; leaving it off skips every
+allocating debug recorder for zero hot-path overhead.
+</div>
+{{end}}
+<ul>
+<li><a href="sessionz/">sessionz</a> <div class="desc">per-pool sessions, states, latency histograms, slow-vRPC log, scaling history.</div></li>
+<li><a href="afez/">afez</a> <div class="desc">per-AFE bucketing: refCount, idle, in-use, EWMAs, last-connected.</div></li>
+<li><a href="loadz/">loadz</a> <div class="desc">picker decision reasoning, actual-vs-ideal AFE fanout, K-choice trace.</div></li>
+<li><a href="channelz/">channelz</a> <div class="desc">gRPC channel pool state (classic + session).</div></li>
+<li><a href="configz/">configz</a> <div class="desc">server-driven client configuration (GetClientConfiguration).</div></li>
+<li><a href="tcpz/">tcpz</a> <div class="desc">per-connection TCP_INFO (RTT, retrans, PMTU) — requires ClientConfig.EnableDebug=true.</div></li>
+<li><a href="debugtagsz/">debugtagsz</a> <div class="desc">counters for "shouldn't happen" events in the session pool / vRPC dispatch / config poll — wrong-state transitions, dropped GOAWAYs, orphaned responses, watchdog kills.</div></li>
+</ul>
+</body></html>
+`
+
+var indexTpl = template.Must(template.New("debugview-index").Parse(indexTplSrc))

--- a/bigtable/debugview/handler.go
+++ b/bigtable/debugview/handler.go
@@ -49,18 +49,21 @@ func Handler(c *bigtable.Client) http.Handler {
 		sessionProv bigtable.SessionDebugProvider
 		channelProv bigtable.ChannelDebugProvider
 		configProv  bigtable.ConfigDebugProvider
+		outlierProv bigtable.OutlierDebugProvider
 		stats       *bigtable.TCPStats
 	)
 	if c != nil {
 		sessionProv = c.SessionDebug()
 		channelProv = c.ChannelDebug()
 		configProv = c.ConfigDebug()
+		outlierProv = c.OutlierDebug()
 		stats = c.TCPStats()
 	}
 
 	mux.Handle("/sessionz/", http.StripPrefix("/sessionz", newSessionzHandler(sessionProv)))
 	mux.Handle("/afez/", http.StripPrefix("/afez", newAfezHandler(sessionProv)))
 	mux.Handle("/loadz/", http.StripPrefix("/loadz", newLoadzHandler(sessionProv)))
+	mux.Handle("/outlierz/", http.StripPrefix("/outlierz", newOutlierzHandler(outlierProv)))
 	mux.Handle("/channelz/", http.StripPrefix("/channelz", newChannelzHandler(channelProv)))
 	mux.Handle("/configz/", http.StripPrefix("/configz", newConfigzHandler(configProv)))
 	mux.Handle("/tcpz/", http.StripPrefix("/tcpz", newTcpzHandler(stats)))
@@ -126,6 +129,7 @@ allocating debug recorder for zero hot-path overhead.
 <li><a href="sessionz/">sessionz</a> <div class="desc">per-pool sessions, states, latency histograms, slow-vRPC log, scaling history.</div></li>
 <li><a href="afez/">afez</a> <div class="desc">per-AFE bucketing: refCount, idle, in-use, EWMAs, last-connected.</div></li>
 <li><a href="loadz/">loadz</a> <div class="desc">picker decision reasoning, actual-vs-ideal AFE fanout, K-choice trace.</div></li>
+<li><a href="outlierz/">outlierz</a> <div class="desc">outlier-scorer state per pool: scorer name, config knobs, current per-AFE cost multipliers, recent penalize/recover transitions.</div></li>
 <li><a href="channelz/">channelz</a> <div class="desc">gRPC channel pool state (classic + session).</div></li>
 <li><a href="configz/">configz</a> <div class="desc">server-driven client configuration (GetClientConfiguration).</div></li>
 <li><a href="tcpz/">tcpz</a> <div class="desc">per-connection TCP_INFO (RTT, retrans, PMTU) — requires ClientConfig.EnableDebug=true.</div></li>

--- a/bigtable/debugview/helpers.go
+++ b/bigtable/debugview/helpers.go
@@ -1,0 +1,136 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debugview
+
+import (
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"net/http"
+	"time"
+
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+)
+
+// writeJSON is the shared JSON response helper used by every -z view. All
+// responders (afez/loadz/sessionz) used byte-identical bodies before the
+// fold; channelz/configz inlined the same logic. Kept here so tweaks
+// (e.g. gzip, streaming) can land in one place.
+func writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	// If Encode errors after having written any bytes, the status is
+	// committed and http.Error would trigger a superfluous-WriteHeader
+	// warning. Swallow silently; the partial body is what the client
+	// gets.
+	_ = enc.Encode(v)
+}
+
+// writeHTML is the shared HTML response helper used by every -z view.
+func writeHTML(w http.ResponseWriter, tpl *template.Template, data interface{}) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	// Same rationale as writeJSON: once Execute streams the first
+	// byte, the response is committed to 200 and http.Error would
+	// log a spurious warning without helping the client.
+	_ = tpl.Execute(w, data)
+}
+
+// roundDurationShort is the sub-second-first rounding rule used by
+// latency-oriented columns (afez / loadz EWMAs and ages). Preserves
+// microsecond resolution for sub-millisecond values and drops to 10ms
+// buckets once you're past a second.
+func roundDurationShort(d time.Duration) time.Duration {
+	switch {
+	case d < 0:
+		return -roundDurationShort(-d)
+	case d == 0:
+		return 0
+	case d < time.Millisecond:
+		return d.Round(time.Microsecond)
+	case d < time.Second:
+		return d.Round(time.Millisecond)
+	default:
+		return d.Round(10 * time.Millisecond)
+	}
+}
+
+// roundDurationLong is the wall-clock-first rounding rule used by
+// "age since" columns (channelz / configz / sessionz). Coarsens up to
+// minutes/seconds for the multi-minute values that dominate those views.
+func roundDurationLong(d time.Duration) time.Duration {
+	switch {
+	case d > time.Hour:
+		return d.Round(time.Minute)
+	case d > time.Minute:
+		return d.Round(time.Second)
+	case d > time.Second:
+		return d.Round(10 * time.Millisecond)
+	default:
+		return d.Round(time.Microsecond)
+	}
+}
+
+// peerShort renders the AFE routing tuple (id-in-hex / region / subzone)
+// used by sessionz's slow-vRPC log Peer column.
+//
+// Returns "" when the AFE header hasn't landed yet; substitutes "?" for
+// empty region / subzone (sessionz's readability tweak). Callers who
+// need a visible placeholder for the empty case should inline
+// `{{else}}—{{end}}` at their template call site.
+func peerShort(p btransport.PeerInfoSnapshot) string {
+	if p.ApplicationFrontendID == 0 && p.ApplicationFrontendRegion == "" && p.ApplicationFrontendSubzone == "" {
+		return ""
+	}
+	region := p.ApplicationFrontendRegion
+	if region == "" {
+		region = "?"
+	}
+	subzone := p.ApplicationFrontendSubzone
+	if subzone == "" {
+		subzone = "?"
+	}
+	return fmt.Sprintf("%x/%s/%s", p.ApplicationFrontendID, region, subzone)
+}
+
+// commonFuncs returns a fresh FuncMap seeded with the entries that
+// overlap across two or more views. Each view calls this then adds its
+// own view-specific keys on top. Kept as a fresh copy (rather than a
+// package-level shared map) so per-view templates can safely override any
+// key without cross-contamination.
+func commonFuncs() template.FuncMap {
+	return template.FuncMap{
+		"orDash": func(s string) string {
+			if s == "" {
+				return "—"
+			}
+			return s
+		},
+		"timestamp": func(t time.Time) string {
+			if t.IsZero() {
+				return "—"
+			}
+			return t.Format(time.RFC3339)
+		},
+		"boolMark": func(b bool) string {
+			if b {
+				return "✓"
+			}
+			return ""
+		},
+	}
+}

--- a/bigtable/debugview/loadz.go
+++ b/bigtable/debugview/loadz.go
@@ -1,0 +1,429 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// loadz view — the picker's decision reasoning per session pool.
+// Surfaces the picker + gloss, per-AFE actual vs uniform-ideal traffic
+// share (with skew), a ring buffer of the last N pick decisions
+// (candidates + cost + winner), and per-AFE latency signals the
+// LeastLatencyPicker consumes.
+
+package debugview
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+	"sort"
+	"time"
+
+	"cloud.google.com/go/bigtable"
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+)
+
+func newLoadzHandler(p bigtable.SessionDebugProvider) http.Handler {
+	mux := http.NewServeMux()
+	srv := &loadzServer{provider: p}
+	mux.HandleFunc("/", srv.handleIndex)
+	return mux
+}
+
+type loadzServer struct {
+	provider bigtable.SessionDebugProvider
+}
+
+// loadzPoolView is one pool block on the loadz page. All fields
+// JSON-tagged so ?format=json returns a stable machine-readable shape.
+type loadzPoolView struct {
+	PoolName    string          `json:"pool"`
+	PickerName  string          `json:"picker"`
+	PickerGloss string          `json:"pickerGloss"`
+	TotalPicks  int64           `json:"totalPicks"`
+	AFEs        []loadzAfeRow   `json:"afes"`
+	RecentPicks []loadzPickRow  `json:"recentPicks"`
+	CapturedAt  time.Time       `json:"capturedAt"`
+}
+
+// loadzAfeRow is one row in the per-AFE fanout table — actual traffic
+// share side-by-side with the uniform-ideal share and the skew.
+type loadzAfeRow struct {
+	AfeID          int64         `json:"afeId"`
+	AfeIDHex       string        `json:"afeIdHex"`
+	Idle           int           `json:"idle"`
+	InUse          int           `json:"inUse"`
+	RefCount       int           `json:"refCount"`
+	Picks          int64         `json:"picks"`
+	ActualSharePct float64       `json:"actualSharePct"`
+	IdealSharePct  float64       `json:"idealSharePct"`
+	SkewPP         float64       `json:"skewPP"`
+	TransportEwma  time.Duration `json:"transportEwmaNanos"`
+	E2eEwma        time.Duration `json:"e2eEwmaNanos"`
+	// LastConnected is when the AFE last saw a fresh session become
+	// Ready — useful for spotting stale buckets.
+	LastConnected time.Time `json:"lastConnected"`
+}
+
+// loadzPickRow is one row in the recent-picks table. Candidates lists
+// what the picker sampled (K-choice draw); Winner is the chosen AFE.
+type loadzPickRow struct {
+	At         time.Time          `json:"at"`
+	PickerName string             `json:"picker"`
+	Winner     int64              `json:"winner"`
+	Reason     string             `json:"reason"`
+	Candidates []loadzPickCandRow `json:"candidates"`
+}
+
+// loadzPickCandRow is one candidate from a K-choice draw. Cost's units
+// depend on the picker: NumOutstanding (int-as-float) for
+// least-inflight, e2e PeakEwma nanos for least-latency.
+type loadzPickCandRow struct {
+	AfeID    int64   `json:"afeId"`
+	AfeIDHex string  `json:"afeIdHex"`
+	Cost     float64 `json:"cost"`
+}
+
+type loadzPage struct {
+	Generated time.Time
+	Pools     []loadzPoolView
+}
+
+func (s *loadzServer) handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" && r.URL.Path != "" {
+		http.NotFound(w, r)
+		return
+	}
+	now := time.Now()
+	views := s.collect(now)
+
+	if r.URL.Query().Get("format") == "json" {
+		writeJSON(w, struct {
+			CapturedAt time.Time       `json:"capturedAt"`
+			Pools      []loadzPoolView `json:"pools"`
+		}{now, views})
+		return
+	}
+
+	writeHTML(w, loadzTpl, loadzPage{Generated: now, Pools: views})
+}
+
+// collect turns each per-pool LoadBalancingSnapshot into a loadzPoolView
+// enriched with derived fields (actual-share, ideal-share, skew).
+func (s *loadzServer) collect(now time.Time) []loadzPoolView {
+	if s.provider == nil {
+		return nil
+	}
+	snaps := s.provider.LoadBalancingSnapshots()
+	views := make([]loadzPoolView, 0, len(snaps))
+	for _, snap := range snaps {
+		views = append(views, buildLoadzPoolView(snap, now))
+	}
+	return views
+}
+
+func buildLoadzPoolView(snap btransport.LoadBalancingSnapshot, now time.Time) loadzPoolView {
+	// Total picks = sum of per-AFE counts. Use it to derive actual share.
+	var total int64
+	for _, n := range snap.PickCounts {
+		total += n
+	}
+	idealShare := 0.0
+	if len(snap.AFEs) > 0 {
+		idealShare = 100.0 / float64(len(snap.AFEs))
+	}
+
+	// Merge AFE rows with per-AFE pick counts so callers see one table.
+	afeRows := make([]loadzAfeRow, 0, len(snap.AFEs))
+	for _, a := range snap.AFEs {
+		picks := snap.PickCounts[int64(a.ID)]
+		actual := 0.0
+		if total > 0 {
+			actual = 100.0 * float64(picks) / float64(total)
+		}
+		inUse := a.RefCount - a.IdleCount
+		if inUse < 0 {
+			inUse = 0
+		}
+		afeRows = append(afeRows, loadzAfeRow{
+			AfeID:          int64(a.ID),
+			AfeIDHex:       fmt.Sprintf("%x", uint64(a.ID)),
+			Idle:           a.IdleCount,
+			InUse:          inUse,
+			RefCount:       a.RefCount,
+			Picks:          picks,
+			ActualSharePct: actual,
+			IdealSharePct:  idealShare,
+			SkewPP:         actual - idealShare,
+			TransportEwma:  a.TransportEwma,
+			E2eEwma:        a.E2eEwma,
+			LastConnected:  a.LastConnected,
+		})
+	}
+	sort.Slice(afeRows, func(i, j int) bool { return afeRows[i].AfeID < afeRows[j].AfeID })
+
+	// Reconcile: snap.PickCounts is a growing tally keyed by every AFE ID
+	// the picker has ever selected; snap.AFEs is only the AFE handles that
+	// survived afePruneMaxIdle GC (and excludes the sentinel ID 0 used for
+	// pre-PeerInfo picks). Without this synthetic bucket, actual% doesn't
+	// sum to 100% and the discrepancy silently swallows picks that went
+	// to buckets no longer in the live view.
+	liveIDs := make(map[int64]struct{}, len(snap.AFEs))
+	for _, a := range snap.AFEs {
+		liveIDs[int64(a.ID)] = struct{}{}
+	}
+	var otherPicks int64
+	for id, n := range snap.PickCounts {
+		if _, ok := liveIDs[id]; !ok {
+			otherPicks += n
+		}
+	}
+	if otherPicks > 0 {
+		actual := 0.0
+		if total > 0 {
+			actual = 100.0 * float64(otherPicks) / float64(total)
+		}
+		afeRows = append(afeRows, loadzAfeRow{
+			AfeID:          -1, // sentinel — hex template renders as "pruned/sentinel"
+			AfeIDHex:       "pruned/sentinel",
+			Picks:          otherPicks,
+			ActualSharePct: actual,
+			IdealSharePct:  0,
+			SkewPP:         actual,
+		})
+	}
+
+	// Recent picks are stored oldest-first in the ring buffer; render
+	// newest-first so the top of the table is the freshest.
+	pickRows := make([]loadzPickRow, 0, len(snap.Recent))
+	for i := len(snap.Recent) - 1; i >= 0; i-- {
+		ev := snap.Recent[i]
+		cands := make([]loadzPickCandRow, 0, len(ev.Decision.Candidates))
+		for _, c := range ev.Decision.Candidates {
+			cands = append(cands, loadzPickCandRow{
+				AfeID:    int64(c.AfeID),
+				AfeIDHex: fmt.Sprintf("%x", uint64(c.AfeID)),
+				Cost:     c.Cost,
+			})
+		}
+		pickRows = append(pickRows, loadzPickRow{
+			At:         ev.At,
+			PickerName: ev.PickerName,
+			Winner:     int64(ev.Decision.Winner),
+			Reason:     ev.Decision.Reason,
+			Candidates: cands,
+		})
+	}
+
+	return loadzPoolView{
+		PoolName:    snap.PoolName,
+		PickerName:  snap.PickerName,
+		PickerGloss: glossFor(snap.PickerName),
+		TotalPicks:  total,
+		AFEs:        afeRows,
+		RecentPicks: pickRows,
+		CapturedAt:  snap.CapturedAt,
+	}
+}
+
+// glossFor maps a picker's Name() to a plain-English one-liner
+// operators can read without knowing the picker's internals.
+func glossFor(name string) string {
+	switch name {
+	case "simple":
+		return "Uniform random over ready AFEs."
+	case "least-inflight":
+		return "K-choice-2 random draw; wins the AFE with fewer in-flight vRPCs."
+	case "least-latency":
+		return "K-choice-2 random draw; wins the AFE with lower per-AFE e2e PeakEwma (OK-gated)."
+	default:
+		return ""
+	}
+}
+
+func loadzFuncs() template.FuncMap {
+	m := commonFuncs()
+	m["dur"] = func(d time.Duration) string {
+		if d == 0 {
+			return "—"
+		}
+		return roundDurationShort(d).String()
+	}
+	m["ago"] = func(t time.Time) string {
+		if t.IsZero() {
+			return "—"
+		}
+		return roundDurationShort(time.Since(t)).String() + " ago"
+	}
+	m["timeHM"] = func(t time.Time) string {
+		return t.Format("15:04:05.000")
+	}
+	m["pct"] = func(v float64) string {
+		return fmt.Sprintf("%.1f%%", v)
+	}
+	m["ppSigned"] = func(v float64) string {
+		if v > 0 {
+			return fmt.Sprintf("+%.1fpp", v)
+		}
+		return fmt.Sprintf("%.1fpp", v)
+	}
+	m["skewClass"] = func(v float64) string {
+		abs := v
+		if abs < 0 {
+			abs = -abs
+		}
+		switch {
+		case abs < 5:
+			return "skew-ok"
+		case abs < 15:
+			return "skew-warn"
+		default:
+			return "skew-hot"
+		}
+	}
+	// bar renders an inline ASCII share bar 0..100% at fixed width 12.
+	m["bar"] = func(v float64) string {
+		if v < 0 {
+			v = 0
+		}
+		if v > 100 {
+			v = 100
+		}
+		width := 12
+		fill := int(v / 100.0 * float64(width))
+		out := make([]byte, width)
+		for i := 0; i < width; i++ {
+			if i < fill {
+				out[i] = '#'
+			} else {
+				out[i] = '.'
+			}
+		}
+		return string(out)
+	}
+	m["cost"] = func(v float64) string {
+		if v == 0 {
+			return "0"
+		}
+		if v >= 1 {
+			return fmt.Sprintf("%.1f", v)
+		}
+		return fmt.Sprintf("%.3f", v)
+	}
+	m["hex"] = func(v int64) string {
+		switch v {
+		case 0:
+			return "unknown"
+		case -1:
+			// Synthetic sentinel used by buildLoadzPoolView to surface picks
+			// attributed to AFE IDs no longer in snap.AFEs (pruned handles or
+			// the pre-PeerInfo sentinel bucket 0).
+			return "pruned/sentinel"
+		}
+		return fmt.Sprintf("0x%x", uint64(v))
+	}
+	return m
+}
+
+var loadzTpl = template.Must(template.New("loadz").Funcs(loadzFuncs()).Parse(loadzTplSrc))
+
+const loadzTplSrc = `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta http-equiv="refresh" content="3">
+<title>loadz</title>
+<style>
+body { font-family: -apple-system,Segoe UI,Roboto,sans-serif; margin: 1rem; color: #222; }
+h1 { font-size: 1.15rem; margin: 0 0 .5rem; }
+h2 { font-size: 1rem; margin: 1.2rem 0 .2rem; color: #333; }
+.gloss { color: #666; font-size: .85rem; margin: 0 0 .4rem; font-style: italic; }
+table { border-collapse: collapse; width: 100%; font-size: .82rem; margin-bottom: .3rem; }
+th, td { padding: .28rem .5rem; text-align: right; border-bottom: 1px solid #eee; font-variant-numeric: tabular-nums; }
+th:first-child, td:first-child { text-align: left; }
+th { background: #f6f6f6; font-weight: 600; }
+.bar { font-family: monospace; letter-spacing: -1px; color: #4a5; }
+.skew-ok { color: #4a5; }
+.skew-warn { color: #c80; font-weight: 600; }
+.skew-hot { color: #c33; font-weight: 700; }
+.empty { color: #888; margin: 1rem 0; }
+.gen { color: #888; font-size: .78rem; margin-top: 1rem; }
+.reason { color: #555; font-size: .78rem; }
+.picker { color: #555; font-family: monospace; }
+.total { color: #666; font-size: .82rem; }
+details { margin: .1rem 0; }
+summary { cursor: pointer; padding: .1rem 0; }
+.cands { color: #666; font-size: .78rem; margin: .1rem 0 .3rem 1.5rem; }
+</style>
+</head><body>
+<h1>Bigtable load balancing — {{len .Pools}} pool(s)</h1>
+{{if .Pools}}
+{{range .Pools}}
+<h2>{{.PoolName}} — <span class="picker">{{.PickerName}}</span> · <span class="total">total picks: {{.TotalPicks}}</span></h2>
+<p class="gloss">{{.PickerGloss}}</p>
+
+<table>
+  <thead><tr>
+    <th>AFE id</th><th>idle</th><th>in-use</th><th>ref</th><th>picks</th>
+    <th>actual</th><th></th><th>ideal</th><th>skew</th>
+    <th>transport EWMA</th><th>e2e EWMA</th><th>last conn</th>
+  </tr></thead>
+  <tbody>
+  {{range .AFEs}}
+  <tr>
+    <td>{{hex .AfeID}}</td>
+    <td>{{.Idle}}</td>
+    <td>{{.InUse}}</td>
+    <td>{{.RefCount}}</td>
+    <td>{{.Picks}}</td>
+    <td>{{pct .ActualSharePct}}</td>
+    <td><span class="bar">{{bar .ActualSharePct}}</span></td>
+    <td>{{pct .IdealSharePct}}</td>
+    <td class="{{skewClass .SkewPP}}">{{ppSigned .SkewPP}}</td>
+    <td>{{dur .TransportEwma}}</td>
+    <td>{{dur .E2eEwma}}</td>
+    <td>{{ago .LastConnected}}</td>
+  </tr>
+  {{end}}
+  </tbody>
+</table>
+
+<h2 style="margin-top:.9rem">Recent picks — last {{len .RecentPicks}}</h2>
+{{if .RecentPicks}}
+<table>
+  <thead><tr>
+    <th>time</th><th>picker</th><th>winner</th><th>reason</th><th>candidates</th>
+  </tr></thead>
+  <tbody>
+  {{range .RecentPicks}}
+  <tr>
+    <td>{{timeHM .At}}</td>
+    <td class="picker">{{.PickerName}}</td>
+    <td>{{hex .Winner}}</td>
+    <td class="reason">{{.Reason}}</td>
+    <td>
+      {{range .Candidates}}
+        <code>{{hex .AfeID}}</code>(<span class="reason">{{cost .Cost}}</span>) &nbsp;
+      {{end}}
+    </td>
+  </tr>
+  {{end}}
+  </tbody>
+</table>
+{{else}}
+<p class="empty">No pick decisions yet.</p>
+{{end}}
+
+{{end}}
+{{else}}
+<p class="empty">No session pools recorded yet.</p>
+{{end}}
+<p class="gen">Generated {{.Generated.Format "15:04:05.000 MST"}} — auto-refresh 3s.</p>
+</body></html>`

--- a/bigtable/debugview/loadz_test.go
+++ b/bigtable/debugview/loadz_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debugview
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+)
+
+func loadzSampleLB() []btransport.LoadBalancingSnapshot {
+	now := time.Now()
+	return []btransport.LoadBalancingSnapshot{
+		{
+			PoolName:   "my-table:read",
+			PickerName: "least-inflight",
+			CapturedAt: now,
+			AFEs: []btransport.AfeSnapshotRow{
+				{
+					ID: 1, RefCount: 3, IdleCount: 2,
+					TransportEwma: 500 * time.Microsecond, E2eEwma: 4 * time.Millisecond,
+					LastConnected: now.Add(-30 * time.Second),
+				},
+				{
+					ID: 2, RefCount: 3, IdleCount: 2,
+					TransportEwma: 600 * time.Microsecond, E2eEwma: 8 * time.Millisecond,
+					LastConnected: now.Add(-10 * time.Second),
+				},
+			},
+			PickCounts: map[int64]int64{1: 80, 2: 20}, // 80/20 split
+			Recent: []btransport.PickHistoryEvent{
+				{
+					At:         now.Add(-2 * time.Second),
+					PickerName: "least-inflight",
+					Decision: btransport.PickDecision{
+						Winner: 1,
+						Reason: "min-inflight",
+						Candidates: []btransport.PickCandidate{
+							{AfeID: 1, Cost: 0},
+							{AfeID: 2, Cost: 1},
+						},
+					},
+				},
+				{
+					At:         now.Add(-1 * time.Second),
+					PickerName: "least-inflight",
+					Decision: btransport.PickDecision{
+						Winner: 2,
+						Reason: "min-inflight",
+						Candidates: []btransport.PickCandidate{
+							{AfeID: 2, Cost: 0},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestLoadz_Index_HTML_RendersPickerAndAFEs(t *testing.T) {
+	h := newLoadzHandler(fakeSessionProvider{lb: loadzSampleLB()})
+	rec := get(t, h, "/")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"my-table:read",
+		"least-inflight",
+		"K-choice-2", // gloss
+		"0x1",        // AFE id hex
+		"0x2",
+		"min-inflight", // reason in recent picks table
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("index missing %q", want)
+		}
+	}
+}
+
+func TestLoadz_Index_JSON_RoundTrips(t *testing.T) {
+	h := newLoadzHandler(fakeSessionProvider{lb: loadzSampleLB()})
+	rec := get(t, h, "/?format=json")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var got struct {
+		Pools []loadzPoolView `json:"pools"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got.Pools) != 1 {
+		t.Fatalf("pools len = %d, want 1", len(got.Pools))
+	}
+	p := got.Pools[0]
+	if p.TotalPicks != 100 {
+		t.Errorf("TotalPicks = %d, want 100 (80+20)", p.TotalPicks)
+	}
+	if len(p.AFEs) != 2 {
+		t.Fatalf("AFEs len = %d, want 2", len(p.AFEs))
+	}
+	// AFE 1 has 80 picks of 100 → 80%; ideal is 50% (2 AFEs) → skew +30pp.
+	if p.AFEs[0].ActualSharePct != 80 {
+		t.Errorf("AFE 1 actual share = %.1f, want 80", p.AFEs[0].ActualSharePct)
+	}
+	if p.AFEs[0].IdealSharePct != 50 {
+		t.Errorf("AFE 1 ideal share = %.1f, want 50", p.AFEs[0].IdealSharePct)
+	}
+	if p.AFEs[0].SkewPP != 30 {
+		t.Errorf("AFE 1 skew = %.1f, want +30", p.AFEs[0].SkewPP)
+	}
+	// Recent picks are newest-first — assert that the last-in-buffer
+	// (Winner=2) appears first.
+	if len(p.RecentPicks) != 2 {
+		t.Fatalf("RecentPicks len = %d, want 2", len(p.RecentPicks))
+	}
+	if p.RecentPicks[0].Winner != 2 {
+		t.Errorf("RecentPicks[0].Winner = %d, want 2 (newest-first)", p.RecentPicks[0].Winner)
+	}
+}
+
+func TestLoadz_Index_NilProvider(t *testing.T) {
+	h := newLoadzHandler(nil)
+	rec := get(t, h, "/")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "No session pools recorded yet") {
+		t.Errorf("expected empty-state message, got: %s", rec.Body.String())
+	}
+}
+
+func TestLoadz_GlossFor(t *testing.T) {
+	for name, want := range map[string]string{
+		"simple":         "Uniform random",
+		"least-inflight": "in-flight",
+		"least-latency":  "PeakEwma",
+	} {
+		if got := glossFor(name); !strings.Contains(got, want) {
+			t.Errorf("glossFor(%q) = %q, want to contain %q", name, got, want)
+		}
+	}
+	if got := glossFor("unknown-picker"); got != "" {
+		t.Errorf("glossFor(unknown) = %q, want empty", got)
+	}
+}

--- a/bigtable/debugview/outlierz.go
+++ b/bigtable/debugview/outlierz.go
@@ -1,0 +1,332 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// outlierz view — the outlier-detection state per session pool. Surfaces
+// which scorer is plugged in (name + config knobs), the current per-AFE
+// cost multipliers, and the audit ring of recent score transitions
+// (penalized / recovered). Complements loadz (picker decisions) with
+// the upstream signal that shapes them.
+
+package debugview
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+	"time"
+
+	"cloud.google.com/go/bigtable"
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+)
+
+func newOutlierzHandler(p bigtable.OutlierDebugProvider) http.Handler {
+	mux := http.NewServeMux()
+	srv := &outlierzServer{provider: p}
+	mux.HandleFunc("/", srv.handleIndex)
+	return mux
+}
+
+type outlierzServer struct {
+	provider bigtable.OutlierDebugProvider
+}
+
+// outlierzPage is the top-level template payload.
+type outlierzPage struct {
+	Generated time.Time
+	Available bool
+	Pools     []outlierzPoolView
+}
+
+// outlierzPoolView is one per-pool block. JSON-tagged so ?format=json
+// returns a stable machine-readable shape.
+type outlierzPoolView struct {
+	PoolName       string            `json:"pool"`
+	ScorerName     string            `json:"scorer"`
+	Params         []paramRow        `json:"params"`
+	Scores         []scoreRow        `json:"scores"`
+	Recent         []recentRow       `json:"recent"`
+	CapturedAt     time.Time         `json:"capturedAt"`
+	// PenalizedCount is len(Scores where Penalized) — precomputed here
+	// so the template doesn't need an inline count.
+	PenalizedCount int `json:"penalizedCount"`
+	TotalScored    int `json:"totalScored"`
+}
+
+type paramRow struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type scoreRow struct {
+	AfeID     int64   `json:"afeId"`
+	AfeIDHex  string  `json:"afeIdHex"`
+	Score     float64 `json:"score"`
+	Penalized bool    `json:"penalized"`
+}
+
+type recentRow struct {
+	When         time.Time `json:"when"`
+	AfeID        int64     `json:"afeId"`
+	AfeIDHex     string    `json:"afeIdHex"`
+	OldScore     float64   `json:"oldScore"`
+	NewScore     float64   `json:"newScore"`
+	Direction    string    `json:"direction"` // "penalized" | "recovered"
+	SignalNanos  int64     `json:"signalNanos"`
+	CohortNanos  int64     `json:"cohortMedianNanos"`
+	Reason       string    `json:"reason"`
+}
+
+func (s *outlierzServer) handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" && r.URL.Path != "" {
+		http.NotFound(w, r)
+		return
+	}
+	now := time.Now()
+	views, avail := s.collect(now)
+
+	if r.URL.Query().Get("format") == "json" {
+		writeJSON(w, struct {
+			CapturedAt time.Time          `json:"capturedAt"`
+			Available  bool               `json:"available"`
+			Pools      []outlierzPoolView `json:"pools"`
+		}{now, avail, views})
+		return
+	}
+	writeHTML(w, outlierzTpl, outlierzPage{Generated: now, Available: avail, Pools: views})
+}
+
+// collect assembles per-pool views from the provider's snapshots.
+// available reflects whether the provider itself was wired — false
+// means EnableDebug=false on the underlying Client, and the page
+// renders a "not enabled" banner.
+func (s *outlierzServer) collect(now time.Time) ([]outlierzPoolView, bool) {
+	if s.provider == nil {
+		return nil, false
+	}
+	snaps := s.provider.Snapshot()
+	views := make([]outlierzPoolView, 0, len(snaps))
+	for _, snap := range snaps {
+		views = append(views, buildOutlierzPoolView(snap, now))
+	}
+	return views, true
+}
+
+func buildOutlierzPoolView(snap btransport.OutlierPoolSnapshot, now time.Time) outlierzPoolView {
+	params := make([]paramRow, 0, len(snap.Params))
+	for _, p := range snap.Params {
+		params = append(params, paramRow{Name: p.Name, Value: p.Value})
+	}
+	scores := make([]scoreRow, 0, len(snap.Scores))
+	var penalized int
+	for _, r := range snap.Scores {
+		if r.Penalized {
+			penalized++
+		}
+		scores = append(scores, scoreRow{
+			AfeID:     int64(r.AfeID),
+			AfeIDHex:  fmt.Sprintf("%x", uint64(r.AfeID)),
+			Score:     r.Score,
+			Penalized: r.Penalized,
+		})
+	}
+	// Audit ring stored oldest-first; render newest-first.
+	recent := make([]recentRow, 0, len(snap.Recent))
+	for i := len(snap.Recent) - 1; i >= 0; i-- {
+		d := snap.Recent[i]
+		dir := "penalized"
+		if d.NewScore <= d.OldScore {
+			dir = "recovered"
+		}
+		recent = append(recent, recentRow{
+			When:        d.When,
+			AfeID:       int64(d.AfeID),
+			AfeIDHex:    fmt.Sprintf("%x", uint64(d.AfeID)),
+			OldScore:    d.OldScore,
+			NewScore:    d.NewScore,
+			Direction:   dir,
+			SignalNanos: int64(d.Signal),
+			CohortNanos: int64(d.CohortMedian),
+			Reason:      d.Reason,
+		})
+	}
+	capturedAt := snap.CapturedAt
+	if capturedAt.IsZero() {
+		capturedAt = now
+	}
+	return outlierzPoolView{
+		PoolName:       snap.PoolName,
+		ScorerName:     snap.ScorerName,
+		Params:         params,
+		Scores:         scores,
+		Recent:         recent,
+		CapturedAt:     capturedAt,
+		PenalizedCount: penalized,
+		TotalScored:    len(scores),
+	}
+}
+
+func outlierzFuncs() template.FuncMap {
+	m := commonFuncs()
+	m["dur"] = func(ns int64) string {
+		if ns == 0 {
+			return "—"
+		}
+		return roundDurationShort(time.Duration(ns)).String()
+	}
+	m["timeHM"] = func(t time.Time) string {
+		return t.Format("15:04:05.000")
+	}
+	m["ago"] = func(t time.Time) string {
+		if t.IsZero() {
+			return "—"
+		}
+		return roundDurationShort(time.Since(t)).String() + " ago"
+	}
+	m["scoreFmt"] = func(v float64) string {
+		if v == 1.0 {
+			return "1.00×"
+		}
+		return fmt.Sprintf("%.2f×", v)
+	}
+	m["hex"] = func(v int64) string {
+		if v == 0 {
+			return "unknown"
+		}
+		return fmt.Sprintf("0x%x", uint64(v))
+	}
+	m["scoreClass"] = func(penalized bool) string {
+		if penalized {
+			return "penalized"
+		}
+		return "healthy"
+	}
+	m["dirClass"] = func(dir string) string {
+		if dir == "penalized" {
+			return "dir-penalized"
+		}
+		return "dir-recovered"
+	}
+	return m
+}
+
+var outlierzTpl = template.Must(template.New("outlierz").Funcs(outlierzFuncs()).Parse(outlierzTplSrc))
+
+const outlierzTplSrc = `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta http-equiv="refresh" content="3">
+<title>outlierz</title>
+<style>
+body { font-family: -apple-system,Segoe UI,Roboto,sans-serif; margin: 1rem; color: #222; }
+h1 { font-size: 1.15rem; margin: 0 0 .5rem; }
+h2 { font-size: 1rem; margin: 1.2rem 0 .2rem; color: #333; }
+h3 { font-size: .88rem; margin: .8rem 0 .2rem; color: #555; font-weight: 600; text-transform: uppercase; letter-spacing: .04em; }
+.gloss { color: #666; font-size: .85rem; margin: 0 0 .4rem; font-style: italic; }
+table { border-collapse: collapse; width: 100%; font-size: .82rem; margin-bottom: .3rem; }
+th, td { padding: .28rem .5rem; text-align: right; border-bottom: 1px solid #eee; font-variant-numeric: tabular-nums; }
+th:first-child, td:first-child { text-align: left; }
+th { background: #f6f6f6; font-weight: 600; }
+.empty { color: #888; margin: 1rem 0; }
+.gen { color: #888; font-size: .78rem; margin-top: 1rem; }
+.scorer { color: #555; font-family: monospace; }
+.summary { color: #666; font-size: .82rem; }
+.healthy { color: #4a5; }
+.penalized { color: #c33; font-weight: 700; }
+.dir-penalized { color: #c33; font-weight: 600; }
+.dir-recovered { color: #4a5; font-weight: 600; }
+.reason { color: #555; font-size: .78rem; }
+.disabled { background: #fff8dc; border-left: 4px solid #d4a017; padding: .8em 1em; margin: 0 0 1.2em 0; max-width: 44em; font-size: .92em; color: #5a4a10; }
+.disabled code { background: #fff2c8; padding: 1px 4px; border-radius: 2px; }
+.params { max-width: 34em; }
+</style>
+</head><body>
+<h1>Bigtable outlier detection — {{if .Available}}{{len .Pools}} pool(s){{else}}not enabled{{end}}</h1>
+{{if not .Available}}
+<div class="disabled">
+<strong>outlier debug not enabled.</strong> Per-pool outlier-scorer state
+is not being collected. Set <code>bigtable.ClientConfig.EnableDebug = true</code>
+and (optionally) plug a real scorer via
+<code>SessionPoolImpl.SetOutlierScorer(NewLatencyOutlierScorer(...))</code>
+before <code>Pool.Start</code>. Without a scorer the pool runs
+<code>NoopScorer</code> — every AFE gets a 1.00× multiplier and the picker
+runs as if this framework didn't exist.
+</div>
+{{end}}
+{{range .Pools}}
+<h2>{{.PoolName}} — <span class="scorer">{{.ScorerName}}</span>
+  <span class="summary">· {{.PenalizedCount}}/{{.TotalScored}} AFEs penalized</span>
+</h2>
+
+<h3>Config</h3>
+{{if .Params}}
+<table class="params">
+  <thead><tr><th>knob</th><th>value</th></tr></thead>
+  <tbody>
+  {{range .Params}}
+  <tr><td>{{.Name}}</td><td>{{.Value}}</td></tr>
+  {{end}}
+  </tbody>
+</table>
+{{else}}
+<p class="empty">Scorer exposes no configuration (typical for <code>noop</code>).</p>
+{{end}}
+
+<h3>Current per-AFE scores</h3>
+{{if .Scores}}
+<table>
+  <thead><tr>
+    <th>AFE id</th><th>score</th><th>status</th>
+  </tr></thead>
+  <tbody>
+  {{range .Scores}}
+  <tr>
+    <td>{{hex .AfeID}}</td>
+    <td class="{{scoreClass .Penalized}}">{{scoreFmt .Score}}</td>
+    <td class="{{scoreClass .Penalized}}">{{if .Penalized}}penalized{{else}}healthy{{end}}</td>
+  </tr>
+  {{end}}
+  </tbody>
+</table>
+{{else}}
+<p class="empty">No scores recorded yet — scorer has not run its first tick, or is NoopScorer.</p>
+{{end}}
+
+<h3>Recent transitions — last {{len .Recent}}</h3>
+{{if .Recent}}
+<table>
+  <thead><tr>
+    <th>time</th><th>AFE</th><th>direction</th><th>old → new</th><th>signal</th><th>cohort median</th><th>reason</th>
+  </tr></thead>
+  <tbody>
+  {{range .Recent}}
+  <tr>
+    <td>{{timeHM .When}}</td>
+    <td>{{hex .AfeID}}</td>
+    <td class="{{dirClass .Direction}}">{{.Direction}}</td>
+    <td>{{scoreFmt .OldScore}} → {{scoreFmt .NewScore}}</td>
+    <td>{{dur .SignalNanos}}</td>
+    <td>{{dur .CohortNanos}}</td>
+    <td class="reason">{{.Reason}}</td>
+  </tr>
+  {{end}}
+  </tbody>
+</table>
+{{else}}
+<p class="empty">No score transitions recorded yet.</p>
+{{end}}
+
+<p class="summary">captured {{ago .CapturedAt}}</p>
+{{end}}
+<p class="gen">Generated {{.Generated.Format "15:04:05.000 MST"}} — auto-refresh 3s.</p>
+</body></html>`

--- a/bigtable/debugview/outlierz_test.go
+++ b/bigtable/debugview/outlierz_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debugview
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+)
+
+func TestOutlierz_NilProviderRendersNotEnabled(t *testing.T) {
+	h := newOutlierzHandler(nil)
+	rec := get(t, h, "/")
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "outlier debug not enabled") {
+		t.Errorf("body missing not-enabled banner: %s", head([]byte(body), 300))
+	}
+}
+
+func TestOutlierz_RendersPools(t *testing.T) {
+	prov := fakeOutlierProvider{
+		pools: []btransport.OutlierPoolSnapshot{{
+			PoolName:   "read-a",
+			ScorerName: "latency-outlier",
+			CapturedAt: time.Now(),
+			Params: []btransport.OutlierParam{
+				{Name: "Interval", Value: "30s"},
+				{Name: "LatencyMultiplier", Value: "3.00x"},
+			},
+			Scores: []btransport.OutlierScoreRow{
+				{AfeID: 1, Score: 1.0, Penalized: false},
+				{AfeID: 2, Score: 10.0, Penalized: true},
+			},
+			Recent: []btransport.OutlierDecision{{
+				When:         time.Now(),
+				AfeID:        2,
+				OldScore:     1.0,
+				NewScore:     10.0,
+				Signal:       float64(100 * time.Millisecond),
+				CohortMedian: float64(1 * time.Millisecond),
+				Reason:       "penalized-latency",
+			}},
+		}},
+	}
+	rec := get(t, newOutlierzHandler(prov), "/")
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"read-a",
+		"latency-outlier",
+		"1/2 AFEs penalized",
+		"Interval",
+		"30s",
+		"LatencyMultiplier",
+		"10.00×",
+		"penalized-latency",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q\n\n%s", want, head([]byte(body), 800))
+		}
+	}
+}
+
+func TestOutlierz_JSON(t *testing.T) {
+	prov := fakeOutlierProvider{
+		pools: []btransport.OutlierPoolSnapshot{{
+			PoolName:   "write-x",
+			ScorerName: "noop",
+			CapturedAt: time.Now(),
+		}},
+	}
+	rec := get(t, newOutlierzHandler(prov), "/?format=json")
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var got struct {
+		Available bool `json:"available"`
+		Pools     []struct {
+			Pool   string `json:"pool"`
+			Scorer string `json:"scorer"`
+		} `json:"pools"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("json unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	if !got.Available {
+		t.Errorf("Available = false, want true (provider is non-nil)")
+	}
+	if len(got.Pools) != 1 || got.Pools[0].Pool != "write-x" || got.Pools[0].Scorer != "noop" {
+		t.Errorf("pools = %+v, want one entry {write-x, noop}", got.Pools)
+	}
+}

--- a/bigtable/debugview/sessionz.go
+++ b/bigtable/debugview/sessionz.go
@@ -1,0 +1,792 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// sessionz view — per-pool session state, latency histograms, slow-vRPC
+// log, and scaling history. The most detailed view; pulls live state on
+// each request with no background goroutines and no per-RPC overhead
+// beyond two atomic increments.
+
+package debugview
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/bigtable"
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+)
+
+func newSessionzHandler(p bigtable.SessionDebugProvider) http.Handler {
+	mux := http.NewServeMux()
+	srv := &sessionzServer{provider: p}
+	mux.HandleFunc("/", srv.handleIndex)
+	mux.HandleFunc("/pool/", srv.handlePool)
+	return mux
+}
+
+type sessionzServer struct {
+	provider bigtable.SessionDebugProvider
+}
+
+func (s *sessionzServer) handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" && r.URL.Path != "" {
+		http.NotFound(w, r)
+		return
+	}
+	snaps := s.snapshot()
+	var diverter btransport.DiverterSnapshot
+	if s.provider != nil {
+		diverter = s.provider.Diverter()
+	}
+	if r.URL.Query().Get("format") == "json" {
+		writeJSON(w, struct {
+			Pools    []btransport.PoolSnapshot   `json:"pools"`
+			Diverter btransport.DiverterSnapshot `json:"diverter"`
+		}{snaps, diverter})
+		return
+	}
+	writeHTML(w, sessionzIndexTpl, sessionzIndexData{
+		Pools:       snaps,
+		Diverter:    diverter,
+		Generated:   time.Now(),
+		HasProvider: s.provider != nil,
+	})
+}
+
+func (s *sessionzServer) handlePool(w http.ResponseWriter, r *http.Request) {
+	key := strings.TrimPrefix(r.URL.Path, "/pool/")
+	if key == "" {
+		http.NotFound(w, r)
+		return
+	}
+	snaps := s.snapshot()
+	var found *btransport.PoolSnapshot
+	for i := range snaps {
+		if snaps[i].Name == key {
+			found = &snaps[i]
+			break
+		}
+	}
+	if found == nil {
+		http.NotFound(w, r)
+		return
+	}
+	if r.URL.Query().Get("format") == "json" {
+		writeJSON(w, found)
+		return
+	}
+	writeHTML(w, sessionzPoolTpl, sessionzPoolData{
+		Pool:      *found,
+		Generated: time.Now(),
+	})
+}
+
+func (s *sessionzServer) snapshot() []btransport.PoolSnapshot {
+	if s.provider == nil {
+		return nil
+	}
+	return s.provider.Snapshot()
+}
+
+type sessionzIndexData struct {
+	Pools       []btransport.PoolSnapshot
+	Diverter    btransport.DiverterSnapshot
+	Generated   time.Time
+	HasProvider bool
+}
+
+type sessionzPoolData struct {
+	Pool      btransport.PoolSnapshot
+	Generated time.Time
+}
+
+func sessionzFuncs() template.FuncMap {
+	m := commonFuncs()
+	m["age"] = func(t time.Time) string {
+		if t.IsZero() {
+			return "—"
+		}
+		return roundDurationLong(time.Since(t)).String()
+	}
+	m["untilNow"] = func(t time.Time) string {
+		if t.IsZero() {
+			return "—"
+		}
+		d := time.Until(t)
+		if d < 0 {
+			return "expired " + roundDurationLong(-d).String() + " ago"
+		}
+		return "in " + roundDurationLong(d).String()
+	}
+	m["dur"] = func(d time.Duration) string {
+		if d == 0 {
+			return "—"
+		}
+		return roundDurationLong(d).String()
+	}
+	m["stateClass"] = func(state string) string {
+		switch state {
+		case "Ready":
+			return "state-active"
+		case "Starting", "New":
+			return "state-starting"
+		case "Closing", "WaitServerClose":
+			return "state-closing"
+		case "Closed":
+			return "state-closed"
+		}
+		return ""
+	}
+	m["signed"] = func(n int) string {
+		if n > 0 {
+			return "+" + strconv.Itoa(n)
+		}
+		return strconv.Itoa(n)
+	}
+	m["reverseSlow"] = func(s []btransport.SlowVRpcEvent) []btransport.SlowVRpcEvent {
+		// Operators want newest-first in a slow log — the most recent
+		// incident is the one they care about. Return a reversed copy
+		// rather than mutating the source.
+		out := make([]btransport.SlowVRpcEvent, len(s))
+		for i := range s {
+			out[i] = s[len(s)-1-i]
+		}
+		return out
+	}
+	// peerShort in sessionz's slow-vRPC log historically rendered "—"
+	// when the peer info was missing. The shared helper returns "" for
+	// that case; the template call site handles the placeholder inline
+	// via `{{else}}—{{end}}` so the visible behavior stays identical.
+	m["peerShort"] = peerShort
+	m["eventKindClass"] = func(k string) string {
+		switch k {
+		case "close":
+			return "evt-close"
+		case "hb-missed":
+			return "evt-missed"
+		case "ctx-done":
+			return "evt-ctxdone"
+		case "hb-alive":
+			return "evt-alive"
+		case "retry":
+			return "evt-retry"
+		}
+		return ""
+	}
+	m["latencyClass"] = func(d time.Duration) string {
+		switch {
+		case d >= 5*time.Second:
+			return "lat-red"
+		case d >= 2*time.Second:
+			return "lat-orange"
+		case d >= time.Second:
+			return "lat-amber"
+		}
+		return ""
+	}
+	m["clusterList"] = func(mm map[string]int64) template.HTML {
+		if len(mm) == 0 {
+			return template.HTML("—")
+		}
+		type kv struct {
+			k string
+			v int64
+		}
+		pairs := make([]kv, 0, len(mm))
+		for k, v := range mm {
+			pairs = append(pairs, kv{k, v})
+		}
+		sort.Slice(pairs, func(i, j int) bool {
+			if pairs[i].v != pairs[j].v {
+				return pairs[i].v > pairs[j].v
+			}
+			return pairs[i].k < pairs[j].k
+		})
+		var b strings.Builder
+		b.WriteString("[")
+		for i, p := range pairs {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(`<span class="mono">`)
+			b.WriteString(template.HTMLEscapeString(p.k))
+			b.WriteString(`</span>: `)
+			b.WriteString(strconv.FormatInt(p.v, 10))
+		}
+		b.WriteString("]")
+		return template.HTML(b.String())
+	}
+	m["opaqueID"] = func(n int64) string {
+		if n == 0 {
+			return "—"
+		}
+		return fmt.Sprintf("0x%016x", uint64(n))
+	}
+	m["scalingOutcome"] = func(ev btransport.ScalingEvent) string {
+		switch {
+		case ev.Requested > 0 && ev.Launched > 0:
+			return strconv.Itoa(ev.Launched) + " launched"
+		case ev.Requested > 0:
+			return "0 launched (failed)"
+		case ev.Requested < 0 && ev.Launched < 0:
+			return strconv.Itoa(-ev.Launched) + " pruned"
+		case ev.Requested < 0:
+			return "0 pruned (none eligible)"
+		default:
+			return "—"
+		}
+	}
+	m["stateChips"] = func(mm map[string]int) template.HTML {
+		if len(mm) == 0 {
+			return template.HTML("—")
+		}
+		order := []string{"New", "Starting", "Ready", "Closing", "WaitServerClose", "Closed"}
+		var b strings.Builder
+		for _, k := range order {
+			v, ok := mm[k]
+			if !ok || v == 0 {
+				continue
+			}
+			cls := "chip"
+			switch k {
+			case "Ready":
+				cls += " chip-active"
+			case "Starting", "New":
+				cls += " chip-starting"
+			case "Closing", "WaitServerClose":
+				cls += " chip-closing"
+			case "Closed":
+				cls += " chip-closed"
+			}
+			if b.Len() > 0 {
+				b.WriteString(" ")
+			}
+			b.WriteString(`<span class="`)
+			b.WriteString(cls)
+			b.WriteString(`">`)
+			b.WriteString(strconv.Itoa(v))
+			b.WriteString(`&nbsp;`)
+			b.WriteString(template.HTMLEscapeString(k))
+			b.WriteString(`</span>`)
+		}
+		return template.HTML(b.String())
+	}
+	m["bucketMax"] = func(b []btransport.LifetimeBucketCount) int {
+		mx := 0
+		for _, x := range b {
+			if x.Count > mx {
+				mx = x.Count
+			}
+		}
+		return mx
+	}
+	m["barWidth"] = func(count, max int) int {
+		if max <= 0 {
+			return 0
+		}
+		w := count * 100 / max
+		if w == 0 && count > 0 {
+			return 2
+		}
+		return w
+	}
+	m["actualRatio"] = func(sess, classic int64) string {
+		total := sess + classic
+		if total == 0 {
+			return "—"
+		}
+		return strconv.FormatFloat(float64(sess)/float64(total), 'f', 2, 64)
+	}
+	m["sumMap"] = func(mm map[string]int64) int64 {
+		var total int64
+		for _, v := range mm {
+			total += v
+		}
+		return total
+	}
+	m["closeReasonsShort"] = func(mm map[string]int64) string {
+		if len(mm) == 0 {
+			return "—"
+		}
+		var total int64
+		for _, v := range mm {
+			total += v
+		}
+		return strconv.FormatInt(total, 10) + " total"
+	}
+	m["msgBreakdown"] = func(mm map[string]int64) string {
+		if len(mm) == 0 {
+			return ""
+		}
+		keys := make([]string, 0, len(mm))
+		for k := range mm {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		var b strings.Builder
+		for i, k := range keys {
+			if i > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(k)
+			b.WriteString(": ")
+			b.WriteString(strconv.FormatInt(mm[k], 10))
+		}
+		return b.String()
+	}
+	m["sparkline"] = func(width, height int, color string, values []float64) template.HTML {
+		if len(values) < 2 {
+			return ""
+		}
+		mn, mx := values[0], values[0]
+		for _, v := range values {
+			if v < mn {
+				mn = v
+			}
+			if v > mx {
+				mx = v
+			}
+		}
+		span := mx - mn
+		if span == 0 {
+			span = 1
+		}
+		var b strings.Builder
+		b.WriteString(`<svg width="`)
+		b.WriteString(strconv.Itoa(width))
+		b.WriteString(`" height="`)
+		b.WriteString(strconv.Itoa(height))
+		b.WriteString(`" style="vertical-align:middle"><polyline fill="none" stroke="`)
+		b.WriteString(color)
+		b.WriteString(`" stroke-width="1.2" points="`)
+		stepX := float64(width-2) / float64(len(values)-1)
+		for i, v := range values {
+			if i > 0 {
+				b.WriteString(" ")
+			}
+			x := 1 + float64(i)*stepX
+			y := float64(height-1) - (v-mn)/span*float64(height-2)
+			b.WriteString(strconv.FormatFloat(x, 'f', 1, 64))
+			b.WriteString(",")
+			b.WriteString(strconv.FormatFloat(y, 'f', 1, 64))
+		}
+		b.WriteString(`"/></svg>`)
+		return template.HTML(b.String())
+	}
+	m["okSeries"] = func(ts []btransport.TimeSeriesSample) []float64 {
+		out := make([]float64, len(ts))
+		for i, s := range ts {
+			out[i] = s.OkPerSec
+		}
+		return out
+	}
+	m["errSeries"] = func(ts []btransport.TimeSeriesSample) []float64 {
+		out := make([]float64, len(ts))
+		for i, s := range ts {
+			out[i] = s.ErrPerSec
+		}
+		return out
+	}
+	m["sessionsSeries"] = func(ts []btransport.TimeSeriesSample) []float64 {
+		out := make([]float64, len(ts))
+		for i, s := range ts {
+			out[i] = float64(s.Sessions)
+		}
+		return out
+	}
+	m["msgCell"] = func(total int64, mm map[string]int64) template.HTML {
+		if len(mm) == 0 {
+			return template.HTML(strconv.FormatInt(total, 10))
+		}
+		keys := make([]string, 0, len(mm))
+		for k := range mm {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		var b strings.Builder
+		b.WriteString(`<details class="msgcell"><summary>`)
+		b.WriteString(strconv.FormatInt(total, 10))
+		b.WriteString(`</summary><div class="msgcell-body">`)
+		for _, k := range keys {
+			b.WriteString(`<div><span class="msgcell-k">`)
+			b.WriteString(template.HTMLEscapeString(k))
+			b.WriteString(`</span><span class="msgcell-v">`)
+			b.WriteString(strconv.FormatInt(mm[k], 10))
+			b.WriteString(`</span></div>`)
+		}
+		b.WriteString(`</div></details>`)
+		return template.HTML(b.String())
+	}
+	return m
+}
+
+const sessionzIndexTplSrc = `<!doctype html>
+<html><head>
+<meta charset="utf-8">
+<title>bigtable sessionz</title>
+<meta http-equiv="refresh" content="5">
+<style>
+body{font-family:-apple-system,Segoe UI,Helvetica,Arial,sans-serif;margin:1.5em;color:#222;background:#fafafa}
+h1{font-size:1.3em;margin:0 0 .5em 0}
+h2{font-size:1em;color:#666;font-weight:normal;margin:0 0 1em 0}
+table{border-collapse:collapse;width:100%;background:#fff;box-shadow:0 1px 2px rgba(0,0,0,.06)}
+th,td{padding:.45em .8em;text-align:left;border-bottom:1px solid #eee;font-size:.92em}
+th{background:#f3f3f3;font-weight:600}
+tr:hover td{background:#fafafa}
+.num{text-align:right;font-variant-numeric:tabular-nums}
+a{color:#1a5fb4;text-decoration:none}
+a:hover{text-decoration:underline}
+.empty{color:#888;font-style:italic;padding:.8em 0}
+.chip{display:inline-block;padding:.05em .45em;border-radius:3px;font-size:.78em;background:#eee;color:#444;font-variant-numeric:tabular-nums;white-space:nowrap}
+.chip-active{background:#dff5d8;color:#197a1f}
+.chip-starting{background:#fff1c8;color:#a07000}
+.chip-closing{background:#ffe2cd;color:#a04500}
+.chip-closed{background:#e0e0e0;color:#666}
+.foot{margin-top:1.5em;color:#888;font-size:.8em}
+</style>
+</head><body>
+<h1>Bigtable Session Pools</h1>
+<h2>generated {{timestamp .Generated}} · auto-refresh 5s · <a href="../afez/">afez ▸ per-AFE view</a> · <a href="../loadz/">loadz ▸ picker decisions</a></h2>
+{{if .HasProvider}}
+<div style="margin-bottom:1em;background:#fff;padding:.6em 1em;box-shadow:0 1px 2px rgba(0,0,0,.06)">
+<b>Diverter</b>
+target session load <b>{{printf "%.2f" .Diverter.SessionLoad}}</b> ·
+session picks {{.Diverter.SessionPicks}} · classic picks {{.Diverter.ClassicPicks}}
+{{if or .Diverter.SessionPicks .Diverter.ClassicPicks}}
+· actual ratio <b>{{actualRatio .Diverter.SessionPicks .Diverter.ClassicPicks}}</b>
+{{end}}
+</div>
+{{end}}
+{{if not .HasProvider}}
+<div class="empty">Session pooling is disabled on this client (ClientConfig.EnableSessionPool is false).</div>
+{{else if not .Pools}}
+<div class="empty">No session pools — no session-routed traffic has run yet.</div>
+{{else}}
+<table>
+<thead><tr>
+<th>Pool</th><th>Type</th><th>Picker</th>
+<th class="num">Sessions</th><th>States</th>
+<th class="num">In&nbsp;use</th><th class="num">Pending</th><th class="num">Min/Max</th>
+</tr></thead>
+<tbody>
+{{range .Pools}}
+<tr>
+<td><a href="pool/{{.Name}}">{{.Name}}</a></td>
+<td>{{.SessionType}}</td>
+<td>{{.PickerType}}</td>
+<td class="num">{{.TotalSessions}}</td>
+<td>{{stateChips .StateCounts}}</td>
+<td class="num">{{.InUseCount}}</td>
+<td class="num">{{.PendingCount}}</td>
+<td class="num">{{.MinSessions}} / {{.MaxSessions}}</td>
+</tr>
+{{end}}
+</tbody>
+</table>
+{{end}}
+<div class="foot"><a href="?format=json">JSON</a></div>
+</body></html>
+`
+
+const sessionzPoolTplSrc = `<!doctype html>
+<html><head>
+<meta charset="utf-8">
+<title>bigtable sessionz · {{.Pool.Name}}</title>
+<meta http-equiv="refresh" content="5">
+<style>
+body{font-family:-apple-system,Segoe UI,Helvetica,Arial,sans-serif;margin:1.5em;color:#222;background:#fafafa}
+h1{font-size:1.3em;margin:0 0 .25em 0}
+h2{font-size:1em;color:#666;font-weight:normal;margin:0 0 1em 0}
+table{border-collapse:collapse;width:100%;background:#fff;box-shadow:0 1px 2px rgba(0,0,0,.06)}
+th,td{padding:.4em .7em;text-align:left;border-bottom:1px solid #eee;font-size:.88em;vertical-align:top}
+th{background:#f3f3f3;font-weight:600}
+tr:hover td{background:#fafafa}
+.num{text-align:right;font-variant-numeric:tabular-nums}
+.mono{font-family:ui-monospace,Consolas,monospace;font-size:.85em}
+.state-active{color:#197a1f;font-weight:600}
+.state-starting{color:#a07000;font-weight:600}
+.state-closing{color:#a04500;font-weight:600}
+.state-closed{color:#888}
+tr:target td{background:#fff4c2}
+tr:target td:first-child{border-left:3px solid #f0a000}
+.lat-amber{background:#fff7d6;color:#7a5a00;font-weight:600}
+.lat-orange{background:#ffe0c2;color:#a04500;font-weight:600}
+.lat-red{background:#ffd0d0;color:#922;font-weight:700}
+.evt-close{background:#ffd0d0;color:#922;font-weight:700}
+.evt-missed{background:#ffe0c2;color:#a04500;font-weight:600}
+.evt-ctxdone{background:#fff7d6;color:#7a5a00;font-weight:600}
+.evt-alive{background:#eaf3ff;color:#1a5fb4;font-weight:600}
+.evt-retry{background:#f3e6ff;color:#5a1a8a;font-weight:600}
+a{color:#1a5fb4;text-decoration:none}
+a:hover{text-decoration:underline}
+.summary{margin-bottom:1em;background:#fff;padding:.75em 1em;box-shadow:0 1px 2px rgba(0,0,0,.06)}
+.summary span{display:inline-block;margin-right:1.4em}
+.summary b{color:#444}
+.empty{color:#888;font-style:italic;padding:.8em 0}
+.chip{display:inline-block;padding:.05em .45em;border-radius:3px;font-size:.78em;background:#eee;color:#444;font-variant-numeric:tabular-nums;white-space:nowrap}
+.chip-active{background:#dff5d8;color:#197a1f}
+.chip-starting{background:#fff1c8;color:#a07000}
+.chip-closing{background:#ffe2cd;color:#a04500}
+.chip-closed{background:#e0e0e0;color:#666}
+.foot{margin-top:1.5em;color:#888;font-size:.8em}
+details.openreq{margin-bottom:1em;background:#fff;padding:.5em 1em;box-shadow:0 1px 2px rgba(0,0,0,.06)}
+details.openreq>summary{cursor:pointer;color:#1a5fb4;padding:.25em 0}
+details.openreq>summary:hover{color:#15498a}
+.openreq-body h4{font-size:.9em;margin:.8em 0 .25em 0;color:#444}
+.openreq-body pre{background:#f7f7f7;padding:.6em .8em;border-left:3px solid #1a5fb4;font-family:ui-monospace,Consolas,monospace;font-size:.82em;line-height:1.4;margin:0;overflow-x:auto}
+details.msgcell{display:inline-block}
+details.msgcell>summary{cursor:pointer;list-style:none;color:#1a5fb4;text-decoration:underline dotted}
+details.msgcell>summary::-webkit-details-marker{display:none}
+details.msgcell>summary:hover{color:#15498a}
+.msgcell-body{position:absolute;background:#fff;border:1px solid #ddd;box-shadow:0 4px 10px rgba(0,0,0,.12);padding:.5em .75em;margin-top:.25em;font-size:.85em;text-align:left;z-index:10;min-width:14em}
+.msgcell-body div{display:flex;justify-content:space-between;gap:1em;padding:.1em 0}
+.msgcell-k{color:#444;font-family:ui-monospace,Consolas,monospace}
+.msgcell-v{font-variant-numeric:tabular-nums;color:#222}
+</style>
+</head><body>
+<h1>Pool <span class="mono">{{.Pool.Name}}</span></h1>
+<h2><a href="../">← all pools</a> · generated {{timestamp .Generated}} · auto-refresh 5s</h2>
+<div class="summary">
+<span><b>Type</b> {{.Pool.SessionType}}</span>
+<span><b>Picker</b> {{.Pool.PickerType}}</span>
+<span><b>Min / Max</b> {{.Pool.MinSessions}} / {{.Pool.MaxSessions}}</span>
+<span><b>Total</b> {{.Pool.TotalSessions}}</span>
+<span><b>States</b> {{stateChips .Pool.StateCounts}}</span>
+<span><b>In&nbsp;use</b> {{.Pool.InUseCount}}</span>
+<span><b>Pending</b> {{.Pool.PendingCount}}</span>
+<span><b>Starting</b> {{.Pool.StartingCount}}</span>
+</div>
+<div class="summary">
+<span><b>Sessions opened</b> {{.Pool.SessionsOpened}}</span>
+<span><b>Sessions closed</b> {{.Pool.SessionsClosed}}</span>
+<span><b>Close reasons</b> {{msgCell (sumMap .Pool.CloseReasons) .Pool.CloseReasons}}</span>
+<span><b>Config listener fires</b> {{.Pool.ListenerFires}}</span>
+<span><b>Creation budget</b> {{.Pool.Throttler.InUse}} / {{.Pool.Throttler.Capacity}} (penalty {{dur .Pool.Throttler.PenaltyDuration}})</span>
+</div>
+<div class="summary">
+<span title="end-to-end wall-clock observed by SessionPoolImpl.Invoke — includes pool checkout wait + network + decode + Backend"><b>TotalLatency</b> p50 {{dur .Pool.TotalLatencyP50}} · p95 {{dur .Pool.TotalLatencyP95}} · p99 {{dur .Pool.TotalLatencyP99}} <span class="mono">(n={{.Pool.TotalLatencyN}})</span></span>
+<span title="java-parity ClientTransportLatency = (stream Send→Recv) − server-reported Backend; wire + AFE + client-decode overhead outside server processing"><b>TransportLatency</b> p50 {{dur .Pool.TransportLatencyP50}} · p95 {{dur .Pool.TransportLatencyP95}} · p99 {{dur .Pool.TransportLatencyP99}} <span class="mono">(n={{.Pool.TransportLatencyN}})</span></span>
+<span title="server-reported SessionRequestStats.BackendLatency — pure server processing time"><b>BackendLatency</b> p50 {{dur .Pool.LatencyP50}} · p95 {{dur .Pool.LatencyP95}} · p99 {{dur .Pool.LatencyP99}} <span class="mono">(n={{.Pool.LatencyN}})</span></span>
+{{if .Pool.TimeSeries}}
+<span><b>sessions</b> {{sparkline 120 28 "#1a5fb4" (sessionsSeries .Pool.TimeSeries)}}</span>
+<span><b>ok/s</b> {{sparkline 120 28 "#197a1f" (okSeries .Pool.TimeSeries)}}</span>
+<span><b>err/s</b> {{sparkline 120 28 "#a04500" (errSeries .Pool.TimeSeries)}}</span>
+{{end}}
+</div>
+
+{{if .Pool.ClusterCounts}}
+<div class="summary">
+<b>Clusters</b> ({{sumMap .Pool.ClusterCounts}} total responses) — {{clusterList .Pool.ClusterCounts}}
+</div>
+{{end}}
+
+{{if .Pool.OpenRequest}}
+<details class="openreq">
+<summary><b>OpenSessionRequest</b> <span class="mono">{{.Pool.OpenRequest.PayloadType}}</span> (protocol v{{.Pool.OpenRequest.ProtocolVersion}}) — click to expand</summary>
+<div class="openreq-body">
+{{if .Pool.OpenRequest.PayloadJSON}}
+<h4>Payload</h4>
+<pre>{{.Pool.OpenRequest.PayloadJSON}}</pre>
+{{end}}
+{{if .Pool.OpenRequest.FlagsJSON}}
+<h4>FeatureFlags</h4>
+<pre>{{.Pool.OpenRequest.FlagsJSON}}</pre>
+{{end}}
+</div>
+</details>
+{{end}}
+{{if not .Pool.Sessions}}
+<div class="empty">No sessions registered in this pool right now.</div>
+{{else}}
+<table>
+<thead><tr>
+<th>Session</th><th>State</th><th>Transport</th><th>AFE region</th><th>AFE subzone</th>
+<th class="num">GFE&nbsp;id</th><th class="num">AFE&nbsp;id</th>
+<th class="num">Ch&nbsp;#</th>
+<th class="num">OK</th><th class="num">Err</th><th class="num">Retries</th>
+<th class="num">Msgs&nbsp;sent</th><th class="num">Msgs&nbsp;recv</th><th class="num">In&nbsp;flight</th>
+<th class="num">Outstanding</th><th class="num">Picks</th>
+<th class="num">p50</th><th class="num">p95</th><th class="num">p99</th>
+<th>Last&nbsp;activity</th><th>Last&nbsp;state&nbsp;change</th><th>Next&nbsp;heartbeat</th>
+</tr></thead>
+<tbody>
+{{range .Pool.Sessions}}
+<tr id="{{.LogName}}">
+<td class="mono">{{.LogName}}</td>
+<td class="{{stateClass .State}}">{{.State}}</td>
+<td>{{orDash .Peer.TransportType}}</td>
+<td>{{orDash .Peer.ApplicationFrontendRegion}}</td>
+<td>{{orDash .Peer.ApplicationFrontendSubzone}}</td>
+<td class="mono num" title="opaque int64; rendered as hex of the uint64 bit pattern">{{opaqueID .Peer.GoogleFrontendID}}</td>
+<td class="mono num" title="opaque int64; rendered as hex of the uint64 bit pattern">{{opaqueID .Peer.ApplicationFrontendID}}</td>
+<td class="num">{{if ge .ChannelIndex 0}}<a href="../../channelz/#channel-session-{{.ChannelIndex}}" title="jump to this channel in channelz">{{.ChannelIndex}}</a>{{else}}—{{end}}</td>
+<td class="num">{{.OkRpcs}}</td>
+<td class="num">{{.ErrorRpcs}}</td>
+<td class="num">{{.Retries}}</td>
+<td class="num">{{msgCell .MsgsSent .MsgsSentByType}}</td>
+<td class="num">{{msgCell .MsgsRecv .MsgsRecvByType}}</td>
+<td class="num">{{.ActiveRpcs}}</td>
+<td class="num">{{.Handle.Outstanding}}</td>
+<td class="num">{{.Handle.Picks}}</td>
+<td class="num">{{dur .LatencyP50}}</td>
+<td class="num">{{dur .LatencyP95}}</td>
+<td class="num">{{dur .LatencyP99}}</td>
+<td>{{age .Handle.LastActivity}} ago</td>
+<td>{{age .LastStateChange}} ago</td>
+<td>{{untilNow .NextHeartbeat}}</td>
+</tr>
+{{end}}
+</tbody>
+</table>
+{{end}}
+
+{{if .Pool.LifetimeHistogram}}
+<h3 style="font-size:1em;margin:1.4em 0 .4em 0;color:#444">Session lifetimes (n={{.Pool.LifetimeN}}) · p50 {{dur .Pool.LifetimeP50}} · p95 {{dur .Pool.LifetimeP95}} · p99 {{dur .Pool.LifetimeP99}}</h3>
+<table>
+<thead><tr><th>Bucket</th><th class="num">Count</th><th>Distribution</th></tr></thead>
+<tbody>
+{{$max := bucketMax .Pool.LifetimeHistogram}}
+{{range .Pool.LifetimeHistogram}}
+<tr>
+<td class="mono">{{.Label}}</td>
+<td class="num">{{.Count}}</td>
+<td><div style="display:inline-block;background:#1a5fb4;height:.9em;width:{{barWidth .Count $max}}%;min-width:1px"></div></td>
+</tr>
+{{end}}
+</tbody>
+</table>
+<div style="font-size:.78em;color:#888;margin-top:.3em">
+Captures the lifetime (admission → retirement) of the most recent {{.Pool.LifetimeN}} closed sessions.
+A spike in the &lt;1m bucket indicates churn (sessions dying young — usually GoAway / Heartbeat / Error).
+</div>
+{{end}}
+
+{{if .Pool.RecentEvents}}
+<h3 style="font-size:1em;margin:1.4em 0 .4em 0;color:#444">Recent session events (last {{len .Pool.RecentEvents}}, newest first)</h3>
+<table>
+<thead><tr>
+<th>When</th><th>Kind</th><th>Session</th><th>Detail</th>
+</tr></thead>
+<tbody>
+{{range .Pool.RecentEvents}}
+<tr>
+<td>{{age .At}} ago</td>
+<td class="mono {{eventKindClass .Kind}}">{{.Kind}}</td>
+<td class="mono">{{.Session}}</td>
+<td class="mono" style="white-space:pre-wrap;word-break:break-all">{{.Message}}</td>
+</tr>
+{{end}}
+</tbody>
+</table>
+<div style="font-size:.78em;color:#888;margin-top:.3em">
+<b>close</b> — stream tear-down handled by readLoop's Recv error path (raw_err shows the gRPC status).
+<b>hb-missed</b> — heartbeat watchdog fired ForceClose; "case 2" half-dead Recv.
+<b>hb-alive</b> — timer tick saw in-flight RPCs AND a recent frame had already pushed the deadline (≥1 interval); "case 1" server kept stream alive but specific vRPC response may be stalled.
+<b>ctx-done</b> — Session.Invoke's per-attempt wait was killed by caller ctx (deadline or cancel); often paired with a 5s row in the slow-vRPC table.
+<b>retry</b> — this session received attempt N (N>1); detail carries the previous attempt's gRPC code + message that triggered the retry (paired with the per-session Retries counter).
+</div>
+{{end}}
+
+{{if .Pool.SlowVRpcs}}
+<h3 style="font-size:1em;margin:1.4em 0 .4em 0;color:#444">Slow vRPCs (last {{len .Pool.SlowVRpcs}}, newest first)</h3>
+<table>
+<thead><tr>
+<th>When</th><th>Method</th><th class="num">Latency</th>
+<th class="num">PoolWait</th><th class="num">Transport</th><th class="num">Backend</th>
+<th>Session</th><th class="num">RpcID</th><th class="num">SessionAge</th>
+<th>Peer (afe/region/subzone)</th>
+<th>Remote (→ tcpz)</th>
+<th>Status</th>
+</tr></thead>
+<tbody>
+{{range reverseSlow .Pool.SlowVRpcs}}
+<tr>
+<td>{{age .At}} ago</td>
+<td class="mono">{{.Method}}</td>
+<td class="num {{latencyClass .Latency}}">{{dur .Latency}}</td>
+<td class="num" title="time inside CheckoutSession — waiting for an idle session at the pool boundary">{{dur .PoolWait}}</td>
+<td class="num" title="java-parity ClientTransportLatency = (stream Send→Recv) − Backend; wire + AFE + client-decode overhead outside server processing">{{dur .TransportLatency}}</td>
+<td class="num" title="server-reported BackendLatency">{{dur .BackendLatency}}</td>
+<td class="mono">{{.Session}}</td>
+<td class="num" title="per-session 1-indexed RPC id; small values indicate a fresh session">{{.RPCIDOnSession}}</td>
+<td class="num" title="age of the session at the time of this call">{{dur .SessionAge}}</td>
+<td class="mono" title="ApplicationFrontendId (hex) / region / subzone of the AFE this session was bound to at call time">{{with (peerShort .Peer)}}{{.}}{{else}}—{{end}}</td>
+<td class="mono" title="TCP remote (AFE) addr this session's stream is bound to. Click to filter tcpz to the conn(s) with this remote.">{{if .RemoteAddr}}<a href="../../tcpz/?remote={{.RemoteAddr | urlquery}}">{{.RemoteAddr}}</a>{{else}}—{{end}}</td>
+<td>{{if .Success}}OK{{else}}<span style="color:#922">{{.ErrCode}}</span>{{end}}</td>
+</tr>
+{{end}}
+</tbody>
+</table>
+<div style="font-size:.78em;color:#888;margin-top:.3em">
+<b>PoolWait</b> ≈ <b>Latency</b> → workers exceeded pool capacity; queued at the pool boundary waiting for an idle session.
+<b>Transport</b> ≫ <b>Backend</b> → time was spent on the wire (network RTT / server queue), not in server processing.
+<b>Backend</b> close to <b>Latency</b> → server itself was slow.
+Low <b>RpcID</b> + small <b>SessionAge</b> → fresh session warm-up cost.
+<b>Remote</b> → click to filter tcpz to the conn this session is bound to (per-conn TCP_INFO: RTT/cwnd/retrans).
+</div>
+{{end}}
+
+{{if .Pool.ScalingHistory}}
+<h3 style="font-size:1em;margin:1.4em 0 .4em 0;color:#444">Scaling history (newest last, last {{len .Pool.ScalingHistory}})</h3>
+<table>
+<thead><tr>
+<th>When</th>
+<th class="num">Pool&nbsp;was</th>
+<th class="num">Sizer&nbsp;asked</th>
+<th class="num">Action&nbsp;result</th>
+<th>Branch</th>
+<th class="num" title="Stats at decision time: ready/starting/in-use/pending(waiters)">R/S/U/P</th>
+<th class="num" title="Sizer intermediates: effective-pending / sessions-in-use / idle-cushion / desired-capacity">eP/sU/idle/desired</th>
+<th class="num" title="Immediate vs eventual capacity (ready vs ready+starting)">imm/evt</th>
+<th>Reason</th>
+</tr></thead>
+<tbody>
+{{range .Pool.ScalingHistory}}
+<tr>
+<td>{{age .At}} ago</td>
+<td class="num">{{.Before}}</td>
+<td class="num">{{signed .Requested}}</td>
+<td class="num">{{scalingOutcome .}}</td>
+<td class="mono" title="scale-up | scale-down (advisory — pool shrinks via non-replacement in OnClose, not via prune) | dead-band | no-stats">{{.Decision.Branch}}</td>
+<td class="num mono" title="ready={{.Decision.ReadyCount}}&#10;starting={{.Decision.StartingCount}}&#10;in_use={{.Decision.InUseCount}}&#10;pending(waiters)={{.Decision.PendingCount}}">{{.Decision.ReadyCount}}/{{.Decision.StartingCount}}/{{.Decision.InUseCount}}/{{.Decision.PendingCount}}</td>
+<td class="num mono" title="effectivePending = ceil(pending/{{.Decision.NewSessionQLen}}) = {{.Decision.EffectivePending}}&#10;sessionsInUse = inUse + effPending = {{.Decision.SessionsInUse}}&#10;idle = max(minIdle={{.Decision.MinIdleSessions}}, ceil(sessionsInUse*{{.Decision.HeadroomPct}})) = {{.Decision.IdleHeadroom}}&#10;desired = clamp(sessionsInUse+idle, min={{.Decision.MinSessions}}, max={{.Decision.MaxSessions}}) = {{.Decision.DesiredCapacity}}">{{.Decision.EffectivePending}}/{{.Decision.SessionsInUse}}/{{.Decision.IdleHeadroom}}/{{.Decision.DesiredCapacity}}</td>
+<td class="num mono" title="immediate = ready ({{.Decision.ImmediateCapacity}})&#10;eventual = ready + starting ({{.Decision.EventualCapacity}})&#10;Scale up if desired>eventual; scale-down is advisory (pool shrinks by non-replacement in OnClose); dead-band otherwise.">{{.Decision.ImmediateCapacity}}/{{.Decision.EventualCapacity}}</td>
+<td>{{.Reason}}</td>
+</tr>
+{{end}}
+</tbody>
+</table>
+<div style="font-size:.78em;color:#888;margin-top:.3em">
+<b>Pool&nbsp;was</b> = live pool size when the sizer decided.
+<b>Sizer&nbsp;asked</b> = delta requested (+ scale up, − advisory scale-down; scale-down deltas are informational — the pool shrinks passively via OnClose's replace-on-death gate, mirroring java-bigtable).
+<b>Action&nbsp;result</b> = sessions launched (scale up — these are handshaking and become Active shortly after).
+<b>R/S/U/P</b> = Ready / Starting / In-use / Pending(waiters) at decision time.
+<b>eP/sU/idle/desired</b> = effectivePending / sessionsInUse / idleCushion / desiredCapacity — hover for the formula.
+<b>imm/evt</b> = immediate (ready) vs eventual (ready+starting) capacity; the dead band between them prevents pruning sessions whose handshake is still landing.
+</div>
+{{end}}
+
+<div class="foot"><a href="?format=json">JSON</a> · <a href="../">all pools</a></div>
+</body></html>
+`
+
+var (
+	sessionzIndexTpl = template.Must(template.New("sessionz-index").Funcs(sessionzFuncs()).Parse(sessionzIndexTplSrc))
+	sessionzPoolTpl  = template.Must(template.New("sessionz-pool").Funcs(sessionzFuncs()).Parse(sessionzPoolTplSrc))
+)

--- a/bigtable/debugview/sessionz_test.go
+++ b/bigtable/debugview/sessionz_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debugview
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+)
+
+func sessionzSampleSnapshot() []btransport.PoolSnapshot {
+	return []btransport.PoolSnapshot{
+		{
+			Name:          "my-table:read",
+			SessionType:   "table",
+			MinSessions:   2,
+			MaxSessions:   10,
+			PickerType:    "RandomPicker",
+			ReadyCount:    2,
+			StartingCount: 0,
+			InUseCount:    1,
+			PendingCount:  3,
+			TotalSessions: 2,
+			CapturedAt:    time.Now(),
+			Sessions: []btransport.SessionSnapshot{
+				{
+					LogName:           "session-read-1",
+					State:             "Ready",
+					SessionType:       "table",
+					LastStateChange:   time.Now().Add(-90 * time.Second),
+					OkRpcs:            42,
+					ErrorRpcs:         1,
+					ActiveRpcs:        3,
+					HeartbeatInterval: 10 * time.Second,
+					NextHeartbeat:     time.Now().Add(20 * time.Second),
+					Peer: btransport.PeerInfoSnapshot{
+						TransportType:              "session_directpath",
+						GoogleFrontendID:           12345,
+						ApplicationFrontendID:      67890,
+						ApplicationFrontendRegion:  "us-central1",
+						ApplicationFrontendSubzone: "us-central1-b1",
+					},
+					Handle: btransport.SessionHandleSnapshot{
+						Outstanding:  3,
+						LastActivity: time.Now().Add(-5 * time.Second),
+					},
+				},
+				{
+					LogName:     "session-read-2",
+					State:       "Starting",
+					SessionType: "table",
+				},
+			},
+		},
+	}
+}
+
+func TestSessionz_Index_HTML_RendersPools(t *testing.T) {
+	h := newSessionzHandler(fakeSessionProvider{pools: sessionzSampleSnapshot()})
+	rec := get(t, h, "/")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("Content-Type = %q, want text/html", ct)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"my-table:read", "RandomPicker", "table", "Bigtable Session Pools"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("index missing %q", want)
+		}
+	}
+}
+
+func TestSessionz_Index_JSON_RoundTrips(t *testing.T) {
+	pools := sessionzSampleSnapshot()
+	h := newSessionzHandler(fakeSessionProvider{pools: pools})
+	rec := get(t, h, "/?format=json")
+
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	var got struct {
+		Pools    []btransport.PoolSnapshot   `json:"pools"`
+		Diverter btransport.DiverterSnapshot `json:"diverter"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v", err)
+	}
+	if len(got.Pools) != 1 || got.Pools[0].Name != pools[0].Name {
+		t.Errorf("JSON round-trip mismatch: %+v", got)
+	}
+	if len(got.Pools[0].Sessions) != 2 {
+		t.Errorf("Sessions len = %d, want 2", len(got.Pools[0].Sessions))
+	}
+}
+
+func TestSessionz_Pool_HTML_RendersSessions(t *testing.T) {
+	h := newSessionzHandler(fakeSessionProvider{pools: sessionzSampleSnapshot()})
+	rec := get(t, h, "/pool/my-table:read")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	wants := []string{
+		"my-table:read",
+		"session-read-1", "session-read-2",
+		"Ready", "Starting",
+		"session_directpath",
+		"us-central1", "us-central1-b1",
+		"42", // OK count
+	}
+	for _, w := range wants {
+		if !strings.Contains(body, w) {
+			t.Errorf("pool detail missing %q", w)
+		}
+	}
+}
+
+func TestSessionz_Pool_NotFound(t *testing.T) {
+	h := newSessionzHandler(fakeSessionProvider{pools: sessionzSampleSnapshot()})
+	rec := get(t, h, "/pool/does-not-exist")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestSessionz_Index_NoProvider_Disabled(t *testing.T) {
+	h := newSessionzHandler(nil)
+	rec := get(t, h, "/")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "Session pooling is disabled") {
+		t.Errorf("expected disabled message; got %q", rec.Body.String())
+	}
+}
+
+func TestSessionz_Index_NoPools_Empty(t *testing.T) {
+	h := newSessionzHandler(fakeSessionProvider{pools: nil})
+	rec := get(t, h, "/")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "No session pools") {
+		t.Errorf("expected empty-state message; got %q", rec.Body.String())
+	}
+}
+
+func TestSessionz_Pool_JSON(t *testing.T) {
+	pools := sessionzSampleSnapshot()
+	h := newSessionzHandler(fakeSessionProvider{pools: pools})
+	rec := get(t, h, "/pool/my-table:read?format=json")
+
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	var got btransport.PoolSnapshot
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v", err)
+	}
+	if got.Name != pools[0].Name {
+		t.Errorf("Name = %q, want %q", got.Name, pools[0].Name)
+	}
+}

--- a/bigtable/debugview/shared_test.go
+++ b/bigtable/debugview/shared_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debugview
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"cloud.google.com/go/bigtable"
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+)
+
+// fakeSessionProvider satisfies bigtable.SessionDebugProvider for the
+// four session-backed views (sessionz / afez / flightz / loadz). Each
+// per-view test file sets whichever field its view exercises; the other
+// two methods return zero values.
+type fakeSessionProvider struct {
+	pools    []btransport.PoolSnapshot
+	diverter btransport.DiverterSnapshot
+	lb       []btransport.LoadBalancingSnapshot
+}
+
+func (f fakeSessionProvider) Snapshot() []btransport.PoolSnapshot { return f.pools }
+func (f fakeSessionProvider) Diverter() btransport.DiverterSnapshot {
+	return f.diverter
+}
+func (f fakeSessionProvider) LoadBalancingSnapshots() []btransport.LoadBalancingSnapshot {
+	return f.lb
+}
+
+// fakeChannelProvider satisfies bigtable.ChannelDebugProvider for
+// channelz tests.
+type fakeChannelProvider struct {
+	pools []bigtable.ChannelPoolDebug
+}
+
+func (f fakeChannelProvider) Snapshot() []bigtable.ChannelPoolDebug { return f.pools }
+
+// fakeConfigProvider satisfies bigtable.ConfigDebugProvider for configz
+// tests.
+type fakeConfigProvider struct {
+	snap btransport.ConfigSnapshot
+}
+
+func (f fakeConfigProvider) Snapshot() btransport.ConfigSnapshot { return f.snap }
+
+// get is a tiny helper wrapping httptest to keep the per-view test
+// files short. Every view's tests exercise Handler via the same shape.
+func get(t *testing.T, h http.Handler, target string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// head returns the first n bytes of b as a string, with an ellipsis when
+// truncated. Used by tests that need to include a body snippet in an
+// error message without dumping the whole page.
+func head(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "…"
+}

--- a/bigtable/debugview/shared_test.go
+++ b/bigtable/debugview/shared_test.go
@@ -57,6 +57,14 @@ type fakeConfigProvider struct {
 
 func (f fakeConfigProvider) Snapshot() btransport.ConfigSnapshot { return f.snap }
 
+// fakeOutlierProvider satisfies bigtable.OutlierDebugProvider for
+// outlierz tests.
+type fakeOutlierProvider struct {
+	pools []btransport.OutlierPoolSnapshot
+}
+
+func (f fakeOutlierProvider) Snapshot() []btransport.OutlierPoolSnapshot { return f.pools }
+
 // get is a tiny helper wrapping httptest to keep the per-view test
 // files short. Every view's tests exercise Handler via the same shape.
 func get(t *testing.T, h http.Handler, target string) *httptest.ResponseRecorder {

--- a/bigtable/debugview/tcpz.go
+++ b/bigtable/debugview/tcpz.go
@@ -1,0 +1,1616 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// tcpz view — per-connection TCP_INFO (RTT, retransmits, cwnd, MSS, TCP
+// state) for every gRPC dial a bigtable client made through
+// bigtable.TCPStats.
+//
+// Linux only. On other platforms every row surfaces "tcp_info not
+// supported on this platform" in the Err column. Not compatible with
+// DirectPath (xDS bypasses the standard dialer, so nothing is captured).
+
+package debugview
+
+import (
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/bigtable"
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+)
+
+func newTcpzHandler(stats *bigtable.TCPStats) http.Handler {
+	mux := http.NewServeMux()
+	srv := &tcpzServer{stats: stats}
+	mux.HandleFunc("/", srv.handleIndex)
+	return mux
+}
+
+type tcpzServer struct {
+	stats *bigtable.TCPStats
+}
+
+func (s *tcpzServer) snapshot() []btransport.TCPInfoSnapshot {
+	if s.stats == nil {
+		return nil
+	}
+	return s.stats.Snapshot()
+}
+
+func (s *tcpzServer) deadConns() []btransport.DeadConnInfo {
+	if s.stats == nil {
+		return nil
+	}
+	return s.stats.DeadConns()
+}
+
+// tcpzSeverity ranks conns by how much the kernel's TCP_INFO says is
+// wrong with them. Ordering is exploited by the sort (higher first) and
+// by the row-color CSS classes below.
+type tcpzSeverity int
+
+const (
+	sevOK   tcpzSeverity = iota // healthy, no signal
+	sevNote                     // interesting but not a problem (draining, unreadable)
+	sevWarn                     // any real loss/retrans/ECN/reord signal
+	sevCrit                     // RTO-driven Loss state or currently backing off
+)
+
+// classify inspects one TCP_INFO snapshot and returns its severity plus
+// a short "why" list of the specific signals that triggered it. Empty
+// list ↔ sevOK.
+//
+// Rules (highest wins):
+//   - crit: CAState=Loss OR Backoff>0 — RTO-driven loss or currently timing out
+//   - warn: CAState ∈ {Disorder, CWR, Recovery} OR any non-zero retrans /
+//     lost / dsack / ECN / reordering counter
+//   - note: State != ESTABLISHED (closing/draining) OR Err populated
+//     (couldn't read info — usually non-Linux)
+//   - ok:   everything else
+func classify(r btransport.TCPInfoSnapshot) (tcpzSeverity, []string) {
+	if r.Err != "" {
+		return sevNote, []string{"unreadable"}
+	}
+	var why []string
+	sev := sevOK
+	bump := func(s tcpzSeverity, tag string) {
+		if s > sev {
+			sev = s
+		}
+		why = append(why, tag)
+	}
+
+	if r.CAState == "Loss" {
+		bump(sevCrit, "Loss")
+	}
+	if r.Backoff > 0 {
+		bump(sevCrit, "backoff")
+	}
+	switch r.CAState {
+	case "Recovery":
+		bump(sevWarn, "Recovery")
+	case "CWR":
+		bump(sevWarn, "CWR")
+	case "Disorder":
+		bump(sevWarn, "Disorder")
+	}
+	if r.Retransmits > 0 {
+		bump(sevWarn, "retrans")
+	}
+	if r.TotalRetrans > 0 && r.Retransmits == 0 {
+		bump(sevWarn, "past-retrans")
+	}
+	if r.Lost > 0 {
+		bump(sevWarn, "lost")
+	}
+	if r.DsackDups > 0 {
+		bump(sevWarn, "dsack")
+	}
+	if r.DeliveredCE > 0 {
+		bump(sevWarn, "ECN")
+	}
+	if r.ReordSeen > 0 {
+		bump(sevWarn, "reord")
+	}
+
+	if sev == sevOK && r.State != "" && r.State != "ESTABLISHED" {
+		bump(sevNote, r.State)
+	}
+	return sev, why
+}
+
+// rowClass returns the CSS class for the row background.
+func (s tcpzSeverity) rowClass() string {
+	switch s {
+	case sevCrit:
+		return "row-crit"
+	case sevWarn:
+		return "row-warn"
+	case sevNote:
+		return "row-note"
+	}
+	return "row-ok"
+}
+
+// durBucket / pctBucket define a single bucket in a histogram: any value
+// with v < Max lands here. The final bucket in a table uses Max == 0 as
+// "no upper bound" — the ">X" catch-all. Keeping the sentinel as a plain
+// zero avoids threading a bool per bucket.
+type durBucket struct {
+	Max   time.Duration
+	Label string
+}
+
+type pctBucket struct {
+	Max   float64
+	Label string
+}
+
+// Bucket tables tuned for the shapes we actually see on prod bigtable
+// dials: sub-ms RTT, near-zero retrans rates, minutes-to-hours conn
+// lifetimes. Log-ish spacing so a single hot outlier doesn't collapse
+// every other bar into a hairline.
+var rttHistBuckets = []durBucket{
+	{200 * time.Microsecond, "<200µs"},
+	{500 * time.Microsecond, "200µs-500µs"},
+	{time.Millisecond, "500µs-1ms"},
+	{2 * time.Millisecond, "1-2ms"},
+	{5 * time.Millisecond, "2-5ms"},
+	{10 * time.Millisecond, "5-10ms"},
+	{25 * time.Millisecond, "10-25ms"},
+	{50 * time.Millisecond, "25-50ms"},
+	{100 * time.Millisecond, "50-100ms"},
+	{500 * time.Millisecond, "100-500ms"},
+	{0, ">500ms"},
+}
+
+var retransHistBuckets = []pctBucket{
+	{0.0000001, "0%"}, // exact-zero bucket; any positive value falls past this
+	{0.01, "0-0.01%"},
+	{0.05, "0.01-0.05%"},
+	{0.1, "0.05-0.1%"},
+	{0.5, "0.1-0.5%"},
+	{1, "0.5-1%"},
+	{5, "1-5%"},
+	{0, ">5%"},
+}
+
+var ageHistBuckets = []durBucket{
+	{5 * time.Second, "<5s"},
+	{30 * time.Second, "5-30s"},
+	{time.Minute, "30s-1m"},
+	{5 * time.Minute, "1-5m"},
+	{15 * time.Minute, "5-15m"},
+	{time.Hour, "15m-1h"},
+	{6 * time.Hour, "1-6h"},
+	{24 * time.Hour, "6-24h"},
+	{0, ">24h"},
+}
+
+// histBar is one row of a rendered histogram: label + up to two stacked
+// bars (live/dead) + count(s). LivePct/DeadPct are 0-100 widths relative
+// to the panel's tallest bucket so the visual peak always saturates.
+type histBar struct {
+	Label   string
+	Live    int
+	Dead    int // only populated for the age panel
+	LivePct int
+	DeadPct int
+}
+
+// histPanel is one rendered histogram panel above the tcpz table.
+// Summary is a "n=… p50=… max=…" one-liner shown under the title.
+type histPanel struct {
+	Title   string
+	Bars    []histBar
+	Summary string
+	HasDead bool // renders the small "live/dead" legend swatch under the panel
+}
+
+// bucketizeDur returns per-bucket counts for a slice of durations. Zero
+// values are counted (they land in the first bucket, matching the "<200µs"
+// / "<5s" semantics).
+func bucketizeDur(values []time.Duration, buckets []durBucket) []int {
+	counts := make([]int, len(buckets))
+	for _, v := range values {
+		for i, b := range buckets {
+			if b.Max == 0 || v < b.Max {
+				counts[i]++
+				break
+			}
+		}
+	}
+	return counts
+}
+
+// bucketizePct is the retrans-ratio companion to bucketizeDur. The first
+// bucket has an epsilon Max so exact-zero conns get their own bar (they
+// dominate healthy fleets and would otherwise saturate everything else).
+func bucketizePct(values []float64, buckets []pctBucket) []int {
+	counts := make([]int, len(buckets))
+	for _, v := range values {
+		for i, b := range buckets {
+			if b.Max == 0 || v < b.Max {
+				counts[i]++
+				break
+			}
+		}
+	}
+	return counts
+}
+
+// makeHistPanel converts raw live/dead bucket counts into the rendered
+// panel struct. Bar widths are normalized against the tallest single
+// (live+dead) bar in the panel so the peak always fills the track. Empty
+// panels return nil so the template can hide them cleanly.
+func makeHistPanel(title, summary string, labels []string, live, dead []int) *histPanel {
+	if len(live) != len(labels) {
+		return nil
+	}
+	max := 0
+	for i := range labels {
+		total := live[i]
+		if dead != nil {
+			total += dead[i]
+		}
+		if total > max {
+			max = total
+		}
+	}
+	if max == 0 {
+		return nil
+	}
+	bars := make([]histBar, len(labels))
+	for i, lbl := range labels {
+		b := histBar{Label: lbl, Live: live[i]}
+		b.LivePct = live[i] * 100 / max
+		if dead != nil {
+			b.Dead = dead[i]
+			b.DeadPct = dead[i] * 100 / max
+		}
+		bars[i] = b
+	}
+	return &histPanel{Title: title, Bars: bars, Summary: summary, HasDead: dead != nil}
+}
+
+// percentileDur returns the 0..100 percentile of a duration slice using
+// nearest-rank. Non-mutating (sorts a copy). Empty slice → 0.
+func percentileDur(values []time.Duration, p int) time.Duration {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]time.Duration(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	idx := (p * (len(sorted) - 1)) / 100
+	return sorted[idx]
+}
+
+// percentilePct is the float64 analogue of percentileDur.
+func percentilePct(values []float64, p int) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]float64(nil), values...)
+	sort.Float64s(sorted)
+	idx := (p * (len(sorted) - 1)) / 100
+	return sorted[idx]
+}
+
+// bucketLabels extracts the .Label field from a bucket table so
+// makeHistPanel doesn't need two type-specific overloads.
+func durBucketLabels(bs []durBucket) []string {
+	out := make([]string, len(bs))
+	for i, b := range bs {
+		out[i] = b.Label
+	}
+	return out
+}
+func pctBucketLabels(bs []pctBucket) []string {
+	out := make([]string, len(bs))
+	for i, b := range bs {
+		out[i] = b.Label
+	}
+	return out
+}
+
+// buildHistPanels computes the three summary panels shown above the tcpz
+// table. Called once per HTML render (skipped for JSON responses).
+//
+//   - RTT: live conns only, kernel-reported smoothed RTT.
+//   - Retrans ratio: live conns only, BytesRetrans/BytesSent from the
+//     precomputed RetransRatioPct.
+//   - Age: live conns' age-so-far AND dead conns' age-at-death, stacked
+//     in the same buckets — dead is what the user asked for (how long
+//     conns lived before dying); live is the companion (what's alive now).
+func buildHistPanels(live []btransport.TCPInfoSnapshot, dead []btransport.DeadConnInfo) []*histPanel {
+	now := time.Now()
+
+	var rtts []time.Duration
+	var retrans []float64
+	var liveAges []time.Duration
+	for _, s := range live {
+		if s.Err != "" {
+			continue
+		}
+		if s.RTT > 0 {
+			rtts = append(rtts, s.RTT)
+		}
+		if s.BytesSent > 0 {
+			retrans = append(retrans, s.RetransRatioPct)
+		}
+		if !s.DialedAt.IsZero() {
+			liveAges = append(liveAges, now.Sub(s.DialedAt))
+		}
+	}
+	deadAges := make([]time.Duration, 0, len(dead))
+	for _, d := range dead {
+		if d.DialedAt.IsZero() || d.DiedAt.IsZero() {
+			continue
+		}
+		deadAges = append(deadAges, d.DiedAt.Sub(d.DialedAt))
+	}
+
+	var panels []*histPanel
+
+	if len(rtts) > 0 {
+		counts := bucketizeDur(rtts, rttHistBuckets)
+		summary := fmt.Sprintf("n=%d · p50=%s · p90=%s · max=%s",
+			len(rtts),
+			roundRTTShort(percentileDur(rtts, 50)),
+			roundRTTShort(percentileDur(rtts, 90)),
+			roundRTTShort(percentileDur(rtts, 100)))
+		panels = append(panels, makeHistPanel("RTT", summary, durBucketLabels(rttHistBuckets), counts, nil))
+	}
+	if len(retrans) > 0 {
+		counts := bucketizePct(retrans, retransHistBuckets)
+		summary := fmt.Sprintf("n=%d · p50=%s · p90=%s · max=%s",
+			len(retrans),
+			formatPct(percentilePct(retrans, 50)),
+			formatPct(percentilePct(retrans, 90)),
+			formatPct(percentilePct(retrans, 100)))
+		panels = append(panels, makeHistPanel("Retrans ratio", summary, pctBucketLabels(retransHistBuckets), counts, nil))
+	}
+	if len(liveAges)+len(deadAges) > 0 {
+		liveCounts := bucketizeDur(liveAges, ageHistBuckets)
+		deadCounts := bucketizeDur(deadAges, ageHistBuckets)
+		var maxLifetime time.Duration
+		if len(deadAges) > 0 {
+			maxLifetime = percentileDur(deadAges, 100)
+		}
+		summary := fmt.Sprintf("live=%d · dead=%d", len(liveAges), len(deadAges))
+		if len(deadAges) > 0 {
+			summary += fmt.Sprintf(" · dead p50=%s max=%s",
+				roundDurationShort(percentileDur(deadAges, 50)),
+				roundDurationShort(maxLifetime))
+		}
+		panels = append(panels, makeHistPanel("Conn age", summary, durBucketLabels(ageHistBuckets), liveCounts, deadCounts))
+	}
+	return panels
+}
+
+// roundRTTShort renders sub-ms and sub-second RTT durations with sensible
+// precision for the histogram summary line. time.Duration.String() is too
+// verbose ("1.234567ms") and roundDurationShort is tuned for minutes+.
+func roundRTTShort(d time.Duration) string {
+	if d <= 0 {
+		return "—"
+	}
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.0fµs", float64(d)/float64(time.Microsecond))
+	case d < time.Second:
+		return fmt.Sprintf("%.2fms", float64(d)/float64(time.Millisecond))
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+// formatPct renders a small percent value compactly for histogram
+// summaries — mirrors the "pct" template func but returns a plain string
+// (no HTML wrapping).
+func formatPct(v float64) string {
+	if v == 0 {
+		return "0%"
+	}
+	if v < 0.01 {
+		return "<0.01%"
+	}
+	return fmt.Sprintf("%.2f%%", v)
+}
+
+// tcpzRow bundles a snapshot with its precomputed severity so the
+// template doesn't have to re-classify on every template action.
+type tcpzRow struct {
+	btransport.TCPInfoSnapshot
+	Sev      string // rowClass string ("row-crit", …)
+	SevRank  int    // 0..3 matching sevOK..sevCrit; used for group-worst rollups
+	Why      string // joined why list, e.g. "Loss+backoff+lost"
+	Interest bool   // sev > sevOK — the "N interesting" count uses this
+}
+
+// anomalyChip captures one non-zero "interesting counter" to render as
+// a small colored badge on the one-line per-conn row. Emitting only
+// non-zero counters keeps the row scannable — healthy conns are near-empty.
+type anomalyChip struct {
+	Label string // e.g. "retr", "dsack", "ECN"
+	Value string // formatted count / duration
+	Sev   string // "warn" | "crit"
+}
+
+// anomalies returns the per-conn interesting-counter chips in a stable
+// order. Values that are zero (the healthy case) are omitted.
+func (r tcpzRow) Anomalies() []anomalyChip {
+	var out []anomalyChip
+	add := func(label string, v uint32, sev string) {
+		if v == 0 {
+			return
+		}
+		out = append(out, anomalyChip{Label: label, Value: fmt.Sprintf("%d", v), Sev: sev})
+	}
+	addDur := func(label string, d time.Duration, sev string) {
+		if d == 0 {
+			return
+		}
+		out = append(out, anomalyChip{Label: label, Value: d.String(), Sev: sev})
+	}
+	if r.Backoff > 0 {
+		add("bkoff", r.Backoff, "crit")
+	}
+	add("retr", r.Retransmits, "warn")
+	if r.Retransmits == 0 && r.TotalRetrans > 0 {
+		add("past-retr", r.TotalRetrans, "warn")
+	}
+	add("lost", r.Lost, "warn")
+	add("dsack", r.DsackDups, "warn")
+	add("ECN", r.DeliveredCE, "warn")
+	add("reord", r.ReordSeen, "warn")
+	add("probes", r.Probes, "warn")
+	addDur("rwndLim", r.RwndLimited, "warn")
+	addDur("sndLim", r.SndbufLimited, "warn")
+	if r.NotsentBytes > 0 {
+		out = append(out, anomalyChip{Label: "notsent", Value: fmt.Sprintf("%dB", r.NotsentBytes), Sev: "warn"})
+	}
+	return out
+}
+
+// peerGroup aggregates every conn to the same RemoteAddr into one
+// rendered card. The default view groups by remote so operators can tell
+// "one AFE is misbehaving" apart from "one conn is misbehaving." Fields
+// on the group are worst-case rollups across its conns.
+type peerGroup struct {
+	Remote     string
+	Conns      []tcpzRow
+	WorstSev   string        // "row-crit" | "row-warn" | "row-note" | "row-ok"
+	N          int           // len(Conns) after filters
+	NHidden    int           // conns filtered out (e.g. only=hot); dimmed count in the summary
+	SumDelRate uint64        // Σ DeliveryRate — current outbound bandwidth to this remote
+	SumAvgOut  float64       // Σ lifetime BytesAcked/age (bytes/sec)
+	SumAvgIn   float64       // Σ lifetime BytesReceived/age (bytes/sec)
+	MaxRTT     time.Duration // worst smoothed RTT in the group
+	MaxRtxPct  float64       // worst retrans ratio in the group
+	OldestAge  time.Duration // oldest conn's age — proxy for "how long this pool has been open"
+	Interest   int           // count of conns with sev > sevOK
+}
+
+// buildPeerGroups groups rows by RemoteAddr, sorted by group severity
+// desc (crit → warn → note → ok) then by oldest age. Within a group,
+// conns are severity-desc then dial-order (newest first). Empty rows
+// slice → nil groups.
+func buildPeerGroups(rows []tcpzRow, hiddenByRemote map[string]int) []*peerGroup {
+	if len(rows) == 0 {
+		return nil
+	}
+	byRemote := make(map[string]*peerGroup)
+	order := make([]string, 0, len(rows))
+	for _, r := range rows {
+		g, ok := byRemote[r.RemoteAddr]
+		if !ok {
+			g = &peerGroup{Remote: r.RemoteAddr}
+			byRemote[r.RemoteAddr] = g
+			order = append(order, r.RemoteAddr)
+		}
+		g.Conns = append(g.Conns, r)
+		g.N++
+		if r.Interest {
+			g.Interest++
+		}
+		if r.Err == "" {
+			g.SumDelRate += r.DeliveryRate
+			g.SumAvgOut += avgRateBps(r.BytesAcked, r.DialedAt)
+			g.SumAvgIn += avgRateBps(r.BytesReceived, r.DialedAt)
+			if r.RTT > g.MaxRTT {
+				g.MaxRTT = r.RTT
+			}
+			if r.RetransRatioPct > g.MaxRtxPct {
+				g.MaxRtxPct = r.RetransRatioPct
+			}
+		}
+		if !r.DialedAt.IsZero() {
+			if age := time.Since(r.DialedAt); age > g.OldestAge {
+				g.OldestAge = age
+			}
+		}
+	}
+	// Finalize: pick worst-sev + hidden count, sort conns within each.
+	groups := make([]*peerGroup, 0, len(order))
+	for _, remote := range order {
+		g := byRemote[remote]
+		worst := 0
+		for _, c := range g.Conns {
+			if c.SevRank > worst {
+				worst = c.SevRank
+			}
+		}
+		g.WorstSev = sevClassByRank(worst)
+		g.NHidden = hiddenByRemote[remote]
+		sort.SliceStable(g.Conns, func(i, j int) bool {
+			if g.Conns[i].SevRank != g.Conns[j].SevRank {
+				return g.Conns[i].SevRank > g.Conns[j].SevRank
+			}
+			return g.Conns[i].DialedAt.After(g.Conns[j].DialedAt)
+		})
+		groups = append(groups, g)
+	}
+	sort.SliceStable(groups, func(i, j int) bool {
+		ri := sevRank(groups[i].WorstSev)
+		rj := sevRank(groups[j].WorstSev)
+		if ri != rj {
+			return ri > rj
+		}
+		if groups[i].Interest != groups[j].Interest {
+			return groups[i].Interest > groups[j].Interest
+		}
+		return groups[i].OldestAge > groups[j].OldestAge
+	})
+	return groups
+}
+
+// sevClassByRank maps a numeric severity rank back to the row-class
+// string. Inverse of sevRank; used by peerGroup.WorstSev.
+func sevClassByRank(rank int) string {
+	switch rank {
+	case 3:
+		return "row-crit"
+	case 2:
+		return "row-warn"
+	case 1:
+		return "row-note"
+	}
+	return "row-ok"
+}
+
+// tcpzColDef describes one column of the tcpz table: header label,
+// tooltip, CSS class for both th/td, and (if sortable) a comparator
+// returning <0/0/>0 in the natural ascending sense. The "Body" field is
+// the exact template snippet used inside the row's <td> — kept
+// alongside the header so adding a column is a single-slice-entry
+// change.
+type tcpzColDef struct {
+	Key   string // URL sort key; empty = not sortable
+	Label string
+	Class string // "num" / "mono" / "err" / ""
+	Title string
+	Body  string // inner-cell template action, e.g. `{{num .MSS}}`
+	Cmp   func(a, b btransport.TCPInfoSnapshot) int
+	Desc  bool
+}
+
+// tcpzCols is the single source of truth for every column in the tcpz
+// table. The template renders <thead> and <tbody> by iterating this
+// slice. Order here is the display order.
+var tcpzCols = []tcpzColDef{
+	{Key: "", Label: "Why", Class: "why", Title: "Why this row is highlighted — the list of TCP_INFO signals that classified it.", Body: `{{.Why}}`},
+	{Key: "remote", Label: "Remote", Class: "mono", Title: "Peer address (ip:port).", Body: `{{.RemoteAddr}}`, Cmp: cmpStr(func(s btransport.TCPInfoSnapshot) string { return s.RemoteAddr })},
+	{Key: "local", Label: "Local", Class: "mono", Title: "Local socket address.", Body: `{{.LocalAddr}}`, Cmp: cmpStr(func(s btransport.TCPInfoSnapshot) string { return s.LocalAddr })},
+	{Key: "age", Label: "Age", Title: "Time since this conn was dialed.", Body: `{{ago .DialedAt}}`, Cmp: cmpTime(func(s btransport.TCPInfoSnapshot) time.Time { return s.DialedAt }), Desc: true},
+	{Key: "state", Label: "State", Title: "Linux TCP state (ESTABLISHED, CLOSE_WAIT, etc.).", Body: `<span class="state-{{or .State "UNKNOWN"}}">{{or .State "—"}}</span>`, Cmp: cmpStr(func(s btransport.TCPInfoSnapshot) string { return s.State })},
+	{Key: "ca", Label: "Ca", Title: "Congestion-control state: Open=healthy, Disorder=watching for loss, CWR=cwnd-reducing after ECN, Recovery=fast-retransmitting, Loss=RTO-driven collapse (worst).", Body: `<span class="ca-{{or .CAState "Unknown"}}">{{or .CAState "—"}}</span>`, Cmp: cmpStr(func(s btransport.TCPInfoSnapshot) string { return s.CAState })},
+	{Key: "bkoff", Label: "Bkoff", Class: "num", Title: "RTO backoff count. >0 means we've timed out at least once and are waiting exponentially longer.", Body: `{{critNum .Backoff}}`, Cmp: cmpU32(func(s btransport.TCPInfoSnapshot) uint32 { return s.Backoff }), Desc: true},
+	{Key: "rtt", Label: "RTT", Class: "num", Title: "Smoothed round-trip time — the primary 'wire' latency signal.", Body: `{{dur .RTT}}`, Cmp: cmpDur(func(s btransport.TCPInfoSnapshot) time.Duration { return s.RTT }), Desc: true},
+	{Key: "rttvar", Label: "RTTVar", Class: "num", Title: "RTT variance (jitter). High values suggest an unstable path.", Body: `{{dur .RTTVar}}`, Cmp: cmpDur(func(s btransport.TCPInfoSnapshot) time.Duration { return s.RTTVar }), Desc: true},
+	{Key: "minrtt", Label: "MinRTT", Class: "num", Title: "Minimum RTT observed on this conn — the floor of what the network can deliver.", Body: `{{dur .MinRTT}}`, Cmp: cmpDur(func(s btransport.TCPInfoSnapshot) time.Duration { return s.MinRTT }), Desc: true},
+	{Key: "rto", Label: "RTO", Class: "num", Title: "Current retransmit timeout — kernel will re-send unacked bytes after this long. Grows with backoff.", Body: `{{dur .RTO}}`, Cmp: cmpDur(func(s btransport.TCPInfoSnapshot) time.Duration { return s.RTO }), Desc: true},
+	{Key: "mss", Label: "MSS", Class: "num", Title: "Send MSS (max segment size).", Body: `{{num .MSS}}`, Cmp: cmpU32(func(s btransport.TCPInfoSnapshot) uint32 { return s.MSS }), Desc: true},
+	{Key: "pmtu", Label: "PMTU", Class: "num", Title: "Path MTU (bytes). <1500 = tunneling/VPN in path. Watch for PMTU black holes: silent drops if ICMP frag-needed replies are filtered.", Body: `{{pmtu .PMTU}}`, Cmp: cmpU32(func(s btransport.TCPInfoSnapshot) uint32 { return s.PMTU }), Desc: false},
+	{Key: "cwnd", Label: "CWnd", Class: "num", Title: "Send congestion window in MSS units.", Body: `{{num .SndCwnd}}`, Cmp: cmpU32(func(s btransport.TCPInfoSnapshot) uint32 { return s.SndCwnd }), Desc: true},
+	{Key: "ssth", Label: "SSTh", Class: "num", Title: "Slow-start threshold in MSS units. When cwnd &lt; ssthresh we're in slow-start (often after a loss event).", Body: `{{num .SndSsthresh}}`, Cmp: cmpU32(func(s btransport.TCPInfoSnapshot) uint32 { return s.SndSsthresh }), Desc: true},
+	{Key: "sndwnd", Label: "SndWnd", Class: "num", Title: "Peer's advertised receive window (bytes) — the ceiling on what we can put in flight. Small = the peer is throttling us.", Body: `{{win .SndWnd}}`, Cmp: cmpU32(func(s btransport.TCPInfoSnapshot) uint32 { return s.SndWnd }), Desc: true},
+	{Key: "rcvwnd", Label: "RcvWnd", Class: "num", Title: "Our advertised receive window (bytes) — the ceiling the peer can push at us. Shrinking = we're a slow reader.", Body: `{{win .RcvWnd}}`, Cmp: cmpU32(func(s btransport.TCPInfoSnapshot) uint32 { return s.RcvWnd }), Desc: true},
+	{Key: "retr", Label: "Retr", Class: "num", Title: "Recent retransmits (kernel counter).", Body: `{{hotNum .Retransmits}}`, Cmp: cmpU32(func(s btransport.TCPInfoSnapshot) uint32 { return s.Retransmits }), Desc: true},
+	{Key: "totalretr", Label: "TotalRetr", Class: "num", Title: "Total retransmits since conn open — high count means path is lossy.", Body: `{{hotNum .TotalRetrans}}`, Cmp: cmpU32(func(s btransport.TCPInfoSnapshot) uint32 { return s.TotalRetrans }), Desc: true},
+	{Key: "rtxrate", Label: "RtxRate", Class: "num", Title: "Retransmit ratio: bytes retransmitted / bytes sent. The 'actual loss rate' this conn observed.", Body: `{{hotPct .RetransRatioPct}}`, Cmp: cmpF64(func(s btransport.TCPInfoSnapshot) float64 { return s.RetransRatioPct }), Desc: true},
+	{Key: "lost", Label: "Lost", Class: "num", Title: "Segments the kernel considers lost right now.", Body: `{{hotNum .Lost}}`, Cmp: cmpU32(func(s btransport.TCPInfoSnapshot) uint32 { return s.Lost }), Desc: true},
+	{Key: "sackd", Label: "SACKd", Class: "num", Title: "Segments selectively-ACK'd by the receiver.", Body: `{{num .Sacked}}`, Cmp: cmpU32(func(s btransport.TCPInfoSnapshot) uint32 { return s.Sacked }), Desc: true},
+	{Key: "unacked", Label: "Unacked", Class: "num", Title: "Segments sent but not yet ACKed (in flight).", Body: `{{num .Unacked}}`, Cmp: cmpU32(func(s btransport.TCPInfoSnapshot) uint32 { return s.Unacked }), Desc: true},
+	{Key: "dsack", Label: "DSACK", Class: "num", Title: "Duplicate-SACK count — number of SPURIOUS retransmits (we resent bytes the receiver actually got). High DSACK relative to TotalRetr = timing false-positives, not real loss.", Body: `{{hotNum .DsackDups}}`, Cmp: cmpU32(func(s btransport.TCPInfoSnapshot) uint32 { return s.DsackDups }), Desc: true},
+	{Key: "reord", Label: "ReordS", Class: "num", Title: "Times reordering was observed. Reordering can trigger fast-retransmit even without loss.", Body: `{{hotNum .ReordSeen}}`, Cmp: cmpU32(func(s btransport.TCPInfoSnapshot) uint32 { return s.ReordSeen }), Desc: true},
+	{Key: "ecn", Label: "ECN", Class: "num", Title: "Packets delivered with ECN Congestion-Experienced marks. Non-zero = a router is signaling congestion before dropping.", Body: `{{hotNum .DeliveredCE}}`, Cmp: cmpU32(func(s btransport.TCPInfoSnapshot) uint32 { return s.DeliveredCE }), Desc: true},
+	{Key: "sent", Label: "Sent", Class: "num", Title: "Total data bytes SENT (outbound cumulative).", Body: `{{bytes .BytesSent}}`, Cmp: cmpU64(func(s btransport.TCPInfoSnapshot) uint64 { return s.BytesSent }), Desc: true},
+	{Key: "recv", Label: "Recv", Class: "num", Title: "Total data bytes RECEIVED (inbound cumulative).", Body: `{{bytes .BytesReceived}}`, Cmp: cmpU64(func(s btransport.TCPInfoSnapshot) uint64 { return s.BytesReceived }), Desc: true},
+	{Key: "retrans", Label: "Retrans", Class: "num", Title: "Total bytes retransmitted (data).", Body: `{{hotBytes .BytesRetrans}}`, Cmp: cmpU64(func(s btransport.TCPInfoSnapshot) uint64 { return s.BytesRetrans }), Desc: true},
+	{Key: "delrate", Label: "DelRate", Class: "num", Title: "Recent outbound delivery rate — kernel's BBR estimate (bytes/sec) of the rate ACKs are flowing back. Best 'current bandwidth OUT' signal we have.", Body: `{{rate .DeliveryRate}}`, Cmp: cmpU64(func(s btransport.TCPInfoSnapshot) uint64 { return s.DeliveryRate }), Desc: true},
+	{Key: "avgout", Label: "AvgOut", Class: "num", Title: "Lifetime OUTBOUND throughput: BytesAcked ÷ conn age. Complements DelRate (instantaneous, kernel-windowed) — steady traffic makes them converge, bursty traffic makes AvgOut lag.", Body: `{{avgRate .BytesAcked .DialedAt}}`, Cmp: cmpF64(func(s btransport.TCPInfoSnapshot) float64 { return avgRateBps(s.BytesAcked, s.DialedAt) }), Desc: true},
+	{Key: "avgin", Label: "AvgIn", Class: "num", Title: "Lifetime INBOUND throughput: BytesReceived ÷ conn age. TCP_INFO has no windowed inbound-rate field, so lifetime avg is the cheapest honest answer — a windowed value would require diffing snapshots per conn.", Body: `{{avgRate .BytesReceived .DialedAt}}`, Cmp: cmpF64(func(s btransport.TCPInfoSnapshot) float64 { return avgRateBps(s.BytesReceived, s.DialedAt) }), Desc: true},
+	{Key: "notsent", Label: "NotSent", Class: "num", Title: "Bytes buffered but not yet on wire. High = we're app-limited or CPU-limited, not network-limited.", Body: `{{num .NotsentBytes}}`, Cmp: cmpU32(func(s btransport.TCPInfoSnapshot) uint32 { return s.NotsentBytes }), Desc: true},
+	{Key: "rwndlim", Label: "RwndLim", Class: "num", Title: "Cumulative time the sender was blocked by the peer's receive window. Non-zero = flow control cost real wall clock; the peer is a slow reader.", Body: `{{hotDur .RwndLimited}}`, Cmp: cmpDur(func(s btransport.TCPInfoSnapshot) time.Duration { return s.RwndLimited }), Desc: true},
+	{Key: "sndbuflim", Label: "SndBufLim", Class: "num", Title: "Cumulative time blocked by our own SO_SNDBUF. Non-zero = our local send buffer is undersized for the bandwidth-delay product.", Body: `{{hotDur .SndbufLimited}}`, Cmp: cmpDur(func(s btransport.TCPInfoSnapshot) time.Duration { return s.SndbufLimited }), Desc: true},
+	{Key: "lastrecv", Label: "LastRecv", Title: "Time since the socket last received data.", Body: `{{dur .LastDataRecv}}`, Cmp: cmpDur(func(s btransport.TCPInfoSnapshot) time.Duration { return s.LastDataRecv }), Desc: true},
+	{Key: "lastsent", Label: "LastSent", Title: "Time since the socket last sent data.", Body: `{{dur .LastDataSent}}`, Cmp: cmpDur(func(s btransport.TCPInfoSnapshot) time.Duration { return s.LastDataSent }), Desc: true},
+	{Key: "", Label: "Err", Class: "err", Title: "Populated when TCP_INFO couldn't be read on a live fd (e.g. non-Linux OS).", Body: `{{.Err}}`},
+}
+
+// tcpzColByKey builds a lookup for tcpzCols; done once at init so the
+// request handler doesn't re-scan the slice per request.
+var tcpzColByKey = func() map[string]*tcpzColDef {
+	m := make(map[string]*tcpzColDef, len(tcpzCols))
+	for i := range tcpzCols {
+		if tcpzCols[i].Key != "" {
+			m[tcpzCols[i].Key] = &tcpzCols[i]
+		}
+	}
+	return m
+}()
+
+// cmp* factories: thin wrappers that turn "extract field X" into a
+// comparator. Keeps the tcpzColDef literals dense and readable.
+func cmpStr(get func(btransport.TCPInfoSnapshot) string) func(a, b btransport.TCPInfoSnapshot) int {
+	return func(a, b btransport.TCPInfoSnapshot) int { return strings.Compare(get(a), get(b)) }
+}
+func cmpU32(get func(btransport.TCPInfoSnapshot) uint32) func(a, b btransport.TCPInfoSnapshot) int {
+	return func(a, b btransport.TCPInfoSnapshot) int {
+		x, y := get(a), get(b)
+		switch {
+		case x < y:
+			return -1
+		case x > y:
+			return 1
+		}
+		return 0
+	}
+}
+func cmpU64(get func(btransport.TCPInfoSnapshot) uint64) func(a, b btransport.TCPInfoSnapshot) int {
+	return func(a, b btransport.TCPInfoSnapshot) int {
+		x, y := get(a), get(b)
+		switch {
+		case x < y:
+			return -1
+		case x > y:
+			return 1
+		}
+		return 0
+	}
+}
+func cmpF64(get func(btransport.TCPInfoSnapshot) float64) func(a, b btransport.TCPInfoSnapshot) int {
+	return func(a, b btransport.TCPInfoSnapshot) int {
+		x, y := get(a), get(b)
+		switch {
+		case x < y:
+			return -1
+		case x > y:
+			return 1
+		}
+		return 0
+	}
+}
+func cmpDur(get func(btransport.TCPInfoSnapshot) time.Duration) func(a, b btransport.TCPInfoSnapshot) int {
+	return func(a, b btransport.TCPInfoSnapshot) int {
+		x, y := get(a), get(b)
+		switch {
+		case x < y:
+			return -1
+		case x > y:
+			return 1
+		}
+		return 0
+	}
+}
+// avgRateBps returns lifetime throughput in bytes/sec (BytesAcked ÷
+// age). Zero when the conn hasn't ACKed data yet, isn't dialed, or
+// age is non-positive. Used both by the display func and the column
+// comparator so sort order matches the rendered value.
+func avgRateBps(bytesAcked uint64, dialedAt time.Time) float64 {
+	if bytesAcked == 0 || dialedAt.IsZero() {
+		return 0
+	}
+	age := time.Since(dialedAt).Seconds()
+	if age <= 0 {
+		return 0
+	}
+	return float64(bytesAcked) / age
+}
+
+// formatBytesPerSec renders a bytes/sec value with a scale suffix.
+// Shared by the "rate" (kernel-reported DeliveryRate) and "avgRate"
+// (BytesAcked ÷ age) template funcs so both columns format identically.
+func formatBytesPerSec(v float64) string {
+	if v <= 0 {
+		return "—"
+	}
+	switch {
+	case v >= 1<<20:
+		return fmt.Sprintf("%.1f MB/s", v/(1<<20))
+	case v >= 1<<10:
+		return fmt.Sprintf("%.1f KB/s", v/(1<<10))
+	default:
+		return fmt.Sprintf("%.0f B/s", v)
+	}
+}
+
+func cmpTime(get func(btransport.TCPInfoSnapshot) time.Time) func(a, b btransport.TCPInfoSnapshot) int {
+	return func(a, b btransport.TCPInfoSnapshot) int {
+		x, y := get(a), get(b)
+		switch {
+		case x.Before(y):
+			return -1
+		case x.After(y):
+			return 1
+		}
+		return 0
+	}
+}
+
+// tcpzHeaderCell is the per-column view struct the template iterates.
+// Built once per request so all the "which arrow, which link" logic
+// lives in Go — the template just prints strings.
+type tcpzHeaderCell struct {
+	Label     string
+	Class     string
+	Title     string
+	Href      string        // "" if not sortable
+	Arrow     string        // "" / "↑" / "↓"
+	BodyTpl   template.HTML // <td>…</td> inner action, wrapped with class
+	CellClass string        // repeated per row via BodyTpl already; kept for possible reuse
+}
+
+func (s *tcpzServer) handleIndex(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	all := q.Get("all") == "1"
+	onlyHot := q.Get("only") == "hot"
+	flat := q.Get("flat") == "1"
+	expandAll := q.Get("expand") == "all"
+	remoteFilter := q.Get("remote")
+	sortKey, sortDir := parseSort(q)
+
+	raw := s.snapshot()
+	total := len(raw)
+	hidden := 0
+	if remoteFilter != "" {
+		filtered := raw[:0]
+		for _, snap := range raw {
+			if snap.RemoteAddr != remoteFilter {
+				hidden++
+				continue
+			}
+			filtered = append(filtered, snap)
+		}
+		raw = filtered
+	} else if !all {
+		filtered := raw[:0]
+		for _, snap := range raw {
+			if strings.HasSuffix(snap.RemoteAddr, ":443") {
+				hidden++
+				continue
+			}
+			filtered = append(filtered, snap)
+		}
+		raw = filtered
+	}
+
+	// Serve JSON before we build display-only fields.
+	if q.Get("format") == "json" {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		_ = json.NewEncoder(w).Encode(raw)
+		return
+	}
+
+	rows := make([]tcpzRow, 0, len(raw))
+	interesting := 0
+	dropped := 0
+	// hiddenByRemote tracks conns dropped by ?only=hot per remote, so
+	// each group can show "N shown · M hidden" without under-representing
+	// active-but-quiet peers.
+	hiddenByRemote := map[string]int{}
+	for _, snap := range raw {
+		sev, why := classify(snap)
+		if sev > sevOK {
+			interesting++
+		}
+		if onlyHot && sev < sevWarn {
+			dropped++
+			hiddenByRemote[snap.RemoteAddr]++
+			continue
+		}
+		rows = append(rows, tcpzRow{
+			TCPInfoSnapshot: snap,
+			Sev:             sev.rowClass(),
+			SevRank:         int(sev),
+			Why:             strings.Join(why, "+"),
+			Interest:        sev > sevOK,
+		})
+	}
+
+	sortRows(rows, sortKey, sortDir)
+	groups := buildPeerGroups(rows, hiddenByRemote)
+
+	// Histograms cover the pre-filter live snapshot (raw) plus every
+	// remembered dead conn, so the summary reflects the fleet — the "only
+	// hot" / :443-hidden table filters shouldn't be able to hide a hot
+	// cluster from the distribution.
+	histPanels := buildHistPanels(raw, s.deadConns())
+
+	baseParams := url.Values{}
+	if all {
+		baseParams.Set("all", "1")
+	}
+	if onlyHot {
+		baseParams.Set("only", "hot")
+	}
+	if flat {
+		// Sort links must round-trip the flat toggle; otherwise clicking
+		// a column header jumps back to the grouped default view.
+		baseParams.Set("flat", "1")
+	}
+	headers := make([]tcpzHeaderCell, len(tcpzCols))
+	for i, c := range tcpzCols {
+		hc := tcpzHeaderCell{Label: c.Label, Class: c.Class, Title: c.Title}
+		if c.Cmp != nil {
+			nextDir := "asc"
+			if c.Desc {
+				nextDir = "desc"
+			}
+			if sortKey == c.Key {
+				if sortDir == "asc" {
+					hc.Arrow = "↑"
+					nextDir = "desc"
+				} else {
+					hc.Arrow = "↓"
+					nextDir = "asc"
+				}
+			}
+			p := cloneValues(baseParams)
+			p.Set("sort", c.Key)
+			p.Set("dir", nextDir)
+			hc.Href = "?" + p.Encode()
+		}
+		headers[i] = hc
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	data := struct {
+		Rows        []tcpzRow
+		Groups      []*peerGroup
+		Cols        []tcpzColDef
+		Headers     []tcpzHeaderCell
+		HistPanels  []*histPanel
+		Count       int
+		GroupCount  int
+		Total       int
+		Hidden      int
+		Interesting int
+		Dropped     int
+		ShowAll     bool
+		OnlyHot     bool
+		Flat        bool
+		ExpandAll   bool
+		SortKey     string
+		SortDir     string
+		SortByDial  bool
+		Generated   time.Time
+	}{
+		Rows:        rows,
+		Groups:      groups,
+		Cols:        tcpzCols,
+		Headers:     headers,
+		HistPanels:  histPanels,
+		Count:       len(rows),
+		GroupCount:  len(groups),
+		Total:       total,
+		Hidden:      hidden,
+		Interesting: interesting,
+		Dropped:     dropped,
+		ShowAll:     all,
+		OnlyHot:     onlyHot,
+		Flat:        flat,
+		ExpandAll:   expandAll,
+		SortKey:     sortKey,
+		SortDir:     sortDir,
+		SortByDial:  sortKey == "dial",
+		Generated:   time.Now(),
+	}
+	tpl := tcpzTpl
+	if flat {
+		tpl = tcpzFlatTpl
+	}
+	if err := tpl.Execute(w, data); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// parseSort normalizes ?sort=<key>&dir=<asc|desc>. Unknown keys silently
+// fall back to "sev" so a stale bookmarked URL doesn't 404. dir="" means
+// "use the column's natural direction" (handled by sortRows).
+func parseSort(q url.Values) (key, dir string) {
+	key = q.Get("sort")
+	dir = q.Get("dir")
+	if dir != "asc" && dir != "desc" {
+		dir = ""
+	}
+	switch key {
+	case "", "sev", "dial":
+		if key == "" {
+			key = "sev"
+		}
+		return key, dir
+	}
+	if _, ok := tcpzColByKey[key]; !ok {
+		return "sev", "" // unknown column — fall back cleanly
+	}
+	return key, dir
+}
+
+// sortRows reorders rows in place per key+dir. Special keys "sev" and
+// "dial" don't map to columns and get their own comparators. All other
+// keys map to a tcpzColDef.Cmp.
+func sortRows(rows []tcpzRow, key, dir string) {
+	switch key {
+	case "sev":
+		sort.SliceStable(rows, func(i, j int) bool {
+			si := sevRank(rows[i].Sev)
+			sj := sevRank(rows[j].Sev)
+			if si != sj {
+				return si > sj
+			}
+			return rows[i].DialedAt.Before(rows[j].DialedAt)
+		})
+		return
+	case "dial":
+		sort.SliceStable(rows, func(i, j int) bool {
+			return rows[i].DialedAt.Before(rows[j].DialedAt)
+		})
+		return
+	}
+	c, ok := tcpzColByKey[key]
+	if !ok || c.Cmp == nil {
+		return
+	}
+	desc := c.Desc
+	if dir == "asc" {
+		desc = false
+	} else if dir == "desc" {
+		desc = true
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		r := c.Cmp(rows[i].TCPInfoSnapshot, rows[j].TCPInfoSnapshot)
+		if r == 0 {
+			return rows[i].DialedAt.Before(rows[j].DialedAt)
+		}
+		if desc {
+			return r > 0
+		}
+		return r < 0
+	})
+}
+
+// cloneValues returns a shallow copy of v so we can mutate it per header
+// link without polluting the base params slice.
+func cloneValues(v url.Values) url.Values {
+	out := make(url.Values, len(v))
+	for k, vs := range v {
+		out[k] = append([]string(nil), vs...)
+	}
+	return out
+}
+
+// sevRank maps the row-class string back to a comparable int so the
+// sort comparator doesn't have to hold onto the severity enum
+// separately.
+func sevRank(cls string) int {
+	switch cls {
+	case "row-crit":
+		return 3
+	case "row-warn":
+		return 2
+	case "row-note":
+		return 1
+	}
+	return 0
+}
+
+// tcpzBodyTpls holds each column's cell-body snippet, parsed once at
+// package init against the same funcs map the outer template uses. The
+// outer template's per-row loop calls {{cell $i $row}} which executes
+// the matching bodyTpl — this keeps the outer template short and lets
+// column order / additions be a one-slice-entry change to tcpzCols.
+var tcpzBodyTpls []*template.Template
+
+func tcpzFuncs() template.FuncMap {
+	return template.FuncMap{
+		"dur": func(d time.Duration) string {
+			if d == 0 {
+				return "—"
+			}
+			return d.String()
+		},
+		"ago": func(t time.Time) string {
+			if t.IsZero() {
+				return "—"
+			}
+			return time.Since(t).Round(time.Second).String()
+		},
+		"num": func(v uint32) string {
+			if v == 0 {
+				return "—"
+			}
+			return fmt.Sprintf("%d", v)
+		},
+		"pmtu": func(v uint32) template.HTML {
+			if v == 0 {
+				return template.HTML("—")
+			}
+			switch {
+			case v >= 1500:
+				return template.HTML(fmt.Sprintf("%d", v))
+			case v < 1300:
+				return template.HTML(fmt.Sprintf(`<b class="hot" title="%d B below 1500 — unusually heavy encapsulation">%d</b>`, 1500-v, v))
+			default:
+				return template.HTML(fmt.Sprintf(`<span title="%d B below 1500 — tunneling in path">%d</span>`, 1500-v, v))
+			}
+		},
+		"num64": func(v uint64) string {
+			if v == 0 {
+				return "—"
+			}
+			return fmt.Sprintf("%d", v)
+		},
+		"pct": func(v float64) string {
+			if v == 0 {
+				return "—"
+			}
+			if v < 0.01 {
+				return "<0.01%"
+			}
+			return fmt.Sprintf("%.2f%%", v)
+		},
+		"rate": func(v uint64) string {
+			if v == 0 {
+				return "—"
+			}
+			return formatBytesPerSec(float64(v))
+		},
+		"avgRate": func(bytesAcked uint64, dialedAt time.Time) string {
+			return formatBytesPerSec(avgRateBps(bytesAcked, dialedAt))
+		},
+		"bytes": func(v uint64) string {
+			if v == 0 {
+				return "—"
+			}
+			f := float64(v)
+			switch {
+			case f >= 1<<30:
+				return fmt.Sprintf("%.1f GiB", f/(1<<30))
+			case f >= 1<<20:
+				return fmt.Sprintf("%.1f MiB", f/(1<<20))
+			case f >= 1<<10:
+				return fmt.Sprintf("%.1f KiB", f/(1<<10))
+			default:
+				return fmt.Sprintf("%d B", v)
+			}
+		},
+		"hotNum": func(v uint32) template.HTML {
+			if v == 0 {
+				return template.HTML("—")
+			}
+			return template.HTML(fmt.Sprintf(`<b class="hot">%d</b>`, v))
+		},
+		"hotDur": func(d time.Duration) template.HTML {
+			if d == 0 {
+				return template.HTML("—")
+			}
+			return template.HTML(fmt.Sprintf(`<b class="hot">%s</b>`, d.String()))
+		},
+		"win": func(v uint32) string {
+			if v == 0 {
+				return "—"
+			}
+			f := float64(v)
+			switch {
+			case f >= 1<<20:
+				return fmt.Sprintf("%.1f MiB", f/(1<<20))
+			case f >= 1<<10:
+				return fmt.Sprintf("%.1f KiB", f/(1<<10))
+			default:
+				return fmt.Sprintf("%d B", v)
+			}
+		},
+		"critNum": func(v uint32) template.HTML {
+			if v == 0 {
+				return template.HTML("—")
+			}
+			return template.HTML(fmt.Sprintf(`<b class="hot crit">%d</b>`, v))
+		},
+		"hotBytes": func(v uint64) template.HTML {
+			if v == 0 {
+				return template.HTML("—")
+			}
+			f := float64(v)
+			var s string
+			switch {
+			case f >= 1<<30:
+				s = fmt.Sprintf("%.1f GiB", f/(1<<30))
+			case f >= 1<<20:
+				s = fmt.Sprintf("%.1f MiB", f/(1<<20))
+			case f >= 1<<10:
+				s = fmt.Sprintf("%.1f KiB", f/(1<<10))
+			default:
+				s = fmt.Sprintf("%d B", v)
+			}
+			return template.HTML(fmt.Sprintf(`<b class="hot">%s</b>`, s))
+		},
+		"hotPct": func(v float64) template.HTML {
+			if v == 0 {
+				return template.HTML("—")
+			}
+			var s string
+			if v < 0.01 {
+				s = "<0.01%"
+			} else {
+				s = fmt.Sprintf("%.2f%%", v)
+			}
+			return template.HTML(fmt.Sprintf(`<b class="hot">%s</b>`, s))
+		},
+		"or": func(s, fallback string) string {
+			if s == "" {
+				return fallback
+			}
+			return s
+		},
+		// cell renders one column's inner HTML for one row by executing
+		// the per-column body template. tcpzBodyTpls is populated in
+		// init(); Parse only needs the func to exist, not for bodies to
+		// be ready yet.
+		"cell": func(idx int, r tcpzRow) (template.HTML, error) {
+			var buf strings.Builder
+			if err := tcpzBodyTpls[idx].Execute(&buf, r); err != nil {
+				return "", err
+			}
+			return template.HTML(buf.String()), nil
+		},
+		// bpsF: format a float64 bytes/sec (aggregate) with the same
+		// scale suffix as the per-conn "rate" func. Zero → dash.
+		"bpsF": func(v float64) string {
+			if v <= 0 {
+				return "—"
+			}
+			return formatBytesPerSec(v)
+		},
+		// ageDur: pretty-print a positive duration; used by peer-group
+		// summaries where we've already computed age with time.Since.
+		"ageDur": func(d time.Duration) string {
+			if d <= 0 {
+				return "—"
+			}
+			return d.Round(time.Second).String()
+		},
+	}
+}
+
+// Cache the funcs so column bodies parse against the exact same map the
+// outer template uses.
+var tcpzFuncsCached = tcpzFuncs()
+
+func init() {
+	tcpzBodyTpls = make([]*template.Template, len(tcpzCols))
+	for i, c := range tcpzCols {
+		t, err := template.New(fmt.Sprintf("tcpz-col-%d", i)).Funcs(tcpzFuncsCached).Parse(c.Body)
+		if err != nil {
+			panic(fmt.Sprintf("tcpz: parse column %q body: %v", c.Label, err))
+		}
+		tcpzBodyTpls[i] = t
+	}
+}
+
+// tcpzFlatTpl renders the classic wide-table view (?flat=1). Kept as an
+// escape hatch for muscle-memory bookmarks; the default is the grouped
+// card view (tcpzTpl below).
+var tcpzFlatTpl = template.Must(template.New("tcpz-flat").Funcs(tcpzFuncsCached).Parse(tcpzFlatTplSrc))
+
+const tcpzFlatTplSrc = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>tcpz — {{.Count}} conns{{if .Interesting}} · {{.Interesting}} hot{{end}}</title>
+<meta http-equiv="refresh" content="5">
+<style>
+body { font: 13px/1.4 -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; margin: 1em; color: #222; }
+h1 { font-size: 1.1em; margin: 0 0 .3em 0; }
+.meta { color: #666; margin-bottom: .3em; }
+.legend { color: #666; margin-bottom: .8em; font-size: 12px; }
+.legend .sw { display: inline-block; width: .85em; height: .85em; vertical-align: -1px; border: 1px solid #ccc; margin-right: 3px; }
+.legend .sw.crit { background: #fdecea; border-color: #f2c2bd; }
+.legend .sw.warn { background: #fff5e0; border-color: #ecd9a3; }
+.legend .sw.note { background: #eef4fb; border-color: #cddceb; }
+.legend .sw.ok   { background: #ffffff; }
+table { border-collapse: collapse; width: 100%; }
+th, td { text-align: left; padding: 4px 8px; border-bottom: 1px solid #eee; }
+th { background: #f4f4f4; font-weight: 600; position: sticky; top: 0; }
+td.num { text-align: right; font-variant-numeric: tabular-nums; }
+td.mono, th.mono { font-family: SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px; }
+tr.row-crit td { background: #fdecea; }
+tr.row-warn td { background: #fff5e0; }
+tr.row-note td { background: #eef4fb; }
+tr.row-crit:hover td { background: #fadbd7; }
+tr.row-warn:hover td { background: #ffecc4; }
+tr.row-note:hover td { background: #dde9f4; }
+tr.row-ok:hover td   { background: #fafafa; }
+.why { color: #666; font-size: 11px; font-family: SFMono-Regular, Menlo, Consolas, monospace; }
+tr.row-crit .why { color: #b32222; }
+tr.row-warn .why { color: #a04500; }
+b.hot { color: #a04500; }
+b.hot.crit { color: #b32222; background: #f7d7d3; padding: 0 3px; border-radius: 2px; }
+a.col-sort { color: inherit; text-decoration: none; }
+a.col-sort:hover { text-decoration: underline; }
+a.col-sort .arr { color: #d95700; margin-left: 2px; }
+.empty { color: #888; margin: 2em 0; }
+.err { color: #a04500; }
+.state-ESTABLISHED { color: #197a1f; }
+.state-CLOSE_WAIT, .state-FIN_WAIT1, .state-FIN_WAIT2, .state-CLOSING, .state-LAST_ACK, .state-TIME_WAIT { color: #a04500; font-weight: 600; }
+.ca-Open { color: #197a1f; }
+.ca-Disorder { color: #a06a00; font-weight: 600; }
+.ca-CWR { color: #a04500; font-weight: 600; }
+.ca-Recovery { color: #b32222; font-weight: 600; }
+.ca-Loss { color: #b32222; font-weight: 700; }
+.hist-grid { display: flex; gap: 1em; flex-wrap: wrap; margin: .4em 0 1em 0; }
+.hist-panel { flex: 1 1 320px; min-width: 280px; border: 1px solid #e8e8e8; border-radius: 3px; padding: .5em .7em; background: #fafafa; }
+.hist-title { font-weight: 600; margin-bottom: .1em; font-size: 12px; }
+.hist-summary { color: #666; font-size: 11px; font-variant-numeric: tabular-nums; margin-bottom: .35em; }
+.hist-row { display: grid; grid-template-columns: 82px 1fr 60px; gap: 6px; align-items: center; font-size: 11px; font-variant-numeric: tabular-nums; line-height: 1.35; }
+.hist-lbl { color: #555; font-family: SFMono-Regular, Menlo, Consolas, monospace; text-align: right; }
+.hist-track { position: relative; height: 10px; background: #eee; border-radius: 2px; overflow: hidden; }
+.hist-bar-live { position: absolute; top: 0; bottom: 0; left: 0; background: #4a7fbf; }
+.hist-bar-dead { position: absolute; top: 0; bottom: 0; background: #b8763f; opacity: .85; }
+.hist-cnt { color: #444; font-family: SFMono-Regular, Menlo, Consolas, monospace; }
+.hist-cnt .dead { color: #a04500; }
+.hist-legend { color: #666; font-size: 11px; margin-top: .4em; }
+.hist-legend .sw { display: inline-block; width: .75em; height: .75em; vertical-align: -1px; border-radius: 2px; margin: 0 3px 0 6px; }
+.hist-legend .sw.live { background: #4a7fbf; }
+.hist-legend .sw.dead { background: #b8763f; }
+</style>
+</head>
+<body>
+<h1>tcpz — {{.Count}} conn{{if ne .Count 1}}s{{end}}{{if .Interesting}} · <span style="color:#b32222">{{.Interesting}} interesting</span>{{end}}{{if .Hidden}} <span style="color:#888;font-weight:400;font-size:.85em">({{.Hidden}} :443 hidden)</span>{{end}}{{if .Dropped}} <span style="color:#888;font-weight:400;font-size:.85em">({{.Dropped}} healthy hidden)</span>{{end}}</h1>
+<div class="meta">Snapshot at {{.Generated.Format "15:04:05.000"}} · auto-refresh 5s · <a href="?format=json{{if .ShowAll}}&amp;all=1{{end}}">JSON</a>
+ · <a href="?{{if .ShowAll}}all=1{{end}}{{if .OnlyHot}}{{if .ShowAll}}&amp;{{end}}only=hot{{end}}">grouped view</a>
+{{if .ShowAll}} · <a href="?flat=1">hide :443 (default)</a>{{else if .Hidden}} · <a href="?flat=1&amp;all=1">show all ({{.Total}})</a>{{end}}
+{{if .OnlyHot}} · <a href="?flat=1{{if .ShowAll}}&amp;all=1{{end}}">show healthy too</a>{{else}} · <a href="?flat=1&amp;only=hot{{if .ShowAll}}&amp;all=1{{end}}">only hot</a>{{end}}
+· sort: {{if eq .SortKey "sev"}}<b>severity</b>{{else}}<a href="?flat=1&amp;{{if .ShowAll}}all=1&amp;{{end}}{{if .OnlyHot}}only=hot&amp;{{end}}sort=sev">severity</a>{{end}}
+| {{if eq .SortKey "dial"}}<b>dial order</b>{{else}}<a href="?flat=1&amp;{{if .ShowAll}}all=1&amp;{{end}}{{if .OnlyHot}}only=hot&amp;{{end}}sort=dial">dial order</a>{{end}}
+{{if and (ne .SortKey "sev") (ne .SortKey "dial")}} | column: <b>{{.SortKey}} {{if eq .SortDir "asc"}}↑{{else}}↓{{end}}</b>{{end}}
+</div>
+<div class="legend">Row color:
+<span class="sw crit"></span>Loss / backoff (RTO-driven)
+<span class="sw warn"></span>retrans / DSACK / ECN / reorder
+<span class="sw note"></span>non-ESTABLISHED / unreadable
+<span class="sw ok"></span>healthy
+· <b class="hot">bold orange</b> = the specific counter that flagged the row.
+</div>
+{{if .HistPanels}}
+<div class="hist-grid">
+{{range $panel := .HistPanels}}
+<div class="hist-panel">
+<div class="hist-title">{{$panel.Title}}</div>
+<div class="hist-summary">{{$panel.Summary}}</div>
+{{range $panel.Bars}}
+<div class="hist-row">
+<span class="hist-lbl">{{.Label}}</span>
+<span class="hist-track">
+{{if .LivePct}}<span class="hist-bar-live" style="width:{{.LivePct}}%"></span>{{end}}
+{{if .DeadPct}}<span class="hist-bar-dead" style="left:{{.LivePct}}%;width:{{.DeadPct}}%"></span>{{end}}
+</span>
+<span class="hist-cnt">{{.Live}}{{if $panel.HasDead}} / <span class="dead">{{.Dead}}</span>{{end}}</span>
+</div>
+{{end}}
+{{if $panel.HasDead}}<div class="hist-legend"><span class="sw live"></span>live<span class="sw dead"></span>dead</div>{{end}}
+</div>
+{{end}}
+</div>
+{{end}}
+{{if not .Rows}}
+<div class="empty">No conns registered. Either the client uses DirectPath (xDS bypasses the standard dialer, so nothing is captured), no traffic has been dialed yet, {{if .OnlyHot}}every conn is healthy (try <a href="?">without ?only=hot</a>), {{end}}or bigtable.TCPStats was never passed into the Client's options.</div>
+{{else}}
+<table>
+<thead><tr>
+{{range .Headers}}
+<th{{if .Class}} class="{{.Class}}"{{end}} title="{{.Title}}">{{if .Href}}<a class="col-sort" href="{{.Href}}">{{.Label}}{{if .Arrow}}<span class="arr">{{.Arrow}}</span>{{end}}</a>{{else}}{{.Label}}{{end}}</th>
+{{end}}
+</tr></thead>
+<tbody>
+{{range $r := .Rows}}
+<tr class="{{$r.Sev}}">{{range $i, $c := $.Cols}}<td{{if $c.Class}} class="{{$c.Class}}"{{end}}>{{cell $i $r}}</td>{{end}}</tr>
+{{end}}
+</tbody>
+</table>
+{{end}}
+</body>
+</html>
+`
+
+// tcpzTpl is the default grouped view: one card per remote peer, with
+// a one-line summary per conn expandable to six field cards
+// (Traffic / Latency / Loss / Window / RTO / Idle). Designed so a
+// healthy fleet is a wall of green with tiny numbers, and one hot conn
+// turns its whole card orange with the specific counter that flagged
+// it visible without expanding anything.
+var tcpzTpl = template.Must(template.New("tcpz-grouped").Funcs(tcpzFuncsCached).Parse(tcpzTplSrc))
+
+const tcpzTplSrc = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>tcpz — {{.GroupCount}} peer{{if ne .GroupCount 1}}s{{end}}{{if .Interesting}} · {{.Interesting}} hot{{end}}</title>
+<meta http-equiv="refresh" content="5">
+<style>
+body { font: 13px/1.4 -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; margin: 1em; color: #222; background: #fafbfc; }
+h1 { font-size: 1.15em; margin: 0 0 .3em 0; }
+.meta { color: #666; margin-bottom: .5em; }
+.meta a { color: #2f5f9f; text-decoration: none; }
+.meta a:hover { text-decoration: underline; }
+.legend { color: #666; margin-bottom: .8em; font-size: 12px; }
+.legend .sw { display: inline-block; width: .85em; height: .85em; vertical-align: -1px; border-radius: 2px; border: 1px solid #ccc; margin-right: 3px; }
+.legend .sw.crit { background: #fdecea; border-color: #f2c2bd; }
+.legend .sw.warn { background: #fff5e0; border-color: #ecd9a3; }
+.legend .sw.note { background: #eef4fb; border-color: #cddceb; }
+.legend .sw.ok   { background: #eefaf0; border-color: #cfe9d3; }
+
+/* Peer group card */
+.grp { border: 1px solid #dfe3e8; border-radius: 6px; background: #fff; margin: 0 0 .8em 0; overflow: hidden; box-shadow: 0 1px 0 rgba(0,0,0,.03); }
+.grp.row-crit { border-color: #f2c2bd; background: #fef7f5; }
+.grp.row-warn { border-color: #ecd9a3; background: #fefbf1; }
+.grp.row-note { border-color: #cddceb; background: #f6f9fd; }
+.grp-hdr { display: flex; align-items: center; gap: .7em; padding: .55em .8em; border-bottom: 1px solid #eee; background: rgba(0,0,0,.015); }
+.grp.row-crit .grp-hdr { background: #fbe3df; border-bottom-color: #f2c2bd; }
+.grp.row-warn .grp-hdr { background: #fbeecd; border-bottom-color: #ecd9a3; }
+.grp.row-note .grp-hdr { background: #e6eefa; border-bottom-color: #cddceb; }
+.grp-remote { font-family: SFMono-Regular, Menlo, Consolas, monospace; font-size: 12.5px; font-weight: 600; color: #333; }
+.grp-stats { color: #555; font-size: 12px; font-variant-numeric: tabular-nums; margin-left: auto; }
+.grp-stats b { color: #222; font-weight: 600; }
+.grp-count { color: #444; font-size: 12px; }
+.grp-count .hot { color: #b32222; font-weight: 600; }
+.grp-count .hidden { color: #888; }
+
+/* Chip: state / CA / anomaly. Consistent shape across all rows. */
+.chip { display: inline-block; padding: 1px 6px; border-radius: 10px; font-size: 11px; font-variant-numeric: tabular-nums; border: 1px solid #ccc; background: #f6f6f6; color: #444; }
+.chip.state-ESTABLISHED { background: #eefaf0; border-color: #cfe9d3; color: #197a1f; }
+.chip.state-CLOSE_WAIT, .chip.state-FIN_WAIT1, .chip.state-FIN_WAIT2, .chip.state-CLOSING, .chip.state-LAST_ACK, .chip.state-TIME_WAIT { background: #fbeecd; border-color: #ecd9a3; color: #a04500; }
+.chip.ca-Open { background: #eefaf0; border-color: #cfe9d3; color: #197a1f; }
+.chip.ca-Disorder { background: #fbeecd; border-color: #ecd9a3; color: #a04500; }
+.chip.ca-CWR, .chip.ca-Recovery { background: #fbe3df; border-color: #f2c2bd; color: #b32222; }
+.chip.ca-Loss { background: #fbe3df; border-color: #f2c2bd; color: #b32222; font-weight: 700; }
+.chip.anom-warn { background: #fbeecd; border-color: #ecd9a3; color: #a04500; font-weight: 600; }
+.chip.anom-crit { background: #fbe3df; border-color: #f2c2bd; color: #b32222; font-weight: 700; }
+
+/* Per-conn one-line summary; details for the expanded field cards. */
+details.conn { border-top: 1px solid #eee; }
+details.conn:first-of-type { border-top: none; }
+details.conn > summary { list-style: none; cursor: pointer; padding: .45em .8em; display: flex; align-items: center; gap: .6em; font-size: 12.5px; }
+details.conn > summary::-webkit-details-marker { display: none; }
+details.conn > summary::before { content: "▶"; color: #999; font-size: 10px; width: 10px; }
+details.conn[open] > summary::before { content: "▼"; }
+details.conn > summary:hover { background: rgba(0,0,0,.02); }
+.conn-id { font-family: SFMono-Regular, Menlo, Consolas, monospace; color: #555; min-width: 130px; }
+.conn-tp { font-family: SFMono-Regular, Menlo, Consolas, monospace; font-variant-numeric: tabular-nums; color: #333; margin-left: auto; }
+.conn-tp .up { color: #197a1f; }
+.conn-tp .dn { color: #2f5f9f; }
+.conn-why { color: #a04500; font-size: 11px; font-family: SFMono-Regular, Menlo, Consolas, monospace; }
+details.conn.row-crit > summary { background: rgba(179,34,34,.05); }
+details.conn.row-crit .conn-why { color: #b32222; }
+
+/* Field cards inside an expanded conn */
+.cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: .5em; padding: .5em .8em .8em .8em; background: rgba(0,0,0,.02); }
+.card { background: #fff; border: 1px solid #e2e6ea; border-radius: 4px; padding: .45em .6em; font-size: 12px; }
+.card h4 { margin: 0 0 .3em 0; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: #666; font-weight: 600; }
+.card dl { display: grid; grid-template-columns: 1fr auto; gap: 1px 8px; margin: 0; font-variant-numeric: tabular-nums; }
+.card dt { color: #555; }
+.card dd { margin: 0; color: #222; text-align: right; font-family: SFMono-Regular, Menlo, Consolas, monospace; }
+.card dd .hot { color: #a04500; font-weight: 600; }
+.card dd .hot.crit { color: #b32222; font-weight: 700; }
+.card dd.warn { color: #a04500; font-weight: 600; }
+.card dd.crit { color: #b32222; font-weight: 700; }
+.card.err-card { border-color: #f2c2bd; background: #fef7f5; grid-column: 1 / -1; }
+
+/* Reuse the histogram panels verbatim from the flat view */
+.hist-grid { display: flex; gap: 1em; flex-wrap: wrap; margin: .4em 0 1em 0; }
+.hist-panel { flex: 1 1 320px; min-width: 280px; border: 1px solid #e2e6ea; border-radius: 4px; padding: .5em .7em; background: #fff; }
+.hist-title { font-weight: 600; margin-bottom: .1em; font-size: 12px; }
+.hist-summary { color: #666; font-size: 11px; font-variant-numeric: tabular-nums; margin-bottom: .35em; }
+.hist-row { display: grid; grid-template-columns: 82px 1fr 60px; gap: 6px; align-items: center; font-size: 11px; font-variant-numeric: tabular-nums; line-height: 1.35; }
+.hist-lbl { color: #555; font-family: SFMono-Regular, Menlo, Consolas, monospace; text-align: right; }
+.hist-track { position: relative; height: 10px; background: #f0f0f0; border-radius: 2px; overflow: hidden; }
+.hist-bar-live { position: absolute; top: 0; bottom: 0; left: 0; background: #4a7fbf; }
+.hist-bar-dead { position: absolute; top: 0; bottom: 0; background: #b8763f; opacity: .85; }
+.hist-cnt { color: #444; font-family: SFMono-Regular, Menlo, Consolas, monospace; }
+.hist-cnt .dead { color: #a04500; }
+.hist-legend { color: #666; font-size: 11px; margin-top: .4em; }
+.hist-legend .sw { display: inline-block; width: .75em; height: .75em; vertical-align: -1px; border-radius: 2px; margin: 0 3px 0 6px; }
+.hist-legend .sw.live { background: #4a7fbf; }
+.hist-legend .sw.dead { background: #b8763f; }
+
+.empty { color: #888; margin: 2em 0; }
+</style>
+</head>
+<body>
+<h1>tcpz — {{.GroupCount}} peer{{if ne .GroupCount 1}}s{{end}} · {{.Count}} conn{{if ne .Count 1}}s{{end}}{{if .Interesting}} · <span style="color:#b32222">{{.Interesting}} interesting</span>{{end}}{{if .Hidden}} <span style="color:#888;font-weight:400;font-size:.85em">({{.Hidden}} :443 hidden)</span>{{end}}{{if .Dropped}} <span style="color:#888;font-weight:400;font-size:.85em">({{.Dropped}} healthy hidden)</span>{{end}}</h1>
+<div class="meta">Snapshot at {{.Generated.Format "15:04:05.000"}} · auto-refresh 5s
+ · <a href="?format=json{{if .ShowAll}}&amp;all=1{{end}}">JSON</a>
+{{if .ShowAll}} · <a href="?">hide :443 (default)</a>{{else if .Hidden}} · <a href="?all=1">show all ({{.Total}})</a>{{end}}
+{{if .OnlyHot}} · <a href="?{{if .ShowAll}}all=1{{end}}">show healthy too</a>{{else}} · <a href="?only=hot{{if .ShowAll}}&amp;all=1{{end}}">only hot</a>{{end}}
+{{if .ExpandAll}} · <a href="?{{if .ShowAll}}all=1{{end}}{{if .OnlyHot}}{{if .ShowAll}}&amp;{{end}}only=hot{{end}}">collapse all</a>{{else}} · <a href="?expand=all{{if .ShowAll}}&amp;all=1{{end}}{{if .OnlyHot}}&amp;only=hot{{end}}">expand all</a>{{end}}
+ · <a href="?flat=1{{if .ShowAll}}&amp;all=1{{end}}{{if .OnlyHot}}&amp;only=hot{{end}}">flat view (raw table)</a>
+</div>
+<div class="legend">Card color by worst conn in the peer group:
+<span class="sw crit"></span>Loss / backoff (RTO-driven)
+<span class="sw warn"></span>retrans / DSACK / ECN / reorder
+<span class="sw note"></span>non-ESTABLISHED / unreadable
+<span class="sw ok"></span>healthy
+· <span class="chip anom-warn">retr:3</span>/<span class="chip anom-crit">bkoff:2</span> chips on a conn row = non-zero counters worth investigating (zeros stay hidden).
+</div>
+{{if .HistPanels}}
+<div class="hist-grid">
+{{range $panel := .HistPanels}}
+<div class="hist-panel">
+<div class="hist-title">{{$panel.Title}}</div>
+<div class="hist-summary">{{$panel.Summary}}</div>
+{{range $panel.Bars}}
+<div class="hist-row">
+<span class="hist-lbl">{{.Label}}</span>
+<span class="hist-track">
+{{if .LivePct}}<span class="hist-bar-live" style="width:{{.LivePct}}%"></span>{{end}}
+{{if .DeadPct}}<span class="hist-bar-dead" style="left:{{.LivePct}}%;width:{{.DeadPct}}%"></span>{{end}}
+</span>
+<span class="hist-cnt">{{.Live}}{{if $panel.HasDead}} / <span class="dead">{{.Dead}}</span>{{end}}</span>
+</div>
+{{end}}
+{{if $panel.HasDead}}<div class="hist-legend"><span class="sw live"></span>live<span class="sw dead"></span>dead</div>{{end}}
+</div>
+{{end}}
+</div>
+{{end}}
+{{if not .Groups}}
+<div class="empty">No conns registered. Either the client uses DirectPath (xDS bypasses the standard dialer, so nothing is captured), no traffic has been dialed yet, {{if .OnlyHot}}every conn is healthy (try <a href="?">without ?only=hot</a>), {{end}}or bigtable.TCPStats was never passed into the Client's options.</div>
+{{else}}
+{{range $g := .Groups}}
+<div class="grp {{$g.WorstSev}}">
+  <div class="grp-hdr">
+    <span class="grp-remote">{{$g.Remote}}</span>
+    <span class="grp-count">{{$g.N}} conn{{if ne $g.N 1}}s{{end}}{{if $g.Interest}} · <span class="hot">{{$g.Interest}} hot</span>{{end}}{{if $g.NHidden}} · <span class="hidden">{{$g.NHidden}} hidden</span>{{end}}</span>
+    <span class="grp-stats">
+      {{if $g.SumDelRate}}now <b>{{rate $g.SumDelRate}}</b>{{end}}
+      {{if $g.SumAvgOut}} · avg out <b>{{bpsF $g.SumAvgOut}}</b>{{end}}
+      {{if $g.SumAvgIn}} · in <b>{{bpsF $g.SumAvgIn}}</b>{{end}}
+      {{if $g.MaxRTT}} · worst RTT <b>{{$g.MaxRTT}}</b>{{end}}
+      {{if $g.MaxRtxPct}} · worst rtx <b>{{pct $g.MaxRtxPct}}</b>{{end}}
+      {{if $g.OldestAge}} · oldest <b>{{ageDur $g.OldestAge}}</b>{{end}}
+    </span>
+  </div>
+  {{range $r := $g.Conns}}
+  <details class="conn {{$r.Sev}}"{{if $.ExpandAll}} open{{end}}>
+    <summary>
+      <span class="conn-id">{{ago $r.DialedAt}} · {{$r.LocalAddr}}</span>
+      <span class="chip state-{{or $r.State "UNKNOWN"}}">{{or $r.State "—"}}</span>
+      {{if $r.CAState}}{{if ne $r.CAState "Open"}}<span class="chip ca-{{$r.CAState}}">{{$r.CAState}}</span>{{end}}{{end}}
+      {{range $a := $r.Anomalies}}<span class="chip anom-{{$a.Sev}}">{{$a.Label}}:{{$a.Value}}</span>{{end}}
+      {{if $r.Why}}<span class="conn-why">{{$r.Why}}</span>{{end}}
+      <span class="conn-tp">
+        {{if $r.DeliveryRate}}<span class="up">↑{{rate $r.DeliveryRate}}</span>{{else}}<span style="color:#aaa">idle</span>{{end}}
+      </span>
+    </summary>
+    <div class="cards">
+      <div class="card">
+        <h4>Traffic</h4>
+        <dl>
+          <dt>DelRate</dt><dd>{{rate $r.DeliveryRate}}</dd>
+          <dt>AvgOut</dt><dd>{{avgRate $r.BytesAcked $r.DialedAt}}</dd>
+          <dt>AvgIn</dt><dd>{{avgRate $r.BytesReceived $r.DialedAt}}</dd>
+          <dt>Sent</dt><dd>{{bytes $r.BytesSent}}</dd>
+          <dt>Recv</dt><dd>{{bytes $r.BytesReceived}}</dd>
+          <dt>NotSent</dt><dd>{{num $r.NotsentBytes}}</dd>
+          <dt>Pacing</dt><dd>{{rate $r.PacingRate}}</dd>
+        </dl>
+      </div>
+      <div class="card">
+        <h4>Latency</h4>
+        <dl>
+          <dt>RTT</dt><dd>{{dur $r.RTT}}</dd>
+          <dt>RTTVar</dt><dd>{{dur $r.RTTVar}}</dd>
+          <dt>MinRTT</dt><dd>{{dur $r.MinRTT}}</dd>
+          <dt>RTO</dt><dd>{{dur $r.RTO}}</dd>
+          <dt>ATO</dt><dd>{{dur $r.ATO}}</dd>
+          <dt>LastRecv</dt><dd>{{dur $r.LastDataRecv}}</dd>
+          <dt>LastSent</dt><dd>{{dur $r.LastDataSent}}</dd>
+        </dl>
+      </div>
+      <div class="card">
+        <h4>Loss / retrans</h4>
+        <dl>
+          <dt>Retr</dt><dd>{{hotNum $r.Retransmits}}</dd>
+          <dt>TotalRetr</dt><dd>{{hotNum $r.TotalRetrans}}</dd>
+          <dt>RtxRate</dt><dd>{{hotPct $r.RetransRatioPct}}</dd>
+          <dt>BytesRetrans</dt><dd>{{hotBytes $r.BytesRetrans}}</dd>
+          <dt>Lost</dt><dd>{{hotNum $r.Lost}}</dd>
+          <dt>SACKd</dt><dd>{{num $r.Sacked}}</dd>
+          <dt>DSACK</dt><dd>{{hotNum $r.DsackDups}}</dd>
+          <dt>ReordS</dt><dd>{{hotNum $r.ReordSeen}}</dd>
+          <dt>ECN</dt><dd>{{hotNum $r.DeliveredCE}}</dd>
+        </dl>
+      </div>
+      <div class="card">
+        <h4>Window / MSS</h4>
+        <dl>
+          <dt>CWnd</dt><dd>{{num $r.SndCwnd}}</dd>
+          <dt>SSTh</dt><dd>{{num $r.SndSsthresh}}</dd>
+          <dt>SndWnd</dt><dd>{{win $r.SndWnd}}</dd>
+          <dt>RcvWnd</dt><dd>{{win $r.RcvWnd}}</dd>
+          <dt>Unacked</dt><dd>{{num $r.Unacked}}</dd>
+          <dt>MSS</dt><dd>{{num $r.MSS}}</dd>
+          <dt>PMTU</dt><dd>{{pmtu $r.PMTU}}</dd>
+        </dl>
+      </div>
+      <div class="card">
+        <h4>RTO / probes</h4>
+        <dl>
+          <dt>Backoff</dt><dd>{{critNum $r.Backoff}}</dd>
+          <dt>Probes</dt><dd>{{hotNum $r.Probes}}</dd>
+          <dt>TotalRTO</dt><dd>{{hotNum $r.TotalRTO}}</dd>
+          <dt>RTOrecov</dt><dd>{{num $r.TotalRTORecoveries}}</dd>
+          <dt>RTOtime</dt><dd>{{dur $r.TotalRTOTime}}</dd>
+          <dt>Rehash</dt><dd>{{hotNum $r.Rehash}}</dd>
+          <dt>RcvOoO</dt><dd>{{num $r.RcvOooPack}}</dd>
+        </dl>
+      </div>
+      <div class="card">
+        <h4>Blocking / segs</h4>
+        <dl>
+          <dt>RwndLim</dt><dd>{{hotDur $r.RwndLimited}}</dd>
+          <dt>SndBufLim</dt><dd>{{hotDur $r.SndbufLimited}}</dd>
+          <dt>BusyTime</dt><dd>{{dur $r.BusyTime}}</dd>
+          <dt>SegsOut</dt><dd>{{num $r.SegsOut}}</dd>
+          <dt>SegsIn</dt><dd>{{num $r.SegsIn}}</dd>
+          <dt>DataSegsOut</dt><dd>{{num $r.DataSegsOut}}</dd>
+          <dt>DataSegsIn</dt><dd>{{num $r.DataSegsIn}}</dd>
+        </dl>
+      </div>
+      {{if $r.Err}}
+      <div class="card err-card">
+        <h4>Err</h4>
+        <div>{{$r.Err}}</div>
+      </div>
+      {{end}}
+    </div>
+  </details>
+  {{end}}
+</div>
+{{end}}
+{{end}}
+</body>
+</html>
+`

--- a/bigtable/debugview/tcpz_test.go
+++ b/bigtable/debugview/tcpz_test.go
@@ -1,0 +1,348 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debugview
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/bigtable"
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+)
+
+// TestTcpz_EmptyRenders confirms the handler serves a valid HTML page
+// with the "no conns registered" hint when no dials have happened yet.
+// Exercises the template on the empty-slice path (guards against a
+// template bug that only surfaces without data).
+func TestTcpz_EmptyRenders(t *testing.T) {
+	h := newTcpzHandler(bigtable.NewTCPStats())
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("HTTP %d, want 200", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("Content-Type = %q, want text/html*", ct)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "No conns registered") {
+		t.Errorf("empty page did not render the empty-state hint; body:\n%s", body)
+	}
+}
+
+// TestTcpz_JSON confirms ?format=json returns a JSON array (empty is
+// fine) with the right Content-Type. Cheap regression guard for
+// template bypass logic.
+func TestTcpz_JSON(t *testing.T) {
+	h := newTcpzHandler(bigtable.NewTCPStats())
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/?format=json", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("HTTP %d, want 200", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &rows); err != nil {
+		t.Fatalf("JSON decode: %v — body: %s", err, rr.Body.String())
+	}
+	if len(rows) != 0 {
+		t.Errorf("empty registry → rows = %d, want 0", len(rows))
+	}
+}
+
+// TestTcpz_NilStatsSafe guards against a panic when a caller wires the
+// handler without a TCPStats. Renders as if empty.
+func TestTcpz_NilStatsSafe(t *testing.T) {
+	h := newTcpzHandler(nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("HTTP %d, want 200", rr.Code)
+	}
+}
+
+// TestTcpz_Classify pins the severity buckets so that a future edit to
+// the classifier can't quietly re-color rows. Each row picks the
+// *sharpest* signal for that severity — CAState=Loss for crit,
+// TotalRetrans>0 for warn, CLOSE_WAIT for note, an all-zero snapshot
+// for ok.
+func TestTcpz_Classify(t *testing.T) {
+	tests := []struct {
+		name    string
+		snap    btransport.TCPInfoSnapshot
+		wantSev tcpzSeverity
+		wantWhy string // substring match
+	}{
+		{
+			name:    "healthy Open ESTABLISHED",
+			snap:    btransport.TCPInfoSnapshot{CAState: "Open", State: "ESTABLISHED"},
+			wantSev: sevOK,
+		},
+		{
+			name:    "unreadable is note not warn",
+			snap:    btransport.TCPInfoSnapshot{Err: "tcp_info not supported"},
+			wantSev: sevNote,
+			wantWhy: "unreadable",
+		},
+		{
+			name:    "CLOSE_WAIT with no loss = note",
+			snap:    btransport.TCPInfoSnapshot{State: "CLOSE_WAIT", CAState: "Open"},
+			wantSev: sevNote,
+			wantWhy: "CLOSE_WAIT",
+		},
+		{
+			name:    "past retrans = warn",
+			snap:    btransport.TCPInfoSnapshot{State: "ESTABLISHED", CAState: "Open", TotalRetrans: 5},
+			wantSev: sevWarn,
+			wantWhy: "past-retrans",
+		},
+		{
+			name:    "DSACK-only = warn",
+			snap:    btransport.TCPInfoSnapshot{State: "ESTABLISHED", CAState: "Open", DsackDups: 3},
+			wantSev: sevWarn,
+			wantWhy: "dsack",
+		},
+		{
+			name:    "ECN-only = warn",
+			snap:    btransport.TCPInfoSnapshot{State: "ESTABLISHED", CAState: "Open", DeliveredCE: 2},
+			wantSev: sevWarn,
+			wantWhy: "ECN",
+		},
+		{
+			name:    "Recovery CA state = warn",
+			snap:    btransport.TCPInfoSnapshot{State: "ESTABLISHED", CAState: "Recovery"},
+			wantSev: sevWarn,
+			wantWhy: "Recovery",
+		},
+		{
+			name:    "Loss CA state = crit",
+			snap:    btransport.TCPInfoSnapshot{State: "ESTABLISHED", CAState: "Loss", TotalRetrans: 12},
+			wantSev: sevCrit,
+			wantWhy: "Loss",
+		},
+		{
+			name:    "backoff>0 = crit regardless of CA",
+			snap:    btransport.TCPInfoSnapshot{State: "ESTABLISHED", CAState: "Open", Backoff: 1},
+			wantSev: sevCrit,
+			wantWhy: "backoff",
+		},
+		{
+			name: "current retrans burst suppresses past-retrans tag",
+			snap: btransport.TCPInfoSnapshot{
+				State: "ESTABLISHED", CAState: "Open", Retransmits: 2, TotalRetrans: 10,
+			},
+			wantSev: sevWarn,
+			wantWhy: "retrans", // and NOT "past-retrans"
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotSev, why := classify(tc.snap)
+			if gotSev != tc.wantSev {
+				t.Errorf("severity = %v, want %v (why=%v)", gotSev, tc.wantSev, why)
+			}
+			whyStr := strings.Join(why, "+")
+			if tc.wantWhy != "" && !strings.Contains(whyStr, tc.wantWhy) {
+				t.Errorf("why = %q, want to contain %q", whyStr, tc.wantWhy)
+			}
+			// Guard: the "current retrans burst suppresses past-retrans"
+			// invariant is subtle enough to deserve its own assertion.
+			if tc.name == "current retrans burst suppresses past-retrans tag" {
+				if strings.Contains(whyStr, "past-retrans") {
+					t.Errorf("why contains past-retrans when Retransmits>0: %q", whyStr)
+				}
+			}
+		})
+	}
+}
+
+// TestTcpz_ParseSort covers the three shapes: default (sev), known
+// column, and unknown-key fallback to sev. Also asserts that a bad
+// direction gets squashed to "" so column comparators can fall back to
+// their natural direction.
+func TestTcpz_ParseSort(t *testing.T) {
+	tests := []struct {
+		name    string
+		q       string
+		wantKey string
+		wantDir string
+	}{
+		{"empty defaults to sev", "", "sev", ""},
+		{"sev explicit", "sort=sev", "sev", ""},
+		{"dial explicit", "sort=dial", "dial", ""},
+		{"known column ascending", "sort=rtt&dir=asc", "rtt", "asc"},
+		{"known column descending", "sort=totalretr&dir=desc", "totalretr", "desc"},
+		{"unknown column falls back to sev", "sort=bogus", "sev", ""},
+		{"invalid dir dropped", "sort=rtt&dir=sideways", "rtt", ""},
+		{"dir without sort is dropped by fallback", "dir=asc", "sev", "asc"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			q, _ := url.ParseQuery(tc.q)
+			gotKey, gotDir := parseSort(q)
+			if gotKey != tc.wantKey || gotDir != tc.wantDir {
+				t.Errorf("parseSort(%q) = %q,%q; want %q,%q", tc.q, gotKey, gotDir, tc.wantKey, tc.wantDir)
+			}
+		})
+	}
+}
+
+// TestTcpz_SortRows_byColumn exercises the per-column sort path with a
+// small mixed row set. We only assert first/last row identity (peer
+// address) — that's the observable behavior clicking a header changes.
+func TestTcpz_SortRows_byColumn(t *testing.T) {
+	t0 := time.Unix(1_700_000_000, 0)
+	mk := func(peer string, rtt time.Duration, retrans uint32, dialOffset time.Duration) tcpzRow {
+		snap := btransport.TCPInfoSnapshot{
+			RemoteAddr: peer, RTT: rtt, TotalRetrans: retrans,
+			DialedAt: t0.Add(dialOffset),
+			CAState:  "Open", State: "ESTABLISHED",
+		}
+		sev, why := classify(snap)
+		return tcpzRow{
+			TCPInfoSnapshot: snap,
+			Sev:             sev.rowClass(),
+			Why:             strings.Join(why, "+"),
+			Interest:        sev > sevOK,
+		}
+	}
+	base := func() []tcpzRow {
+		return []tcpzRow{
+			mk("a:1", 12*time.Millisecond, 0, 0),
+			mk("b:2", 3*time.Millisecond, 5, time.Second),
+			mk("c:3", 40*time.Millisecond, 0, 2*time.Second),
+			mk("d:4", 8*time.Millisecond, 0, 3*time.Second),
+		}
+	}
+
+	// rtt desc: c (40ms) first, b (3ms) last.
+	rows := base()
+	sortRows(rows, "rtt", "desc")
+	if rows[0].RemoteAddr != "c:3" || rows[len(rows)-1].RemoteAddr != "b:2" {
+		t.Errorf("rtt desc: got %v..%v, want c:3..b:2", rows[0].RemoteAddr, rows[len(rows)-1].RemoteAddr)
+	}
+
+	// rtt asc: b (3ms) first.
+	rows = base()
+	sortRows(rows, "rtt", "asc")
+	if rows[0].RemoteAddr != "b:2" {
+		t.Errorf("rtt asc: got %v first, want b:2", rows[0].RemoteAddr)
+	}
+
+	// totalretr desc: b (5) first; ties (all zero) break by dial order.
+	rows = base()
+	sortRows(rows, "totalretr", "desc")
+	if rows[0].RemoteAddr != "b:2" {
+		t.Errorf("totalretr desc: got %v first, want b:2", rows[0].RemoteAddr)
+	}
+	if rows[1].RemoteAddr != "a:1" || rows[2].RemoteAddr != "c:3" || rows[3].RemoteAddr != "d:4" {
+		t.Errorf("totalretr desc tie-break order: got %v,%v,%v; want a:1,c:3,d:4",
+			rows[1].RemoteAddr, rows[2].RemoteAddr, rows[3].RemoteAddr)
+	}
+
+	// dial special key: pure oldest-first regardless of other fields.
+	rows = base()
+	sortRows(rows, "dial", "")
+	for i, want := range []string{"a:1", "b:2", "c:3", "d:4"} {
+		if rows[i].RemoteAddr != want {
+			t.Errorf("dial: rows[%d] = %v, want %v", i, rows[i].RemoteAddr, want)
+		}
+	}
+
+	// unknown key is a no-op — order preserved.
+	rows = base()
+	sortRows(rows, "no-such-key", "desc")
+	if rows[0].RemoteAddr != "a:1" {
+		t.Errorf("unknown key: expected no-op, got %v first", rows[0].RemoteAddr)
+	}
+}
+
+// TestTcpz_SortRows_sevPromotesInteresting confirms that the default
+// sev sort puts a Loss-state conn ahead of a healthy conn dialed
+// earlier.
+func TestTcpz_SortRows_sevPromotesInteresting(t *testing.T) {
+	t0 := time.Unix(1_700_000_000, 0)
+	healthy := btransport.TCPInfoSnapshot{RemoteAddr: "healthy:1", State: "ESTABLISHED", CAState: "Open", DialedAt: t0}
+	bad := btransport.TCPInfoSnapshot{RemoteAddr: "bad:2", State: "ESTABLISHED", CAState: "Loss", DialedAt: t0.Add(time.Second)}
+	toRow := func(s btransport.TCPInfoSnapshot) tcpzRow {
+		sev, why := classify(s)
+		return tcpzRow{TCPInfoSnapshot: s, Sev: sev.rowClass(), Why: strings.Join(why, "+"), Interest: sev > sevOK}
+	}
+	rows := []tcpzRow{toRow(healthy), toRow(bad)}
+	sortRows(rows, "sev", "")
+	if rows[0].RemoteAddr != "bad:2" {
+		t.Errorf("sev sort: healthy conn came before Loss conn (got %v first)", rows[0].RemoteAddr)
+	}
+}
+
+// TestTcpz_ColumnSortLinksRender is a smoke test that the rendered
+// HTML wires the escape-hatch flat view (which still exposes sortable
+// columns). The grouped default view sorts by severity implicitly and
+// doesn't render sort chrome, so we check `?flat=1` explicitly.
+func TestTcpz_ColumnSortLinksRender(t *testing.T) {
+	h := newTcpzHandler(bigtable.NewTCPStats())
+
+	// Grouped default: must at least advertise the flat-view escape hatch.
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("grouped view HTTP %d, want 200", rr.Code)
+	}
+	if body := rr.Body.String(); !strings.Contains(body, "flat=1") {
+		t.Errorf("grouped view missing flat-view switcher; body:\n%s", body)
+	}
+
+	// Flat view: must contain the sort meta-bar links (page has no rows
+	// with no data, so the header sort links aren't rendered, but the
+	// meta-bar sort=sev/sort=dial links always are).
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/?flat=1", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("flat view HTTP %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "sort=sev") && !strings.Contains(body, "sort=dial") {
+		t.Errorf("flat view meta bar missing sort links; body:\n%s", body)
+	}
+}
+
+// TestTcpz_SevRank_matchesRowClass ensures the string-based sort rank
+// stays in lockstep with the severity enum. If someone adds a new
+// severity, this test flags the missing case before it becomes a silent
+// mis-sort.
+func TestTcpz_SevRank_matchesRowClass(t *testing.T) {
+	pairs := []struct {
+		sev tcpzSeverity
+	}{
+		{sevOK}, {sevNote}, {sevWarn}, {sevCrit},
+	}
+	prev := -1
+	for _, p := range pairs {
+		got := sevRank(p.sev.rowClass())
+		if got <= prev {
+			t.Errorf("sevRank(%v) = %d, expected strictly increasing (prev=%d)", p.sev, got, prev)
+		}
+		prev = got
+	}
+}

--- a/bigtable/internal/session/api.go
+++ b/bigtable/internal/session/api.go
@@ -108,6 +108,10 @@ type Client interface {
 	SessionDebug() btransport.SessionDebugProvider
 	ChannelDebug() btransport.ChannelDebugProvider
 	ConfigDebug() btransport.ConfigDebugProvider
+	// OutlierDebug exposes per-pool outlier-scorer state (name, config,
+	// current per-AFE scores, recent transitions) for the /debug/outlierz
+	// page. Nil when EnableDebug is false.
+	OutlierDebug() btransport.OutlierDebugProvider
 
 	// AddSessionLoadListener registers a listener invoked every time
 	// the server-driven ClientConfigurationManager reports a new

--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -121,6 +121,17 @@ type Config struct {
 	// off. The debug surface is otherwise unchanged; flipping the
 	// flag on or off requires rebuilding the client.
 	EnableDebug bool
+
+	// OutlierScorerFactory, if non-nil, is invoked once per session
+	// pool this Client creates to construct the OutlierScorer plugged
+	// into that pool. The factory receives the pool's AFE snapshot
+	// source; the returned scorer is installed via
+	// SessionPoolImpl.SetOutlierScorer before Pool.Start so any
+	// LifecycleScorer implementation is given the pool's ctx.
+	//
+	// Nil means every pool runs NoopScorer — no outlier downweight,
+	// zero-cost pass-through in the picker's cost function.
+	OutlierScorerFactory btransport.OutlierScorerFactory
 }
 
 // managedSessionPool bundles a pool with its config-listener unregister
@@ -275,6 +286,7 @@ func NewClient(
 	metricsProvider metrics.MetricsProvider,
 	featureFlagsProto *btpb.FeatureFlags,
 	enableDebug bool,
+	outlierScorerFactory btransport.OutlierScorerFactory,
 	opts ...option.ClientOption,
 ) (Client, error) {
 	factory, err := metrics.NewFactory(ctx, project, instance, appProfile, metricsProvider)
@@ -356,15 +368,16 @@ func NewClient(
 	backgroundCtx, cancel := context.WithCancel(context.Background())
 
 	sc := newSessionClientFromParts(pool, stub, factory, Config{
-		Project:           project,
-		Instance:          instance,
-		AppProfile:        appProfile,
-		FeatureFlagsMD:    directAccessMD,
-		FeatureFlagsProto: featureFlagsProto,
-		ConfigMD:          configMD,
-		MetricsEnabled:    factory.Enabled,
-		BackgroundCtx:     backgroundCtx,
-		EnableDebug:       enableDebug,
+		Project:              project,
+		Instance:             instance,
+		AppProfile:           appProfile,
+		FeatureFlagsMD:       directAccessMD,
+		FeatureFlagsProto:    featureFlagsProto,
+		ConfigMD:             configMD,
+		MetricsEnabled:       factory.Enabled,
+		BackgroundCtx:        backgroundCtx,
+		EnableDebug:          enableDebug,
+		OutlierScorerFactory: outlierScorerFactory,
 	})
 	sc.backgroundCancel = cancel
 	sc.managedChannelPool = managed
@@ -704,6 +717,13 @@ func (sc *sessionClient) getOrCreateSessionPool(
 		poolName, streamFactory, openSessionRequest, md, sessionType,
 		sc.enableDebug,
 	)
+	// Wire the configured OutlierScorerFactory (if any) BEFORE
+	// Pool.Start so LifecycleScorer.Start(poolCtx) fires with the
+	// pool's ctx. Nil factory leaves the pool on NoopScorer — same
+	// behaviour as before the framework existed.
+	if sc.cfg.OutlierScorerFactory != nil {
+		pool.SetOutlierScorer(sc.cfg.OutlierScorerFactory(pool.AfeSnapshotSource()))
+	}
 	mp := &managedSessionPool{pool: pool}
 	sc.sessionPools[key] = mp
 	configManager := sc.configManager

--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -805,6 +805,19 @@ func (sc *sessionClient) LoadBalancingSnapshots() []btransport.LoadBalancingSnap
 	return out
 }
 
+// OutlierDebugSnapshots returns per-pool outlier-scorer state for the
+// /debug/outlierz page. Ordered by pool key. Always non-empty per pool —
+// pools running NoopScorer produce an entry with ScorerName="noop" so
+// operators can see which pools have outlier detection wired.
+func (sc *sessionClient) OutlierDebugSnapshots() []btransport.OutlierPoolSnapshot {
+	entries := sc.orderedPoolEntries()
+	out := make([]btransport.OutlierPoolSnapshot, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.pool.OutlierDebugSnapshot())
+	}
+	return out
+}
+
 // poolEntry is the internal (key, pool) tuple used by snapshot methods
 // so they can sort by poolKey without duplicating the collection loop.
 type poolEntry struct {

--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -274,6 +274,7 @@ func NewClient(
 	project, instance, appProfile string,
 	metricsProvider metrics.MetricsProvider,
 	featureFlagsProto *btpb.FeatureFlags,
+	enableDebug bool,
 	opts ...option.ClientOption,
 ) (Client, error) {
 	factory, err := metrics.NewFactory(ctx, project, instance, appProfile, metricsProvider)
@@ -363,11 +364,7 @@ func NewClient(
 		ConfigMD:          configMD,
 		MetricsEnabled:    factory.Enabled,
 		BackgroundCtx:     backgroundCtx,
-		// EnableDebug intentionally left at zero (false): NewClient has
-		// no external caller upstream today, so exposing a positional
-		// bool on the constructor would ship a dead knob. When the
-		// top-level bigtable.Client wiring lands, that PR can plumb
-		// EnableClientDebug into this Config field directly.
+		EnableDebug:       enableDebug,
 	})
 	sc.backgroundCancel = cancel
 	sc.managedChannelPool = managed

--- a/bigtable/internal/session/debug.go
+++ b/bigtable/internal/session/debug.go
@@ -51,6 +51,16 @@ func (sc *sessionClient) ConfigDebug() btransport.ConfigDebugProvider {
 	return configDebugProviderImpl{mgr: sc.configManager}
 }
 
+// OutlierDebug returns the per-pool outlier-scorer debug provider. Nil
+// when the client was constructed with EnableDebug false (no snapshot
+// state collected).
+func (sc *sessionClient) OutlierDebug() btransport.OutlierDebugProvider {
+	if !sc.enableDebug {
+		return nil
+	}
+	return outlierDebugProviderImpl{sc: sc}
+}
+
 // sessionDebugProviderImpl is the concrete SessionDebugProvider returned
 // by *sessionClient.SessionDebug. Kept unexported — consumers hold the
 // interface. Diverter() returns an empty snapshot; only bigtable.Client
@@ -124,4 +134,16 @@ type configDebugProviderImpl struct {
 
 func (p configDebugProviderImpl) Snapshot() btransport.ConfigSnapshot {
 	return p.mgr.Snapshot()
+}
+
+// outlierDebugProviderImpl is the concrete OutlierDebugProvider
+// returned by *sessionClient.OutlierDebug. Snapshot iterates the pools
+// in stable key order and lets each pool produce its own scorer
+// snapshot.
+type outlierDebugProviderImpl struct {
+	sc *sessionClient
+}
+
+func (p outlierDebugProviderImpl) Snapshot() []btransport.OutlierPoolSnapshot {
+	return p.sc.OutlierDebugSnapshots()
 }

--- a/bigtable/internal/transport/afe_picker.go
+++ b/bigtable/internal/transport/afe_picker.go
@@ -144,10 +144,19 @@ func NewLeastLatencyAfePicker(randomSubsetSize int, recordCandidates bool) *Leas
 func (LeastLatencyAfePicker) Name() string { return "least-latency" }
 
 // PickAfe returns the AFE with the smallest E2eCost among K randomly-
-// drawn ready candidates.
+// drawn ready candidates. If SessionPoolImpl decorated the snapshots
+// with a non-zero OutlierScore (from its plugged-in OutlierScorer),
+// that multiplier inflates the per-candidate cost so outlier AFEs are
+// picked with much lower probability. Undecorated snapshots
+// (OutlierScore == 0) fall back to 1.0 so tests and callers that skip
+// decoration see baseline behaviour.
 func (p LeastLatencyAfePicker) PickAfe(ready []AfeSnapshot) (AfeID, bool, PickDecision) {
 	winner, picked, cands := kChoiceMinCost(ready, p.RandomSubsetSize, p.recordCandidates, func(s AfeSnapshot) float64 {
-		return s.E2eCost
+		score := s.OutlierScore
+		if score == 0 {
+			score = 1.0
+		}
+		return s.E2eCost * score
 	})
 	return decisionFor(winner, picked, cands, "min-latency")
 }

--- a/bigtable/internal/transport/afe_picker.go
+++ b/bigtable/internal/transport/afe_picker.go
@@ -24,6 +24,19 @@ import (
 // standard K-choice draw size.
 const defaultAfeRandomSubsetSize = 2
 
+// defaultOutlierProbeRate is the fraction of LeastLatencyAfePicker
+// picks reserved for penalized AFEs (OutlierScore > 1.0) so their
+// PeakEwma trackers keep receiving fresh samples — otherwise a
+// heavily-downweighted AFE starves under K-choice and can never
+// recover: no traffic means no Update() calls, and PeakEwma.Value()
+// has no time-decay on read, so the stored peak stays high forever.
+//
+// 0.5 % (1 pick in ~200) is a compromise: enough sample flow to detect
+// recovery within a single outlier-detector tick even on modest-QPS
+// pools, low enough that a genuinely-bad AFE only takes a small share
+// of user traffic while it's still bad.
+const defaultOutlierProbeRate = 0.005
+
 // PickCandidate is one AFE the picker considered during a K-choice draw,
 // with the cost value the picker's decision rule used to score it.
 // Cost's interpretation depends on the picker in play: NumOutstanding
@@ -128,16 +141,29 @@ func (p LeastInFlightAfePicker) PickAfe(ready []AfeSnapshot) (AfeID, bool, PickD
 
 // LeastLatencyAfePicker picks the AFE with the lowest per-AFE e2e
 // PeakEwma cost. Same K-choice partial Fisher-Yates as
-// LeastInFlightAfePicker.
+// LeastInFlightAfePicker. Reserves probeRate of picks for penalized
+// AFEs (OutlierScore > 1.0) so their PeakEwmas keep receiving samples
+// and outlier detection can observe recovery — see defaultOutlierProbeRate.
 type LeastLatencyAfePicker struct {
 	RandomSubsetSize int
 	// recordCandidates: see SimpleAfePicker.recordCandidates.
 	recordCandidates bool
+	// probeRate is the fraction of picks reserved for a randomly-chosen
+	// penalized AFE (OutlierScore > 1.0). Zero disables probing entirely;
+	// NewLeastLatencyAfePicker initializes to defaultOutlierProbeRate.
+	// Tests wanting fully-deterministic K-choice construct the struct
+	// literal directly with probeRate: 0.
+	probeRate float64
 }
 
-// NewLeastLatencyAfePicker constructs a LeastLatencyAfePicker.
+// NewLeastLatencyAfePicker constructs a LeastLatencyAfePicker with
+// outlier probing enabled at defaultOutlierProbeRate.
 func NewLeastLatencyAfePicker(randomSubsetSize int, recordCandidates bool) *LeastLatencyAfePicker {
-	return &LeastLatencyAfePicker{RandomSubsetSize: randomSubsetSize, recordCandidates: recordCandidates}
+	return &LeastLatencyAfePicker{
+		RandomSubsetSize: randomSubsetSize,
+		recordCandidates: recordCandidates,
+		probeRate:        defaultOutlierProbeRate,
+	}
 }
 
 // Name returns "least-latency".
@@ -150,15 +176,61 @@ func (LeastLatencyAfePicker) Name() string { return "least-latency" }
 // picked with much lower probability. Undecorated snapshots
 // (OutlierScore == 0) fall back to 1.0 so tests and callers that skip
 // decoration see baseline behaviour.
+//
+// With probability probeRate, PickAfe bypasses K-choice entirely and
+// picks a random penalized AFE (OutlierScore > 1.0) from ready. This
+// is the recovery path — a starved outlier gets a trickle of real
+// traffic so its PeakEwma is updated and the outlier scorer can
+// re-evaluate on its next tick. The pick's Reason is "outlier-probe"
+// so debug tooling can distinguish probe traffic from cost-driven
+// picks. Probing runs only when ready contains at least one penalized
+// candidate; otherwise the code path is a single float compare +
+// linear scan of ready checking for any Penalized candidate.
 func (p LeastLatencyAfePicker) PickAfe(ready []AfeSnapshot) (AfeID, bool, PickDecision) {
-	winner, picked, cands := kChoiceMinCost(ready, p.RandomSubsetSize, p.recordCandidates, func(s AfeSnapshot) float64 {
-		score := s.OutlierScore
-		if score == 0 {
-			score = 1.0
+	if p.probeRate > 0 && rand.Float64() < p.probeRate {
+		if idx := pickProbeCandidate(ready); idx >= 0 {
+			s := ready[idx]
+			d := PickDecision{Winner: s.ID, Reason: "outlier-probe"}
+			if p.recordCandidates {
+				cost := s.E2eCost * effectiveScore(s.OutlierScore)
+				d.Candidates = []PickCandidate{{AfeID: s.ID, Cost: cost}}
+			}
+			return s.ID, true, d
 		}
-		return s.E2eCost * score
+	}
+	winner, picked, cands := kChoiceMinCost(ready, p.RandomSubsetSize, p.recordCandidates, func(s AfeSnapshot) float64 {
+		return s.E2eCost * effectiveScore(s.OutlierScore)
 	})
 	return decisionFor(winner, picked, cands, "min-latency")
+}
+
+// effectiveScore treats a zero OutlierScore (undecorated snapshot) as
+// 1.0 so callers that skip SessionPoolImpl.decorateReady see baseline
+// picker behavior.
+func effectiveScore(s float64) float64 {
+	if s == 0 {
+		return 1.0
+	}
+	return s
+}
+
+// pickProbeCandidate returns the index of a random penalized candidate
+// (OutlierScore > 1.0) in ready, or -1 if none exist. Uses reservoir
+// sampling so no allocation is needed for the intermediate index list;
+// the picker's hot path stays allocation-free on both the probe and
+// no-probe paths.
+func pickProbeCandidate(ready []AfeSnapshot) int {
+	winner := -1
+	seen := 0
+	for i := range ready {
+		if ready[i].OutlierScore > 1.0 {
+			seen++
+			if rand.IntN(seen) == 0 {
+				winner = i
+			}
+		}
+	}
+	return winner
 }
 
 // decisionFor packages kChoiceMinCost's return into a PickDecision.

--- a/bigtable/internal/transport/conn_registry.go
+++ b/bigtable/internal/transport/conn_registry.go
@@ -1,0 +1,331 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+)
+
+// graveyardCap bounds how many recently-dead conn records the registry
+// keeps for the tcpz age-distribution histogram. Sized so a chatty client
+// that recycles conns aggressively still has a representative sample.
+const graveyardCap = 512
+
+// ConnRegistry tracks every *net.TCPConn returned by a custom gRPC dialer
+// so tcpz can render live TCP_INFO for each. The registry never wraps the
+// returned conn — gRPC receives the raw *net.TCPConn unchanged, so nothing
+// in the RPC hot path traverses ConnRegistry code. Registry state is
+// touched only on dial (rare) and Snapshot (only when someone renders
+// tcpz). Dead entries are pruned lazily during Snapshot when getsockopt
+// reports the fd is gone; their (dial, death) times survive in a bounded
+// ring so lifetime distributions include departed conns.
+type ConnRegistry struct {
+	mu    sync.RWMutex
+	seq   uint64 // monotonic id so keys are unique across identical addr pairs
+	conns map[uint64]*trackedConn
+
+	// graveyard is a ring of the most-recent graveyardCap deaths. graveIdx
+	// points at the next slot to write; graveFull says whether we've wrapped.
+	// Kept under the same mu as conns — writes only happen inside Snapshot,
+	// which already re-acquires the write lock for pruning.
+	graveyard []DeadConnInfo
+	graveIdx  int
+	graveFull bool
+}
+
+// trackedConn holds one dial's outputs plus a strong ref to the conn so we
+// can call SyscallConn on it during Snapshot. Strong-ref-with-lazy-prune
+// (vs weak refs or finalizers) trades a small window of stale entries for
+// zero interference with gRPC's lifecycle expectations.
+type trackedConn struct {
+	remoteAddr string
+	localAddr  string
+	dialedAt   time.Time
+	conn       *net.TCPConn
+}
+
+// NewConnRegistry constructs an empty registry.
+func NewConnRegistry() *ConnRegistry {
+	return &ConnRegistry{conns: make(map[uint64]*trackedConn)}
+}
+
+// Dial is the entry point wired into grpc.WithContextDialer. Delegates to
+// net.Dialer.DialContext ("tcp" over addr), and on success records the
+// *net.TCPConn in the registry before returning the raw conn to gRPC —
+// no wrapping, so gRPC's type assertions (*net.TCPConn, SyscallConn, TLS
+// deadline handling) all see exactly what they would without tcpz.
+func (r *ConnRegistry) Dial(ctx context.Context, addr string) (net.Conn, error) {
+	d := &net.Dialer{}
+	conn, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	if tc, ok := conn.(*net.TCPConn); ok {
+		r.add(tc)
+	}
+	return conn, nil
+}
+
+func (r *ConnRegistry) add(tc *net.TCPConn) {
+	r.mu.Lock()
+	r.seq++
+	r.conns[r.seq] = &trackedConn{
+		remoteAddr: tc.RemoteAddr().String(),
+		localAddr:  tc.LocalAddr().String(),
+		dialedAt:   time.Now(),
+		conn:       tc,
+	}
+	r.mu.Unlock()
+}
+
+// TCPInfoSnapshot is the platform-agnostic view of one registered conn as
+// of Snapshot time. On Linux the numeric fields come from struct tcp_info
+// via getsockopt(TCP_INFO); on other platforms Err is populated and the
+// numeric fields are zero. RemoteAddr / LocalAddr / DialedAt are captured
+// at dial time and are always present.
+//
+// Fields are grouped by what question they answer. "Why is TotalRetrans
+// high?" is answered by the Congestion + Loss-classification blocks:
+// CAState/Backoff say what the kernel thinks the loss regime is; DSACK,
+// Reordering, and DeliveredCE distinguish real drops from spurious /
+// out-of-order / ECN-signaled events; BytesRetrans + BytesSent give the
+// actual retrans ratio.
+type TCPInfoSnapshot struct {
+	// Identity — captured at dial time.
+	RemoteAddr string
+	LocalAddr  string
+	DialedAt   time.Time
+
+	// TCP + congestion state.
+	State   string // TCP FSM state (ESTABLISHED, CLOSE_WAIT, …)
+	CAState string // congestion-control state (Open/Disorder/CWR/Recovery/Loss)
+	Backoff uint32 // RTO exponential-backoff count; >0 = we've timed out and are waiting longer
+
+	// Round-trip time.
+	RTT    time.Duration
+	RTTVar time.Duration
+	MinRTT time.Duration
+
+	// Window + segment sizing.
+	MSS         uint32 // send MSS
+	PMTU        uint32 // path MTU (bytes). <1500 = tunneling/VPN in path; silent throughput killer if a middlebox black-holes PMTUD ICMP.
+	SndCwnd     uint32 // send congestion window (MSS units)
+	SndSsthresh uint32 // slow-start threshold; drop = we've reduced cwnd from loss
+	SndWnd      uint32 // current send window (bytes)
+	RcvWnd      uint32 // current receive window (bytes)
+
+	// Loss + retransmit counters.
+	Retransmits  uint32 // current burst of retransmits
+	Retrans      uint32 // currently-outstanding retransmits
+	TotalRetrans uint32 // cumulative retransmits over conn lifetime
+	Lost         uint32 // segments the kernel considers lost right now
+	Sacked       uint32 // segments selectively-ACK'd
+	Unacked      uint32 // segments in flight
+	Reordering   uint32 // reordering-tolerance estimate (bigger = kernel is being patient)
+	ReordSeen    uint32 // times reordering has been observed
+	DsackDups    uint32 // duplicate SACKs — spurious retransmits (receiver actually got the byte)
+	DeliveredCE  uint32 // packets delivered with ECN Congestion-Experienced marks
+	RcvOooPack   uint32 // packets received out-of-order
+
+	// RTO / probe timing.
+	RTO                time.Duration // current retransmit timeout
+	ATO                time.Duration // delayed-ACK timeout
+	Probes             uint32        // zero-window probes attempted
+	TotalRTO           uint32        // cumulative RTOs (Linux 4.20+)
+	TotalRTORecoveries uint32        // cumulative RTO-driven recovery events
+	TotalRTOTime       time.Duration // cumulative time spent in RTO
+
+	// Volume / rate.
+	SegsOut       uint32
+	SegsIn        uint32
+	DataSegsOut   uint32
+	DataSegsIn    uint32
+	BytesSent     uint64        // total data bytes sent
+	BytesAcked    uint64        // total data bytes acknowledged
+	BytesRetrans  uint64        // total data bytes retransmitted (retrans ratio = /BytesSent)
+	BytesReceived uint64        // total data bytes received
+	Delivered     uint32        // total packets delivered
+	DeliveryRate  uint64        // recent delivery rate, bytes/sec (BBR estimate)
+	PacingRate    uint64        // target pacing rate, bytes/sec
+	NotsentBytes  uint32        // bytes buffered but not yet on the wire — app-limited signal
+	BusyTime      time.Duration // cumulative time socket was busy sending
+	RwndLimited   time.Duration // cumulative time limited by receiver window
+	SndbufLimited time.Duration // cumulative time limited by send buffer
+	Rehash        uint32        // times the flow was rehashed (indicates path changes)
+
+	// LastDataRecv / LastDataSent express "how long since the socket last
+	// carried data" — helps distinguish "idle since forever" from "just
+	// hung." Both derived from tcp_info's last_data_{recv,sent}.
+	LastDataRecv time.Duration
+	LastDataSent time.Duration
+
+	// RetransRatioPct = BytesRetrans / BytesSent * 100, precomputed for
+	// the common "% of bytes retransmitted" view. Zero when BytesSent is
+	// zero (no data has flowed yet).
+	RetransRatioPct float64
+
+	// Err is set when this platform can't read TCP_INFO or the read
+	// failed on a live fd. Dead fds (EBADF/ENOTCONN) are pruned rather
+	// than surfaced, so a populated Err always means "conn exists but
+	// info wasn't readable" — e.g. non-Linux OS.
+	Err string
+}
+
+// DeadConnInfo is what the registry remembers about a pruned conn: the
+// endpoints plus dial and death times. Lifetime = DiedAt.Sub(DialedAt) is
+// the value tcpz plots for the "how long did conns live?" histogram.
+// DiedAt is when Snapshot noticed the death (the getsockopt returned
+// EBADF/ENOTCONN/ErrClosed) — approximate but within one Snapshot cadence
+// of actual close.
+type DeadConnInfo struct {
+	RemoteAddr string
+	LocalAddr  string
+	DialedAt   time.Time
+	DiedAt     time.Time
+}
+
+// Snapshot reads TCP_INFO for every registered conn and returns the
+// results, oldest dial first. Dead entries (readTCPInfo returned an
+// isDeadConn error) are removed from the registry before returning so a
+// gRPC-closed conn doesn't linger indefinitely; their (dial, death) pair
+// is copied into the graveyard ring for post-mortem age analysis. All
+// syscalls happen outside the registry lock so a slow syscall can't block
+// dials or other snapshots.
+func (r *ConnRegistry) Snapshot() []TCPInfoSnapshot {
+	r.mu.RLock()
+	keys := make([]uint64, 0, len(r.conns))
+	byKey := make(map[uint64]*trackedConn, len(r.conns))
+	for k, tc := range r.conns {
+		keys = append(keys, k)
+		byKey[k] = tc
+	}
+	r.mu.RUnlock()
+
+	sortKeysAscending(keys)
+
+	out := make([]TCPInfoSnapshot, 0, len(keys))
+	var dead []uint64
+	for _, k := range keys {
+		tc := byKey[k]
+		snap, err := readTCPInfo(tc.conn)
+		if err != nil {
+			if isDeadConn(err) {
+				dead = append(dead, k)
+				continue
+			}
+			snap = TCPInfoSnapshot{Err: err.Error()}
+		}
+		snap.RemoteAddr = tc.remoteAddr
+		snap.LocalAddr = tc.localAddr
+		snap.DialedAt = tc.dialedAt
+		out = append(out, snap)
+	}
+	if len(dead) > 0 {
+		now := time.Now()
+		r.mu.Lock()
+		for _, k := range dead {
+			tc, ok := r.conns[k]
+			if !ok {
+				continue
+			}
+			r.recordDeathLocked(DeadConnInfo{
+				RemoteAddr: tc.remoteAddr,
+				LocalAddr:  tc.localAddr,
+				DialedAt:   tc.dialedAt,
+				DiedAt:     now,
+			})
+			delete(r.conns, k)
+		}
+		r.mu.Unlock()
+	}
+	return out
+}
+
+// recordDeathLocked appends to the graveyard ring. Caller MUST hold
+// r.mu.Lock().
+func (r *ConnRegistry) recordDeathLocked(d DeadConnInfo) {
+	if r.graveyard == nil {
+		r.graveyard = make([]DeadConnInfo, graveyardCap)
+	}
+	r.graveyard[r.graveIdx] = d
+	r.graveIdx++
+	if r.graveIdx >= graveyardCap {
+		r.graveIdx = 0
+		r.graveFull = true
+	}
+}
+
+// DeadConns returns a copy of the graveyard, oldest death first. Bounded
+// at graveyardCap; older deaths are silently dropped as new ones arrive.
+// Empty slice when nothing has died yet.
+func (r *ConnRegistry) DeadConns() []DeadConnInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.graveyard == nil {
+		return nil
+	}
+	var n int
+	if r.graveFull {
+		n = graveyardCap
+	} else {
+		n = r.graveIdx
+	}
+	out := make([]DeadConnInfo, 0, n)
+	if r.graveFull {
+		out = append(out, r.graveyard[r.graveIdx:]...)
+		out = append(out, r.graveyard[:r.graveIdx]...)
+	} else {
+		out = append(out, r.graveyard[:r.graveIdx]...)
+	}
+	return out
+}
+
+// Len reports the registered conn count (including any not-yet-pruned
+// dead entries). Cheap; useful for a "conns=N" summary row.
+func (r *ConnRegistry) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.conns)
+}
+
+// sortKeysAscending is a tiny helper — uint64 sort without pulling
+// sort.Slice's reflection overhead into a debug path that runs frequently.
+func sortKeysAscending(ks []uint64) {
+	for i := 1; i < len(ks); i++ {
+		for j := i; j > 0 && ks[j-1] > ks[j]; j-- {
+			ks[j-1], ks[j] = ks[j], ks[j-1]
+		}
+	}
+}
+
+// unsupportedTCPInfoErr is the error tcp_info_*.go implementations return
+// when the platform can't expose TCP_INFO. Exposed as a constant so tests
+// can assert on it without importing platform-specific code.
+type unsupportedTCPInfoErr struct{}
+
+func (unsupportedTCPInfoErr) Error() string { return "tcp_info not supported on this platform" }
+
+// ErrTCPInfoUnsupported is the sentinel returned by readTCPInfo on non-Linux.
+var ErrTCPInfoUnsupported = unsupportedTCPInfoErr{}
+
+// annotateReadErr is a small helper used by platform-specific readers when
+// they want to prefix a syscall error with context.
+func annotateReadErr(op string, err error) error {
+	return fmt.Errorf("%s: %w", op, err)
+}

--- a/bigtable/internal/transport/conn_registry_test.go
+++ b/bigtable/internal/transport/conn_registry_test.go
@@ -1,0 +1,212 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"net"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestConnRegistry_DialRegistersAndSnapshot verifies Dial captures the
+// remote/local addr and DialedAt, and that Snapshot returns one entry
+// per registered conn. On Linux the RTT / MSS fields should be non-zero
+// after the first byte flows; on other platforms Err is populated.
+func TestConnRegistry_DialRegistersAndSnapshot(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			// Bounce one byte so both sides have measurable TCP state.
+			buf := make([]byte, 1)
+			_, _ = c.Read(buf)
+			_, _ = c.Write(buf)
+			c.Close()
+		}
+	}()
+
+	reg := NewConnRegistry()
+	conn, err := reg.Dial(context.Background(), ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	// Trigger one byte so Linux has stats to report.
+	if _, err := conn.Write([]byte{1}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	buf := make([]byte, 1)
+	if _, err := conn.Read(buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	if got, want := reg.Len(), 1; got != want {
+		t.Fatalf("Len() = %d, want %d", got, want)
+	}
+	snaps := reg.Snapshot()
+	if len(snaps) != 1 {
+		t.Fatalf("Snapshot() len = %d, want 1", len(snaps))
+	}
+	s := snaps[0]
+	if s.RemoteAddr != ln.Addr().String() {
+		t.Errorf("RemoteAddr = %q, want %q", s.RemoteAddr, ln.Addr().String())
+	}
+	if s.LocalAddr == "" {
+		t.Error("LocalAddr empty")
+	}
+	if time.Since(s.DialedAt) > time.Second {
+		t.Errorf("DialedAt = %v, expected within last second", s.DialedAt)
+	}
+	switch runtime.GOOS {
+	case "linux":
+		if s.Err != "" {
+			t.Errorf("Err = %q on linux, want empty", s.Err)
+		}
+		// State should be ESTABLISHED right after handshake+bounce, or
+		// CLOSE_WAIT if the server side already FIN'd — accept either.
+		if s.State == "" {
+			t.Error("State empty on linux")
+		}
+	default:
+		if s.Err == "" {
+			t.Errorf("Err empty on %s, want unsupported sentinel", runtime.GOOS)
+		}
+	}
+}
+
+// TestConnRegistry_SnapshotPrunesDeadConns confirms that a conn whose fd
+// was closed out from under the registry is removed on the next
+// Snapshot — this is the mechanism that keeps the map honest without a
+// Close hook on the wire.
+func TestConnRegistry_SnapshotPrunesDeadConns(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("prune mechanism relies on Linux errno differentiation")
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			c.Close()
+		}
+	}()
+
+	reg := NewConnRegistry()
+	conn, err := reg.Dial(context.Background(), ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	// After Close, the fd is gone. Snapshot should notice and prune —
+	// either immediately or after Go's runtime finalizer clears the fd
+	// entry. Give it one call; if the entry is present but Err-flagged
+	// that's also acceptable, because different kernels report closed
+	// fds via different errnos.
+	_ = reg.Snapshot()
+	// A second snapshot after any lazy state should not leak entries
+	// permanently — assert the map is either empty or the sole entry
+	// is flagged dead.
+	snaps := reg.Snapshot()
+	if len(snaps) == 0 {
+		return // pruned as expected
+	}
+	if snaps[0].Err == "" && snaps[0].State != "" {
+		t.Errorf("expected pruned or errored entry, got live snap: %+v", snaps[0])
+	}
+}
+
+// TestConnRegistry_ConcurrentDialsAndSnapshots is a coarse race check —
+// hammer Dial and Snapshot from parallel goroutines under `-race` to
+// confirm no lock ordering / map-access bugs.
+func TestConnRegistry_ConcurrentDialsAndSnapshots(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				buf := make([]byte, 32)
+				for {
+					n, err := c.Read(buf)
+					if err != nil {
+						c.Close()
+						return
+					}
+					if _, err := c.Write(buf[:n]); err != nil {
+						c.Close()
+						return
+					}
+				}
+			}(c)
+		}
+	}()
+
+	reg := NewConnRegistry()
+	done := make(chan struct{})
+	// conns is populated by the dialer goroutine and read by the main
+	// test after <-done, which provides the happens-before edge. Held
+	// open across the Len() assertion so the registry entries survive
+	// long enough to be observed — closing before the assertion races
+	// registry deregistration and flakes Len()==0 under load.
+	var conns []net.Conn
+	go func() {
+		defer close(done)
+		for i := 0; i < 20; i++ {
+			c, err := reg.Dial(context.Background(), ln.Addr().String())
+			if err != nil {
+				t.Errorf("dial: %v", err)
+				return
+			}
+			conns = append(conns, c)
+			time.Sleep(2 * time.Millisecond)
+		}
+	}()
+	// Snapshotter goroutine.
+	for i := 0; i < 40; i++ {
+		_ = reg.Snapshot()
+		time.Sleep(time.Millisecond)
+	}
+	<-done
+	if reg.Len() == 0 {
+		t.Error("Len() = 0 after 20 dials, expected registered conns")
+	}
+	for _, c := range conns {
+		c.Close()
+	}
+}

--- a/bigtable/internal/transport/debug_api.go
+++ b/bigtable/internal/transport/debug_api.go
@@ -60,6 +60,15 @@ type ChannelPoolDebug struct {
 	// SessionsByChannel maps a connEntry index to the sessions riding
 	// on it. Populated only for the "session" role.
 	SessionsByChannel map[int][]SessionRef
+	// InstanceName is the fully-qualified Bigtable instance path
+	// ("projects/P/instances/I") the pool dials. Populated by the
+	// Client that owns the pool; renderers use it as the top-line
+	// identifier on the channelz page. Empty if the caller couldn't
+	// determine it.
+	InstanceName string
+	// AppProfile is the app profile id every RPC on this pool carries.
+	// Empty when the caller uses the default profile.
+	AppProfile string
 }
 
 // SessionRef identifies one session for the channelz → sessionz reverse

--- a/bigtable/internal/transport/debug_tracer.go
+++ b/bigtable/internal/transport/debug_tracer.go
@@ -166,6 +166,16 @@ const (
 	// Client configuration polling.
 	tagClientConfigPollFailed     = "client_config_poll_failed"
 	tagClientConfigPollCtxExpired = "client_config_poll_ctx_expired"
+
+	// Outlier downweight — paired transition tags from the built-in
+	// LatencyOutlierScorer. Fires on transition only (score change from
+	// last tick), so `rate(outlier_afe_penalized_latency)` reflects
+	// "how often an AFE entered penalty" and dashboards can compute
+	// currently-penalized as sum(penalized) - sum(recovered). The
+	// `_latency` suffix leaves room for future error-rate or retry-
+	// storm variants without renaming.
+	tagOutlierAfePenalizedLatency = "outlier_afe_penalized_latency"
+	tagOutlierAfeRecoveredLatency = "outlier_afe_recovered_latency"
 )
 
 var (

--- a/bigtable/internal/transport/outlier_debug.go
+++ b/bigtable/internal/transport/outlier_debug.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"time"
+)
+
+// OutlierDebugProvider exposes per-pool outlier-scorer state to the
+// debugview package. Symmetric with SessionDebugProvider /
+// ChannelDebugProvider / ConfigDebugProvider — the client implements
+// this to feed the /debug/outlierz page.
+type OutlierDebugProvider interface {
+	// Snapshot returns one entry per session pool the client owns. For
+	// pools running NoopScorer the entry carries ScorerName="noop"
+	// with empty Params / Scores / Recent, so the debug page still
+	// renders a row per pool showing "no outlier detection wired."
+	Snapshot() []OutlierPoolSnapshot
+}
+
+// OutlierPoolSnapshot is the per-pool outlier-detection state a debug
+// page renders — what scorer is plugged in, its config knobs, the
+// current per-AFE score map, and recent score transitions.
+type OutlierPoolSnapshot struct {
+	// PoolName matches the SessionPoolImpl's pool name so debug pages
+	// can cross-link back to sessionz / loadz etc.
+	PoolName string `json:"pool"`
+	// ScorerName is OutlierScorer.Name() — e.g. "noop", "latency-outlier".
+	ScorerName string `json:"scorer"`
+	// Params is the scorer's configuration serialized as name/value
+	// pairs for direct table rendering. Empty for scorers that carry
+	// no configuration (NoopScorer).
+	Params []OutlierParam `json:"params"`
+	// Scores is the current per-AFE score map, sorted by AfeID. Empty
+	// for scorers that don't expose a score map (NoopScorer, or any
+	// scorer that hasn't run its first tick yet).
+	Scores []OutlierScoreRow `json:"scores"`
+	// Recent is the audit ring of the scorer's most recent score
+	// transitions, oldest-first. Empty for scorers without an audit
+	// ring. Rendered newest-first by debug templates.
+	Recent []OutlierDecision `json:"recent"`
+	// CapturedAt is the wall-clock time this snapshot was assembled.
+	CapturedAt time.Time `json:"capturedAt"`
+}
+
+// OutlierParam is one config knob in an OutlierPoolSnapshot's Params
+// list — name/value strings the debug template renders directly.
+type OutlierParam struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// OutlierScoreRow is one row in an OutlierPoolSnapshot's Scores list —
+// the current cost multiplier the scorer assigns to a given AFE.
+type OutlierScoreRow struct {
+	AfeID AfeID `json:"afeId"`
+	// Score is the multiplier the picker's cost function will apply.
+	// 1.0 = no penalty. Values > 1.0 downweight; the scorer decides
+	// the exact magnitude.
+	Score float64 `json:"score"`
+	// Penalized is true when Score > 1.0 — a convenience flag so debug
+	// templates don't have to re-derive the boolean from the float.
+	Penalized bool `json:"penalized"`
+}

--- a/bigtable/internal/transport/outlier_scorer.go
+++ b/bigtable/internal/transport/outlier_scorer.go
@@ -31,12 +31,17 @@ import (
 // target. Implementations must be safe for concurrent Score calls from
 // multiple goroutines without external synchronization.
 //
+// Name returns a short, stable identifier for debug tooling and metrics
+// attribution ("noop", "latency-outlier", …). Must be safe to call
+// concurrently.
+//
 // This is the plug-point for outlier detection: pass an implementation
-// to NewSessionPoolImpl. Default is NoopScorer, which returns 1.0 for
-// every AFE and makes the picker behave exactly as it did before this
-// framework existed.
+// to SessionPoolImpl.SetOutlierScorer. Default is NoopScorer, which
+// returns 1.0 for every AFE and makes the picker behave exactly as it
+// did before this framework existed.
 type OutlierScorer interface {
 	Score(id AfeID) float64
+	Name() string
 }
 
 // LifecycleScorer is optionally implemented by scorers that maintain
@@ -94,3 +99,6 @@ type NoopScorer struct{}
 
 // Score always returns 1.0.
 func (NoopScorer) Score(AfeID) float64 { return 1.0 }
+
+// Name returns "noop".
+func (NoopScorer) Name() string { return "noop" }

--- a/bigtable/internal/transport/outlier_scorer.go
+++ b/bigtable/internal/transport/outlier_scorer.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"time"
+)
+
+// OutlierScorer produces a per-AFE cost multiplier that latency-based
+// AfePickers fold into their decision. Score returns:
+//
+//   - 1.0 for healthy AFEs (no penalty; picker cost is unchanged)
+//   - a value > 1.0 for outliers (picker cost inflates by this factor)
+//   - 1.0 for unknown IDs (any AFE the scorer has not observed)
+//
+// Score is called on the CheckoutSession hot path — once per ready AFE
+// per pick — so implementations must be fast; sub-microsecond is the
+// target. Implementations must be safe for concurrent Score calls from
+// multiple goroutines without external synchronization.
+//
+// This is the plug-point for outlier detection: pass an implementation
+// to NewSessionPoolImpl. Default is NoopScorer, which returns 1.0 for
+// every AFE and makes the picker behave exactly as it did before this
+// framework existed.
+type OutlierScorer interface {
+	Score(id AfeID) float64
+}
+
+// LifecycleScorer is optionally implemented by scorers that maintain
+// background state (a periodic detection loop, for example) and need a
+// context to bound their lifetime. When present, SessionPoolImpl.Start
+// invokes Start(poolCtx) exactly once during pool startup; cancellation
+// of the context signals the scorer to wind down its background work.
+//
+// Scorers that are stateless (NoopScorer, or a caller-supplied
+// hard-coded score map) don't need to implement this interface.
+type LifecycleScorer interface {
+	OutlierScorer
+	Start(ctx context.Context)
+}
+
+// SnapshottingScorer is optionally implemented by scorers that produce
+// audit data (score transitions, decision reasons) for the debug pages
+// and post-mortem tooling. OutlierSnapshot returns a self-contained
+// copy of the audit state — no locks are required on the returned
+// slice, and implementations must not mutate it after returning.
+type SnapshottingScorer interface {
+	OutlierScorer
+	OutlierSnapshot() []OutlierDecision
+}
+
+// OutlierDecision is one entry in a scorer's audit log — a per-target
+// record of a score transition with the signal that drove it. Emitted
+// by SnapshottingScorer.OutlierSnapshot() and rendered by future
+// /debug/outlierz handlers.
+type OutlierDecision struct {
+	// When is the wall-clock time the decision was made.
+	When time.Time
+	// AfeID is the target the decision applies to.
+	AfeID AfeID
+	// OldScore and NewScore bracket the transition. Only transitions
+	// are recorded — no-change ticks do not produce OutlierDecisions.
+	OldScore float64
+	NewScore float64
+	// Signal is the observed metric (latency in ns for a latency-based
+	// scorer) the scorer compared against the cohort.
+	Signal float64
+	// CohortMedian is the reference value the signal was compared to.
+	CohortMedian float64
+	// Reason names the decision rule that fired, e.g. "penalized-latency"
+	// or "recovered-latency". Lower-kebab; stable enough for machine
+	// consumption in debug tooling.
+	Reason string
+}
+
+// NoopScorer returns 1.0 for every AFE — the picker's cost function is
+// unmodified. Zero-cost sentinel used when the pool is constructed
+// without an outlier scorer or when the caller wants to explicitly opt
+// out of outlier downweight.
+type NoopScorer struct{}
+
+// Score always returns 1.0.
+func (NoopScorer) Score(AfeID) float64 { return 1.0 }

--- a/bigtable/internal/transport/outlier_scorer_latency.go
+++ b/bigtable/internal/transport/outlier_scorer_latency.go
@@ -93,22 +93,37 @@ func (c LatencyOutlierConfig) applyDefaults() LatencyOutlierConfig {
 	return c
 }
 
-// afeSnapshotSource is the minimal read-only surface LatencyOutlierScorer
-// needs from a sessionList. *sessionList satisfies it in production;
+// AfeSnapshotSource is the minimal read-only surface LatencyOutlierScorer
+// needs to observe AFE state. *sessionList satisfies it in production;
 // tests pass a fake that returns hand-authored snapshots without
 // standing up a real sessionList.
-type afeSnapshotSource interface {
+//
+// Exported so callers who pass an OutlierScorerFactory via
+// ClientConfig can build stateful scorers over it — the factory
+// receives this interface as its argument.
+type AfeSnapshotSource interface {
 	Snapshot() []AfeSnapshotRow
 }
 
+// OutlierScorerFactory constructs the OutlierScorer plugged into one
+// session pool. Called at pool-construction time; the returned scorer
+// is installed via SessionPoolImpl.SetOutlierScorer and, if it
+// satisfies LifecycleScorer, has Start(poolCtx) called during
+// SessionPoolImpl.Start.
+//
+// src is the pool's own AFE snapshot source — pass to
+// NewLatencyOutlierScorer or your custom scorer to give it a
+// read-only view of pool state.
+type OutlierScorerFactory func(src AfeSnapshotSource) OutlierScorer
+
 // LatencyOutlierScorer is the built-in OutlierScorer that periodically
-// reads per-AFE PeakEwma snapshots from a sessionList, compares each
-// AFE's worst latency against the cohort median, and inflates the score
-// of outliers so latency-based pickers steer traffic away.
+// reads per-AFE PeakEwma snapshots from an AfeSnapshotSource, compares
+// each AFE's worst latency against the cohort median, and inflates the
+// score of outliers so latency-based pickers steer traffic away.
 //
 // Implements OutlierScorer, LifecycleScorer, and SnapshottingScorer.
 type LatencyOutlierScorer struct {
-	src afeSnapshotSource
+	src AfeSnapshotSource
 	cfg LatencyOutlierConfig
 
 	// scores is the hot-path read surface: atomic.Pointer to an
@@ -127,18 +142,11 @@ type LatencyOutlierScorer struct {
 }
 
 // NewLatencyOutlierScorer constructs a LatencyOutlierScorer that reads
-// AFE snapshots from sl. Pass DefaultLatencyOutlierConfig() (or a
+// AFE snapshots from src. Pass DefaultLatencyOutlierConfig() (or a
 // partially-populated LatencyOutlierConfig) as cfg — zero-valued fields
 // pick up defaults. The returned scorer's Score always returns 1.0
 // until Start is called and the first tick lands.
-func NewLatencyOutlierScorer(sl *sessionList, cfg LatencyOutlierConfig) *LatencyOutlierScorer {
-	return newLatencyOutlierScorer(sl, cfg)
-}
-
-// newLatencyOutlierScorer is the unexported constructor accepting the
-// afeSnapshotSource interface — tests inject a fake source; production
-// callers use NewLatencyOutlierScorer which passes a *sessionList.
-func newLatencyOutlierScorer(src afeSnapshotSource, cfg LatencyOutlierConfig) *LatencyOutlierScorer {
+func NewLatencyOutlierScorer(src AfeSnapshotSource, cfg LatencyOutlierConfig) *LatencyOutlierScorer {
 	s := &LatencyOutlierScorer{
 		src: src,
 		cfg: cfg.applyDefaults(),

--- a/bigtable/internal/transport/outlier_scorer_latency.go
+++ b/bigtable/internal/transport/outlier_scorer_latency.go
@@ -1,0 +1,290 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"runtime/debug"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	btopt "cloud.google.com/go/bigtable/internal/option"
+)
+
+// LatencyOutlierConfig tunes LatencyOutlierScorer. Zero values in any
+// field are replaced by the same defaults DefaultLatencyOutlierConfig
+// produces, so callers can override just the knobs they care about.
+type LatencyOutlierConfig struct {
+	// Interval is the detector tick cadence. Default 30s.
+	Interval time.Duration
+	// LatencyMultiplier is the outlier threshold. An AFE is flagged when
+	// its worst PeakEwma (max of e2e and transport) exceeds
+	// LatencyMultiplier × cohort_median AND MinLatencyFloor. Default 3.0.
+	LatencyMultiplier float64
+	// MinLatencyFloor is an absolute floor below which no AFE is ever
+	// penalized — prevents "3× median" from firing when median is
+	// microseconds. Default 20ms.
+	MinLatencyFloor time.Duration
+	// MinCohortSize is the smallest cohort the detector will evaluate.
+	// Pools with fewer AFEs than this get no protection (median is not
+	// meaningful below 3 peers). Default 3.
+	MinCohortSize int
+	// PenaltyMultiplier is the cost-function multiplier applied to
+	// flagged AFEs. A latency-based picker will pick a penalized AFE
+	// with cost = base × PenaltyMultiplier; K-choice-of-2 almost never
+	// picks it vs a healthy sibling at 10x. Default 10.0.
+	PenaltyMultiplier float64
+	// AuditRingSize caps the OutlierSnapshot audit ring. Default 500.
+	AuditRingSize int
+}
+
+// DefaultLatencyOutlierConfig returns the calibrated defaults for
+// production use.
+func DefaultLatencyOutlierConfig() LatencyOutlierConfig {
+	return LatencyOutlierConfig{
+		Interval:          30 * time.Second,
+		LatencyMultiplier: 3.0,
+		MinLatencyFloor:   20 * time.Millisecond,
+		MinCohortSize:     3,
+		PenaltyMultiplier: 10.0,
+		AuditRingSize:     500,
+	}
+}
+
+// applyDefaults fills any zero-valued field with the value from
+// DefaultLatencyOutlierConfig. Called from NewLatencyOutlierScorer so
+// callers can pass a partial config without losing the calibrated
+// defaults on the fields they didn't set.
+func (c LatencyOutlierConfig) applyDefaults() LatencyOutlierConfig {
+	def := DefaultLatencyOutlierConfig()
+	if c.Interval == 0 {
+		c.Interval = def.Interval
+	}
+	if c.LatencyMultiplier == 0 {
+		c.LatencyMultiplier = def.LatencyMultiplier
+	}
+	if c.MinLatencyFloor == 0 {
+		c.MinLatencyFloor = def.MinLatencyFloor
+	}
+	if c.MinCohortSize == 0 {
+		c.MinCohortSize = def.MinCohortSize
+	}
+	if c.PenaltyMultiplier == 0 {
+		c.PenaltyMultiplier = def.PenaltyMultiplier
+	}
+	if c.AuditRingSize == 0 {
+		c.AuditRingSize = def.AuditRingSize
+	}
+	return c
+}
+
+// afeSnapshotSource is the minimal read-only surface LatencyOutlierScorer
+// needs from a sessionList. *sessionList satisfies it in production;
+// tests pass a fake that returns hand-authored snapshots without
+// standing up a real sessionList.
+type afeSnapshotSource interface {
+	Snapshot() []AfeSnapshotRow
+}
+
+// LatencyOutlierScorer is the built-in OutlierScorer that periodically
+// reads per-AFE PeakEwma snapshots from a sessionList, compares each
+// AFE's worst latency against the cohort median, and inflates the score
+// of outliers so latency-based pickers steer traffic away.
+//
+// Implements OutlierScorer, LifecycleScorer, and SnapshottingScorer.
+type LatencyOutlierScorer struct {
+	src afeSnapshotSource
+	cfg LatencyOutlierConfig
+
+	// scores is the hot-path read surface: atomic.Pointer to an
+	// immutable map from AfeID to cost multiplier. Score(id) does one
+	// atomic load + one map lookup. tick() builds a fresh map each
+	// iteration and atomic-swaps it in — no lock held on the read
+	// path.
+	scores atomic.Pointer[map[AfeID]float64]
+
+	// auditMu guards audit + auditNext. Contention is negligible —
+	// writes only during tick transitions (rare), reads only from
+	// OutlierSnapshot (debug tooling).
+	auditMu   sync.Mutex
+	audit     []OutlierDecision
+	auditNext int // next write index when the ring is full
+}
+
+// NewLatencyOutlierScorer constructs a LatencyOutlierScorer that reads
+// AFE snapshots from sl. Pass DefaultLatencyOutlierConfig() (or a
+// partially-populated LatencyOutlierConfig) as cfg — zero-valued fields
+// pick up defaults. The returned scorer's Score always returns 1.0
+// until Start is called and the first tick lands.
+func NewLatencyOutlierScorer(sl *sessionList, cfg LatencyOutlierConfig) *LatencyOutlierScorer {
+	return newLatencyOutlierScorer(sl, cfg)
+}
+
+// newLatencyOutlierScorer is the unexported constructor accepting the
+// afeSnapshotSource interface — tests inject a fake source; production
+// callers use NewLatencyOutlierScorer which passes a *sessionList.
+func newLatencyOutlierScorer(src afeSnapshotSource, cfg LatencyOutlierConfig) *LatencyOutlierScorer {
+	s := &LatencyOutlierScorer{
+		src: src,
+		cfg: cfg.applyDefaults(),
+	}
+	empty := make(map[AfeID]float64)
+	s.scores.Store(&empty)
+	return s
+}
+
+// Score returns the current cost multiplier for id. Returns 1.0 for
+// AFEs the scorer hasn't observed yet — safe default so
+// LeastLatencyAfePicker's cost math never sees a zero multiplier.
+func (s *LatencyOutlierScorer) Score(id AfeID) float64 {
+	m := s.scores.Load()
+	if m == nil {
+		return 1.0
+	}
+	if v, ok := (*m)[id]; ok {
+		return v
+	}
+	return 1.0
+}
+
+// Start spawns the periodic detector loop. Cancels on ctx.Done — the
+// pool's poolCtx is what SessionPoolImpl.Start passes here.
+// Idempotent-safe: SessionPoolImpl.Start already funnels through
+// startOnce so Start is called at most once per scorer instance.
+func (s *LatencyOutlierScorer) Start(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(s.cfg.Interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				s.tick()
+			}
+		}
+	}()
+}
+
+// OutlierSnapshot returns a copy of the audit ring in insertion order
+// (oldest to newest). Safe to render without further locking; the
+// returned slice is a fresh allocation.
+func (s *LatencyOutlierScorer) OutlierSnapshot() []OutlierDecision {
+	s.auditMu.Lock()
+	defer s.auditMu.Unlock()
+	n := len(s.audit)
+	if n == 0 {
+		return nil
+	}
+	out := make([]OutlierDecision, n)
+	if n < s.cfg.AuditRingSize {
+		copy(out, s.audit)
+		return out
+	}
+	// Ring is full — walk from auditNext (oldest) to auditNext-1 (newest).
+	for i := 0; i < n; i++ {
+		out[i] = s.audit[(s.auditNext+i)%n]
+	}
+	return out
+}
+
+// tick runs one detection cycle. Reads a fresh AFE snapshot from the
+// sessionList (single lock acquisition, released before we compute
+// anything), evaluates the outlier rule, and atomically swaps in the
+// new score map. Emits transition tags for AFEs whose score changed
+// from the previous tick.
+func (s *LatencyOutlierScorer) tick() {
+	defer func() {
+		if r := recover(); r != nil {
+			btopt.Debugf(nil, "outlier scorer tick panic: %v\n%s", r, debug.Stack())
+		}
+	}()
+	rows := s.src.Snapshot()
+	if len(rows) < s.cfg.MinCohortSize {
+		// Not enough peers for a stable median. Do NOT clear existing
+		// scores — a shrinking cohort might briefly drop below the
+		// threshold; keeping the prior tick's decision is less
+		// surprising than snapping back to 1.0 on every AFE.
+		return
+	}
+
+	// Compute the outlier signal for each AFE: worst of e2eEwma and
+	// transportEwma. Backend-slow and network-slow are both bad; taking
+	// the max flags either.
+	worsts := make([]time.Duration, len(rows))
+	sorted := make([]time.Duration, len(rows))
+	for i, r := range rows {
+		w := r.E2eEwma
+		if r.TransportEwma > w {
+			w = r.TransportEwma
+		}
+		worsts[i] = w
+		sorted[i] = w
+	}
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	median := sorted[len(sorted)/2]
+
+	old := *s.scores.Load()
+	newScores := make(map[AfeID]float64, len(rows))
+	now := time.Now()
+	for i, r := range rows {
+		newScore := 1.0
+		if worsts[i] > s.cfg.MinLatencyFloor &&
+			float64(worsts[i]) > s.cfg.LatencyMultiplier*float64(median) {
+			newScore = s.cfg.PenaltyMultiplier
+		}
+		newScores[r.ID] = newScore
+
+		oldScore := old[r.ID]
+		if oldScore == 0 {
+			oldScore = 1.0
+		}
+		if oldScore == newScore {
+			continue
+		}
+		reason := "penalized-latency"
+		tag := tagOutlierAfePenalizedLatency
+		if newScore == 1.0 {
+			reason = "recovered-latency"
+			tag = tagOutlierAfeRecoveredLatency
+		}
+		recordDebugTag(tag)
+		s.pushAudit(OutlierDecision{
+			When:         now,
+			AfeID:        r.ID,
+			OldScore:     oldScore,
+			NewScore:     newScore,
+			Signal:       float64(worsts[i]),
+			CohortMedian: float64(median),
+			Reason:       reason,
+		})
+	}
+	s.scores.Store(&newScores)
+}
+
+// pushAudit appends d to the audit ring, overwriting the oldest entry
+// when the ring is full.
+func (s *LatencyOutlierScorer) pushAudit(d OutlierDecision) {
+	s.auditMu.Lock()
+	defer s.auditMu.Unlock()
+	if len(s.audit) < s.cfg.AuditRingSize {
+		s.audit = append(s.audit, d)
+		return
+	}
+	s.audit[s.auditNext] = d
+	s.auditNext = (s.auditNext + 1) % s.cfg.AuditRingSize
+}

--- a/bigtable/internal/transport/outlier_scorer_latency.go
+++ b/bigtable/internal/transport/outlier_scorer_latency.go
@@ -16,6 +16,7 @@ package internal
 
 import (
 	"context"
+	"fmt"
 	"runtime/debug"
 	"sort"
 	"sync"
@@ -159,6 +160,61 @@ func (s *LatencyOutlierScorer) Score(id AfeID) float64 {
 		return v
 	}
 	return 1.0
+}
+
+// Name returns "latency-outlier".
+func (*LatencyOutlierScorer) Name() string { return "latency-outlier" }
+
+// Config returns a copy of the config the scorer was constructed with
+// (after defaults were applied). Debug pages render this to show
+// operators exactly which thresholds are in effect.
+func (s *LatencyOutlierScorer) Config() LatencyOutlierConfig { return s.cfg }
+
+// CurrentScores returns a copy of the current per-AFE score map, sorted
+// by AfeID. Empty until the first tick has landed. Safe for concurrent
+// callers.
+func (s *LatencyOutlierScorer) CurrentScores() []OutlierScoreRow {
+	m := s.scores.Load()
+	if m == nil || len(*m) == 0 {
+		return nil
+	}
+	out := make([]OutlierScoreRow, 0, len(*m))
+	for id, v := range *m {
+		out = append(out, OutlierScoreRow{
+			AfeID:     id,
+			Score:     v,
+			Penalized: v > 1.0,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].AfeID < out[j].AfeID })
+	return out
+}
+
+// DebugSnapshot assembles a full OutlierPoolSnapshot for one pool. The
+// PoolName field is not populated here — the caller (SessionPoolImpl)
+// fills it in. CapturedAt is stamped at call time.
+func (s *LatencyOutlierScorer) DebugSnapshot() OutlierPoolSnapshot {
+	return OutlierPoolSnapshot{
+		ScorerName: s.Name(),
+		Params:     s.paramsForDebug(),
+		Scores:     s.CurrentScores(),
+		Recent:     s.OutlierSnapshot(),
+		CapturedAt: time.Now(),
+	}
+}
+
+// paramsForDebug renders the scorer's config as a list of name/value
+// pairs the debug template can iterate over.
+func (s *LatencyOutlierScorer) paramsForDebug() []OutlierParam {
+	c := s.cfg
+	return []OutlierParam{
+		{Name: "Interval", Value: c.Interval.String()},
+		{Name: "LatencyMultiplier", Value: fmt.Sprintf("%.2fx", c.LatencyMultiplier)},
+		{Name: "MinLatencyFloor", Value: c.MinLatencyFloor.String()},
+		{Name: "MinCohortSize", Value: fmt.Sprintf("%d", c.MinCohortSize)},
+		{Name: "PenaltyMultiplier", Value: fmt.Sprintf("%.2fx", c.PenaltyMultiplier)},
+		{Name: "AuditRingSize", Value: fmt.Sprintf("%d", c.AuditRingSize)},
+	}
 }
 
 // Start spawns the periodic detector loop. Cancels on ctx.Done — the

--- a/bigtable/internal/transport/outlier_scorer_latency.go
+++ b/bigtable/internal/transport/outlier_scorer_latency.go
@@ -286,18 +286,18 @@ func (s *LatencyOutlierScorer) tick() {
 		return
 	}
 
-	// Compute the outlier signal for each AFE: worst of e2eEwma and
-	// transportEwma. Backend-slow and network-slow are both bad; taking
-	// the max flags either.
+	// Signal is e2eEwma alone. transportEwma is fed (e2e - backend) per
+	// sample in RecordVRpcOutcome, so transportEwma <= e2eEwma by
+	// construction — taking max() collapses to e2eEwma. e2e also
+	// naturally captures both failure modes: a slow backend inflates e2e
+	// (transport unchanged), and slow-network / bad AFE inflates
+	// transport which flows into e2e. Client-observed latency is the
+	// canonical signal here.
 	worsts := make([]time.Duration, len(rows))
 	sorted := make([]time.Duration, len(rows))
 	for i, r := range rows {
-		w := r.E2eEwma
-		if r.TransportEwma > w {
-			w = r.TransportEwma
-		}
-		worsts[i] = w
-		sorted[i] = w
+		worsts[i] = r.E2eEwma
+		sorted[i] = r.E2eEwma
 	}
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
 	median := sorted[len(sorted)/2]

--- a/bigtable/internal/transport/outlier_scorer_test.go
+++ b/bigtable/internal/transport/outlier_scorer_test.go
@@ -15,6 +15,7 @@
 package internal
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -40,6 +41,61 @@ func row(id AfeID, e2e, transport time.Duration) AfeSnapshotRow {
 	}
 }
 
+// spyScorer records SetOutlierScorer + LifecycleScorer.Start invocations
+// so tests can assert the pool wired it correctly.
+type spyScorer struct {
+	scoreCalls int64
+	startCalls int64
+}
+
+func (s *spyScorer) Score(AfeID) float64 { s.scoreCalls++; return 1.0 }
+func (*spyScorer) Name() string          { return "spy" }
+func (s *spyScorer) Start(context.Context) {
+	s.startCalls++
+}
+
+// TestSessionPoolImpl_LifecycleScorerStartInvoked pins the wire-in that
+// SessionPoolImpl.Start calls scorer.Start(poolCtx) when the plugged
+// scorer implements LifecycleScorer. Downstream from
+// ClientConfig.OutlierScorerFactory — if this ever regresses, factories
+// wiring LatencyOutlierScorer (which needs the ctx to run its tick
+// loop) would silently no-op.
+func TestSessionPoolImpl_LifecycleScorerStartInvoked(t *testing.T) {
+	pool := NewSessionPoolImpl(
+		1, "test-pool", nil, nil, nil, SessionType(0), false,
+	)
+	spy := &spyScorer{}
+	pool.SetOutlierScorer(spy)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool.Start(ctx)
+	// Give the goroutine a chance if Start's scheduling is async;
+	// current Start invokes ls.Start synchronously.
+	if got := spy.startCalls; got != 1 {
+		t.Errorf("LifecycleScorer.Start called %d times, want 1", got)
+	}
+}
+
+// TestSessionPoolImpl_AfeSnapshotSourceReturnsPoolList verifies the
+// AfeSnapshotSource accessor exposes the pool's sessionList — the
+// interface an OutlierScorerFactory receives to build stateful scorers
+// like LatencyOutlierScorer.
+func TestSessionPoolImpl_AfeSnapshotSourceReturnsPoolList(t *testing.T) {
+	pool := NewSessionPoolImpl(
+		2, "test-pool", nil, nil, nil, SessionType(0), false,
+	)
+	src := pool.AfeSnapshotSource()
+	if src == nil {
+		t.Fatal("AfeSnapshotSource() = nil, want non-nil (pool.sl)")
+	}
+	// Snapshot must be callable and return an empty slice on a fresh pool.
+	rows := src.Snapshot()
+	if len(rows) != 0 {
+		t.Errorf("fresh pool Snapshot() = %d rows, want 0", len(rows))
+	}
+}
+
 func TestNoopScorer_AlwaysReturnsOne(t *testing.T) {
 	var s OutlierScorer = NoopScorer{}
 	for _, id := range []AfeID{0, 1, 42, -1, 1 << 62} {
@@ -51,7 +107,7 @@ func TestNoopScorer_AlwaysReturnsOne(t *testing.T) {
 
 func TestLatencyOutlierScorer_UnknownAfeReturnsOne(t *testing.T) {
 	src := &fakeAfeSource{}
-	s := newLatencyOutlierScorer(src, LatencyOutlierConfig{})
+	s := NewLatencyOutlierScorer(src, LatencyOutlierConfig{})
 	if got := s.Score(42); got != 1.0 {
 		t.Errorf("Score(42) before first tick = %v, want 1.0", got)
 	}
@@ -67,7 +123,7 @@ func TestLatencyOutlierScorer_PenalizesSlowAfe(t *testing.T) {
 			row(5, 100*time.Millisecond, 500*time.Microsecond), // 100x the peers
 		},
 	}
-	s := newLatencyOutlierScorer(src, LatencyOutlierConfig{})
+	s := NewLatencyOutlierScorer(src, LatencyOutlierConfig{})
 	s.tick()
 	for _, id := range []AfeID{1, 2, 3, 4} {
 		if got := s.Score(id); got != 1.0 {
@@ -89,7 +145,7 @@ func TestLatencyOutlierScorer_RecoversWhenLatencyDrops(t *testing.T) {
 			row(5, 100*time.Millisecond, 500*time.Microsecond),
 		},
 	}
-	s := newLatencyOutlierScorer(src, LatencyOutlierConfig{})
+	s := NewLatencyOutlierScorer(src, LatencyOutlierConfig{})
 	s.tick()
 	if got := s.Score(5); got != 10.0 {
 		t.Fatalf("pre-recovery Score(5) = %v, want 10.0", got)
@@ -109,7 +165,7 @@ func TestLatencyOutlierScorer_BelowMinCohortSkips(t *testing.T) {
 			row(2, 100*time.Millisecond, 500*time.Microsecond),
 		},
 	}
-	s := newLatencyOutlierScorer(src, LatencyOutlierConfig{MinCohortSize: 3})
+	s := NewLatencyOutlierScorer(src, LatencyOutlierConfig{MinCohortSize: 3})
 	s.tick()
 	// AFE 2 would look like a huge outlier but cohort has only 2 members.
 	if got := s.Score(2); got != 1.0 {
@@ -127,7 +183,7 @@ func TestLatencyOutlierScorer_BelowLatencyFloorSkips(t *testing.T) {
 			row(5, 900*time.Microsecond, 100*time.Microsecond), // 9× the cohort but below 20ms floor
 		},
 	}
-	s := newLatencyOutlierScorer(src, LatencyOutlierConfig{})
+	s := NewLatencyOutlierScorer(src, LatencyOutlierConfig{})
 	s.tick()
 	if got := s.Score(5); got != 1.0 {
 		t.Errorf("Score(5) at sub-floor latency = %v, want 1.0 (below floor)", got)
@@ -144,7 +200,7 @@ func TestLatencyOutlierScorer_TransitionOnlyEmission(t *testing.T) {
 			row(5, 100*time.Millisecond, 500*time.Microsecond),
 		},
 	}
-	s := newLatencyOutlierScorer(src, LatencyOutlierConfig{})
+	s := NewLatencyOutlierScorer(src, LatencyOutlierConfig{})
 
 	resetDebugTagCountsForTest()
 	s.tick() // AFE 5: 1.0 → 10.0 (penalized fires once)
@@ -175,7 +231,7 @@ func TestLatencyOutlierScorer_AuditRingBounded(t *testing.T) {
 			row(3, 1*time.Millisecond, 500*time.Microsecond),
 		},
 	}
-	s := newLatencyOutlierScorer(src, cfg)
+	s := NewLatencyOutlierScorer(src, cfg)
 	// Force 5 transitions on AFE 3.
 	for i := 0; i < 5; i++ {
 		if i%2 == 0 {
@@ -209,7 +265,7 @@ func TestLatencyOutlierScorer_PickerIntegration(t *testing.T) {
 			row(5, 1*time.Millisecond, 500*time.Microsecond),
 		},
 	}
-	scorer := newLatencyOutlierScorer(src, LatencyOutlierConfig{})
+	scorer := NewLatencyOutlierScorer(src, LatencyOutlierConfig{})
 	scorer.tick()
 	if got := scorer.Score(1); got != 10.0 {
 		t.Fatalf("Score(1) = %v, want 10.0 after penalty tick", got)

--- a/bigtable/internal/transport/outlier_scorer_test.go
+++ b/bigtable/internal/transport/outlier_scorer_test.go
@@ -1,0 +1,254 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"testing"
+	"time"
+)
+
+// fakeAfeSource returns a fixed slice of AfeSnapshotRow. Simulates a
+// sessionList for scorer tests without standing up the real one.
+type fakeAfeSource struct {
+	rows []AfeSnapshotRow
+}
+
+func (f *fakeAfeSource) Snapshot() []AfeSnapshotRow { return f.rows }
+
+// row is a compact test constructor for AfeSnapshotRow. e2e and
+// transport are given as time.Duration for readability.
+func row(id AfeID, e2e, transport time.Duration) AfeSnapshotRow {
+	return AfeSnapshotRow{
+		ID:            id,
+		RefCount:      1,
+		IdleCount:     1,
+		E2eEwma:       e2e,
+		TransportEwma: transport,
+		LastConnected: time.Now(),
+	}
+}
+
+func TestNoopScorer_AlwaysReturnsOne(t *testing.T) {
+	var s OutlierScorer = NoopScorer{}
+	for _, id := range []AfeID{0, 1, 42, -1, 1 << 62} {
+		if got := s.Score(id); got != 1.0 {
+			t.Errorf("NoopScorer.Score(%d) = %v, want 1.0", id, got)
+		}
+	}
+}
+
+func TestLatencyOutlierScorer_UnknownAfeReturnsOne(t *testing.T) {
+	src := &fakeAfeSource{}
+	s := newLatencyOutlierScorer(src, LatencyOutlierConfig{})
+	if got := s.Score(42); got != 1.0 {
+		t.Errorf("Score(42) before first tick = %v, want 1.0", got)
+	}
+}
+
+func TestLatencyOutlierScorer_PenalizesSlowAfe(t *testing.T) {
+	src := &fakeAfeSource{
+		rows: []AfeSnapshotRow{
+			row(1, 1*time.Millisecond, 500*time.Microsecond),
+			row(2, 1*time.Millisecond, 500*time.Microsecond),
+			row(3, 1*time.Millisecond, 500*time.Microsecond),
+			row(4, 1*time.Millisecond, 500*time.Microsecond),
+			row(5, 100*time.Millisecond, 500*time.Microsecond), // 100x the peers
+		},
+	}
+	s := newLatencyOutlierScorer(src, LatencyOutlierConfig{})
+	s.tick()
+	for _, id := range []AfeID{1, 2, 3, 4} {
+		if got := s.Score(id); got != 1.0 {
+			t.Errorf("Score(healthy AFE %d) = %v, want 1.0", id, got)
+		}
+	}
+	if got := s.Score(5); got != 10.0 {
+		t.Errorf("Score(slow AFE 5) = %v, want 10.0", got)
+	}
+}
+
+func TestLatencyOutlierScorer_RecoversWhenLatencyDrops(t *testing.T) {
+	src := &fakeAfeSource{
+		rows: []AfeSnapshotRow{
+			row(1, 1*time.Millisecond, 500*time.Microsecond),
+			row(2, 1*time.Millisecond, 500*time.Microsecond),
+			row(3, 1*time.Millisecond, 500*time.Microsecond),
+			row(4, 1*time.Millisecond, 500*time.Microsecond),
+			row(5, 100*time.Millisecond, 500*time.Microsecond),
+		},
+	}
+	s := newLatencyOutlierScorer(src, LatencyOutlierConfig{})
+	s.tick()
+	if got := s.Score(5); got != 10.0 {
+		t.Fatalf("pre-recovery Score(5) = %v, want 10.0", got)
+	}
+	// AFE 5 recovers.
+	src.rows[4] = row(5, 1*time.Millisecond, 500*time.Microsecond)
+	s.tick()
+	if got := s.Score(5); got != 1.0 {
+		t.Errorf("post-recovery Score(5) = %v, want 1.0", got)
+	}
+}
+
+func TestLatencyOutlierScorer_BelowMinCohortSkips(t *testing.T) {
+	src := &fakeAfeSource{
+		rows: []AfeSnapshotRow{
+			row(1, 1*time.Millisecond, 500*time.Microsecond),
+			row(2, 100*time.Millisecond, 500*time.Microsecond),
+		},
+	}
+	s := newLatencyOutlierScorer(src, LatencyOutlierConfig{MinCohortSize: 3})
+	s.tick()
+	// AFE 2 would look like a huge outlier but cohort has only 2 members.
+	if got := s.Score(2); got != 1.0 {
+		t.Errorf("Score(2) with cohort=2 = %v, want 1.0 (skipped by min-cohort)", got)
+	}
+}
+
+func TestLatencyOutlierScorer_BelowLatencyFloorSkips(t *testing.T) {
+	src := &fakeAfeSource{
+		rows: []AfeSnapshotRow{
+			row(1, 100*time.Microsecond, 100*time.Microsecond),
+			row(2, 100*time.Microsecond, 100*time.Microsecond),
+			row(3, 100*time.Microsecond, 100*time.Microsecond),
+			row(4, 100*time.Microsecond, 100*time.Microsecond),
+			row(5, 900*time.Microsecond, 100*time.Microsecond), // 9× the cohort but below 20ms floor
+		},
+	}
+	s := newLatencyOutlierScorer(src, LatencyOutlierConfig{})
+	s.tick()
+	if got := s.Score(5); got != 1.0 {
+		t.Errorf("Score(5) at sub-floor latency = %v, want 1.0 (below floor)", got)
+	}
+}
+
+func TestLatencyOutlierScorer_TransitionOnlyEmission(t *testing.T) {
+	src := &fakeAfeSource{
+		rows: []AfeSnapshotRow{
+			row(1, 1*time.Millisecond, 500*time.Microsecond),
+			row(2, 1*time.Millisecond, 500*time.Microsecond),
+			row(3, 1*time.Millisecond, 500*time.Microsecond),
+			row(4, 1*time.Millisecond, 500*time.Microsecond),
+			row(5, 100*time.Millisecond, 500*time.Microsecond),
+		},
+	}
+	s := newLatencyOutlierScorer(src, LatencyOutlierConfig{})
+
+	resetDebugTagCountsForTest()
+	s.tick() // AFE 5: 1.0 → 10.0 (penalized fires once)
+	s.tick() // AFE 5: 10.0 → 10.0 (no transition; no tag)
+	s.tick() // AFE 5: 10.0 → 10.0 (still no tag)
+
+	// AFE 5 recovers on tick 4: 10.0 → 1.0 (recovered fires once)
+	src.rows[4] = row(5, 1*time.Millisecond, 500*time.Microsecond)
+	s.tick()
+	// Steady healthy on tick 5: no transition
+	s.tick()
+
+	counts := snapshotDebugTagCounts()
+	if got := counts[tagOutlierAfePenalizedLatency]; got != 1 {
+		t.Errorf("penalized tag fired %d times, want 1 (transition-only)", got)
+	}
+	if got := counts[tagOutlierAfeRecoveredLatency]; got != 1 {
+		t.Errorf("recovered tag fired %d times, want 1 (transition-only)", got)
+	}
+}
+
+func TestLatencyOutlierScorer_AuditRingBounded(t *testing.T) {
+	cfg := LatencyOutlierConfig{AuditRingSize: 3}
+	src := &fakeAfeSource{
+		rows: []AfeSnapshotRow{
+			row(1, 1*time.Millisecond, 500*time.Microsecond),
+			row(2, 1*time.Millisecond, 500*time.Microsecond),
+			row(3, 1*time.Millisecond, 500*time.Microsecond),
+		},
+	}
+	s := newLatencyOutlierScorer(src, cfg)
+	// Force 5 transitions on AFE 3.
+	for i := 0; i < 5; i++ {
+		if i%2 == 0 {
+			src.rows[2] = row(3, 100*time.Millisecond, 500*time.Microsecond)
+		} else {
+			src.rows[2] = row(3, 1*time.Millisecond, 500*time.Microsecond)
+		}
+		s.tick()
+	}
+	got := s.OutlierSnapshot()
+	if len(got) != 3 {
+		t.Errorf("OutlierSnapshot len = %d, want 3 (ring cap)", len(got))
+	}
+	// Oldest evicted: we'd have 5 decisions but only the last 3 survive.
+	for _, d := range got {
+		if d.AfeID != 3 {
+			t.Errorf("decision AfeID = %d, want 3", d.AfeID)
+		}
+	}
+}
+
+func TestLatencyOutlierScorer_PickerIntegration(t *testing.T) {
+	// Populate the scorer's score map by running one tick against a
+	// synthetic snapshot where AFE 1 is a heavy outlier.
+	src := &fakeAfeSource{
+		rows: []AfeSnapshotRow{
+			row(1, 100*time.Millisecond, 500*time.Microsecond),
+			row(2, 1*time.Millisecond, 500*time.Microsecond),
+			row(3, 1*time.Millisecond, 500*time.Microsecond),
+			row(4, 1*time.Millisecond, 500*time.Microsecond),
+			row(5, 1*time.Millisecond, 500*time.Microsecond),
+		},
+	}
+	scorer := newLatencyOutlierScorer(src, LatencyOutlierConfig{})
+	scorer.tick()
+	if got := scorer.Score(1); got != 10.0 {
+		t.Fatalf("Score(1) = %v, want 10.0 after penalty tick", got)
+	}
+
+	// Build picker-facing snapshots and decorate with scores as
+	// SessionPoolImpl.decorateReady would.
+	snaps := []AfeSnapshot{
+		{ID: 1, IdleCount: 1, E2eCost: float64(1 * time.Millisecond)},
+		{ID: 2, IdleCount: 1, E2eCost: float64(1 * time.Millisecond)},
+		{ID: 3, IdleCount: 1, E2eCost: float64(1 * time.Millisecond)},
+		{ID: 4, IdleCount: 1, E2eCost: float64(1 * time.Millisecond)},
+		{ID: 5, IdleCount: 1, E2eCost: float64(1 * time.Millisecond)},
+	}
+	for i := range snaps {
+		snaps[i].OutlierScore = scorer.Score(snaps[i].ID)
+	}
+
+	// Run 5000 K-choice picks with K=2. All AFEs have the same base
+	// E2eCost; only AFE 1 has an inflated score, so K-choice should
+	// almost never pick AFE 1.
+	picker := NewLeastLatencyAfePicker(2, false)
+	counts := map[AfeID]int{}
+	const N = 5000
+	for i := 0; i < N; i++ {
+		// Copy snaps because kChoiceMinCost mutates in place.
+		draw := make([]AfeSnapshot, len(snaps))
+		copy(draw, snaps)
+		id, _, _ := picker.PickAfe(draw)
+		counts[id]++
+	}
+	// Uniform expected = 1000 per AFE. AFE 1 should be picked far less.
+	if counts[1] > N/20 {
+		t.Errorf("AFE 1 (penalized) picked %d/%d times (%.1f%%), want < 5%%",
+			counts[1], N, 100*float64(counts[1])/float64(N))
+	}
+	// Healthy AFEs collectively should absorb roughly all traffic.
+	healthy := counts[2] + counts[3] + counts[4] + counts[5]
+	if healthy < N-N/20 {
+		t.Errorf("healthy AFEs got %d/%d picks, want > 95%%", healthy, N)
+	}
+}

--- a/bigtable/internal/transport/outlier_scorer_test.go
+++ b/bigtable/internal/transport/outlier_scorer_test.go
@@ -77,6 +77,81 @@ func TestSessionPoolImpl_LifecycleScorerStartInvoked(t *testing.T) {
 	}
 }
 
+// TestSessionPoolImpl_DecorateReady_FastPathSkipsLock verifies that
+// decorateReady does not touch p.mu when no custom scorer is plugged
+// in — the hot-path invariant that keeps poolwait latency identical to
+// pre-framework behaviour. Regression sentinel: if a future refactor
+// forgets the hasCustomScorer gate, this test surfaces it because the
+// p.mu lock counter goes above zero.
+func TestSessionPoolImpl_DecorateReady_FastPathSkipsLock(t *testing.T) {
+	pool := NewSessionPoolImpl(
+		42, "test-pool", nil, nil, nil, SessionType(0), false,
+	)
+	// Default state: no custom scorer, hasCustomScorer=false.
+	if pool.hasCustomScorer.Load() {
+		t.Fatal("hasCustomScorer = true on fresh pool, want false")
+	}
+	// Feeding a snapshot must NOT set OutlierScore fields (skipped).
+	ready := []AfeSnapshot{
+		{ID: 1, IdleCount: 1, E2eCost: 1000, OutlierScore: 0},
+		{ID: 2, IdleCount: 1, E2eCost: 1000, OutlierScore: 0},
+	}
+	pool.decorateReady(ready)
+	for i, s := range ready {
+		if s.OutlierScore != 0 {
+			t.Errorf("ready[%d].OutlierScore = %v after fast-path decorate, want 0 (untouched)", i, s.OutlierScore)
+		}
+	}
+
+	// After plugging in a real scorer, decorate must run.
+	pool.SetOutlierScorer(NewLatencyOutlierScorer(pool.AfeSnapshotSource(), LatencyOutlierConfig{}))
+	if !pool.hasCustomScorer.Load() {
+		t.Fatal("hasCustomScorer = false after SetOutlierScorer(latency), want true")
+	}
+	pool.decorateReady(ready)
+	for i, s := range ready {
+		if s.OutlierScore == 0 {
+			t.Errorf("ready[%d].OutlierScore = 0 after custom-scorer decorate, want 1.0 (default score for unknown AFE)", i)
+		}
+	}
+
+	// Explicitly resetting to NoopScorer must flip hasCustomScorer back.
+	pool.SetOutlierScorer(NoopScorer{})
+	if pool.hasCustomScorer.Load() {
+		t.Fatal("hasCustomScorer = true after SetOutlierScorer(Noop), want false")
+	}
+}
+
+// BenchmarkSessionPoolImpl_DecorateReady_Default measures the hot-path
+// cost of decorateReady on a pool without any custom scorer plugged
+// in — should be effectively zero (one atomic.Bool.Load + return).
+// Compare against BenchmarkSessionPoolImpl_DecorateReady_Latency to
+// confirm the fast-path skip does what it claims.
+func BenchmarkSessionPoolImpl_DecorateReady_Default(b *testing.B) {
+	pool := NewSessionPoolImpl(1, "bench", nil, nil, nil, SessionType(0), false)
+	ready := make([]AfeSnapshot, 10)
+	for i := range ready {
+		ready[i] = AfeSnapshot{ID: AfeID(i), IdleCount: 1, E2eCost: 1000}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pool.decorateReady(ready)
+	}
+}
+
+func BenchmarkSessionPoolImpl_DecorateReady_Latency(b *testing.B) {
+	pool := NewSessionPoolImpl(1, "bench", nil, nil, nil, SessionType(0), false)
+	pool.SetOutlierScorer(NewLatencyOutlierScorer(pool.AfeSnapshotSource(), LatencyOutlierConfig{}))
+	ready := make([]AfeSnapshot, 10)
+	for i := range ready {
+		ready[i] = AfeSnapshot{ID: AfeID(i), IdleCount: 1, E2eCost: 1000}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pool.decorateReady(ready)
+	}
+}
+
 // TestSessionPoolImpl_AfeSnapshotSourceReturnsPoolList verifies the
 // AfeSnapshotSource accessor exposes the pool's sessionList — the
 // interface an OutlierScorerFactory receives to build stateful scorers

--- a/bigtable/internal/transport/outlier_scorer_test.go
+++ b/bigtable/internal/transport/outlier_scorer_test.go
@@ -253,6 +253,75 @@ func TestLatencyOutlierScorer_AuditRingBounded(t *testing.T) {
 	}
 }
 
+// TestLeastLatencyAfePicker_OutlierProbeSendsTrafficToPenalized pins
+// the recovery mechanism: even though the outlier is 10x more expensive
+// and would receive ~0 traffic under pure K-choice, probeRate ensures
+// a small fraction of picks still land on it so its PeakEwma updates
+// and the outlier scorer can observe recovery on its next tick.
+func TestLeastLatencyAfePicker_OutlierProbeSendsTrafficToPenalized(t *testing.T) {
+	snaps := []AfeSnapshot{
+		{ID: 1, IdleCount: 1, E2eCost: float64(1 * time.Millisecond), OutlierScore: 10.0}, // penalized
+		{ID: 2, IdleCount: 1, E2eCost: float64(1 * time.Millisecond), OutlierScore: 1.0},
+		{ID: 3, IdleCount: 1, E2eCost: float64(1 * time.Millisecond), OutlierScore: 1.0},
+		{ID: 4, IdleCount: 1, E2eCost: float64(1 * time.Millisecond), OutlierScore: 1.0},
+		{ID: 5, IdleCount: 1, E2eCost: float64(1 * time.Millisecond), OutlierScore: 1.0},
+	}
+	picker := NewLeastLatencyAfePicker(2, false) // probeRate = defaultOutlierProbeRate (0.005)
+	counts := map[AfeID]int{}
+	probeReasonCount := 0
+	const N = 20000
+	for i := 0; i < N; i++ {
+		draw := make([]AfeSnapshot, len(snaps))
+		copy(draw, snaps)
+		id, _, dec := picker.PickAfe(draw)
+		counts[id]++
+		if dec.Reason == "outlier-probe" {
+			probeReasonCount++
+		}
+	}
+	// Expected probe picks: N * probeRate = 20000 * 0.005 = 100 (mean).
+	// Loose bounds: 30..250 (very unlikely to be outside without a bug).
+	if probeReasonCount < 30 || probeReasonCount > 250 {
+		t.Errorf("outlier-probe reason fired %d times, want ~100 (30..250 tolerance)", probeReasonCount)
+	}
+	// Penalized AFE should have received traffic — all of it via probes,
+	// since K-choice never picks a 10x candidate against 1x siblings.
+	if counts[1] == 0 {
+		t.Fatal("penalized AFE 1 got zero picks; probing didn't fire")
+	}
+	// But still nowhere near uniform (which would be N/5 = 4000).
+	if counts[1] > 400 {
+		t.Errorf("penalized AFE 1 got %d picks, want < 400 (probe traffic only)", counts[1])
+	}
+}
+
+// TestLeastLatencyAfePicker_ProbeDisabledStarvesOutlier pins that
+// probeRate=0 makes the outlier truly starve (the pathology we're
+// fixing with probing) — regression check that the probe path is what
+// gets the outlier its picks.
+func TestLeastLatencyAfePicker_ProbeDisabledStarvesOutlier(t *testing.T) {
+	snaps := []AfeSnapshot{
+		{ID: 1, IdleCount: 1, E2eCost: float64(1 * time.Millisecond), OutlierScore: 10.0},
+		{ID: 2, IdleCount: 1, E2eCost: float64(1 * time.Millisecond), OutlierScore: 1.0},
+		{ID: 3, IdleCount: 1, E2eCost: float64(1 * time.Millisecond), OutlierScore: 1.0},
+		{ID: 4, IdleCount: 1, E2eCost: float64(1 * time.Millisecond), OutlierScore: 1.0},
+		{ID: 5, IdleCount: 1, E2eCost: float64(1 * time.Millisecond), OutlierScore: 1.0},
+	}
+	// Construct literal with probeRate: 0 to bypass the default.
+	picker := &LeastLatencyAfePicker{RandomSubsetSize: 2, probeRate: 0}
+	counts := map[AfeID]int{}
+	const N = 5000
+	for i := 0; i < N; i++ {
+		draw := make([]AfeSnapshot, len(snaps))
+		copy(draw, snaps)
+		id, _, _ := picker.PickAfe(draw)
+		counts[id]++
+	}
+	if counts[1] != 0 {
+		t.Errorf("penalized AFE 1 got %d picks with probeRate=0, want 0 (K-choice never picks 10x vs 1x)", counts[1])
+	}
+}
+
 func TestLatencyOutlierScorer_PickerIntegration(t *testing.T) {
 	// Populate the scorer's score map by running one tick against a
 	// synthetic snapshot where AFE 1 is a heavy outlier.

--- a/bigtable/internal/transport/session_list.go
+++ b/bigtable/internal/transport/session_list.go
@@ -91,6 +91,16 @@ type AfeSnapshot struct {
 	NumOutstanding int     // refCount − IdleCount, ≥ 0
 	TransportCost  float64 // PeakEwma nanoseconds; 0 if never updated
 	E2eCost        float64 // PeakEwma nanoseconds; 0 if never updated
+	// OutlierScore is a cost multiplier populated by SessionPoolImpl
+	// from its plugged-in OutlierScorer before handing the snapshot to
+	// the picker. 1.0 = no penalty (default; NoopScorer never returns
+	// anything else). >1.0 = downweight this AFE in the picker's cost
+	// function. Only latency-based pickers (LeastLatencyAfePicker)
+	// currently consume this field; SimpleAfePicker and
+	// LeastInFlightAfePicker ignore it. ReadyAfes leaves this at 0 so
+	// the picker's zero-default check can detect an undecorated snapshot
+	// and fall back to 1.0.
+	OutlierScore float64
 }
 
 // afeHandle is the per-AFE bucket in sessionList: FIFO idle queue,

--- a/bigtable/internal/transport/session_pool.go
+++ b/bigtable/internal/transport/session_pool.go
@@ -181,6 +181,16 @@ type SessionPoolImpl struct {
 	// Pure atomic-counter bumps (msgsSent, retries, etc.) are NOT
 	// gated — a branch check costs more than the atomic.
 	debugEnabled bool
+
+	// scorer is the plugged-in OutlierScorer. Defaults to NoopScorer{}
+	// (returns 1.0 for every AFE — picker cost unchanged). Callers
+	// swap in a real scorer via SetOutlierScorer BEFORE Start; changing
+	// the scorer after Start is not supported (Start may have invoked
+	// LifecycleScorer.Start on the initial scorer, and swapping would
+	// leak that goroutine). Read on the CheckoutSession hot path via
+	// decorateReady; write on the pool-construction path via
+	// SetOutlierScorer.
+	scorer OutlierScorer
 }
 
 // noteVRpcOutcome forwards the outcome to the AFE's PeakEwma trackers
@@ -190,6 +200,39 @@ type SessionPoolImpl struct {
 // of failed opens and keep the breaker from tripping.
 func (p *SessionPoolImpl) noteVRpcOutcome(sh *SessionHandle, e2e, backend time.Duration, ok bool) {
 	p.sl.RecordVRpcOutcome(sh, e2e, backend, ok)
+}
+
+// SetOutlierScorer plugs in an OutlierScorer that latency-based pickers
+// will consult on every CheckoutSession. Passing nil resets to
+// NoopScorer{}. Must be called BEFORE SessionPoolImpl.Start — the pool
+// invokes LifecycleScorer.Start on the plugged-in scorer during its own
+// startup, so swapping mid-run would leak the previous scorer's
+// background goroutine. Intended plug-point for
+// bigtable.ClientConfig.OutlierScorer.
+func (p *SessionPoolImpl) SetOutlierScorer(s OutlierScorer) {
+	if s == nil {
+		s = NoopScorer{}
+	}
+	p.mu.Lock()
+	p.scorer = s
+	p.mu.Unlock()
+}
+
+// decorateReady populates OutlierScore on each snapshot from the
+// currently-installed scorer. Runs on the CheckoutSession hot path once
+// per pick; O(len(ready)) scorer calls. With NoopScorer this loop is a
+// no-op (score field ends up at 1.0), so the branch cost is a single
+// interface call per candidate.
+func (p *SessionPoolImpl) decorateReady(ready []AfeSnapshot) {
+	p.mu.Lock()
+	scorer := p.scorer
+	p.mu.Unlock()
+	if scorer == nil {
+		return
+	}
+	for i := range ready {
+		ready[i].OutlierScore = scorer.Score(ready[i].ID)
+	}
 }
 
 // NewSessionPoolImpl creates a new SessionPoolImpl. id is baked into
@@ -220,6 +263,7 @@ func NewSessionPoolImpl(id uint64, poolName string, streamFactory func(ctx conte
 		poolCancel:         poolCancel,
 		sl:                 newSessionList(),
 		debugEnabled:       debugEnabled,
+		scorer:             NoopScorer{},
 	}
 	pool.m.afePickCounts = make(map[AfeID]int64)
 
@@ -263,8 +307,11 @@ func (p *SessionPoolImpl) CheckoutSession(ctx context.Context) (*SessionHandle, 
 		p.mu.Unlock()
 
 		// Two-tier pick: picker chooses an AFE from the ready snapshot,
-		// then sessionList dequeues one idle session in that AFE.
+		// then sessionList dequeues one idle session in that AFE. The
+		// scorer decorates each snapshot with an OutlierScore before the
+		// picker sees it — latency pickers multiply E2eCost × score.
 		ready := p.sl.ReadyAfes()
+		p.decorateReady(ready)
 		pickerName := picker.Name()
 		afeID, picked, decision := picker.PickAfe(ready)
 		p.recordPickDecision(decision, pickerName)

--- a/bigtable/internal/transport/session_pool.go
+++ b/bigtable/internal/transport/session_pool.go
@@ -235,6 +235,43 @@ func (p *SessionPoolImpl) decorateReady(ready []AfeSnapshot) {
 	}
 }
 
+// OutlierDebugSnapshot returns per-pool outlier-scorer state for the
+// /debug/outlierz page. Always non-empty: even a pool running
+// NoopScorer produces an entry with ScorerName="noop" and empty
+// Params/Scores/Recent so operators can see WHICH pools have outlier
+// detection wired.
+func (p *SessionPoolImpl) OutlierDebugSnapshot() OutlierPoolSnapshot {
+	p.mu.Lock()
+	scorer := p.scorer
+	p.mu.Unlock()
+	snap := OutlierPoolSnapshot{
+		PoolName:   p.poolName,
+		ScorerName: "noop",
+		CapturedAt: time.Now(),
+	}
+	if scorer == nil {
+		return snap
+	}
+	// Preferred path: the scorer knows how to snapshot itself
+	// (LatencyOutlierScorer and any custom impl that satisfies the
+	// interface). This is the only place we assert the optional
+	// debug interface — other paths deliberately stay behind the
+	// minimal OutlierScorer + Name contract.
+	type debugSnapshotter interface {
+		DebugSnapshot() OutlierPoolSnapshot
+	}
+	if d, ok := scorer.(debugSnapshotter); ok {
+		s := d.DebugSnapshot()
+		s.PoolName = p.poolName
+		s.CapturedAt = snap.CapturedAt
+		return s
+	}
+	// Fallback: scorer is minimally-conformant — we can name it but
+	// have no visibility into its internal state.
+	snap.ScorerName = scorer.Name()
+	return snap
+}
+
 // NewSessionPoolImpl creates a new SessionPoolImpl. id is baked into
 // every session log name so channelz/sessionz can reverse-link back to
 // the pool that owns each session.

--- a/bigtable/internal/transport/session_pool.go
+++ b/bigtable/internal/transport/session_pool.go
@@ -187,10 +187,15 @@ type SessionPoolImpl struct {
 	// swap in a real scorer via SetOutlierScorer BEFORE Start; changing
 	// the scorer after Start is not supported (Start may have invoked
 	// LifecycleScorer.Start on the initial scorer, and swapping would
-	// leak that goroutine). Read on the CheckoutSession hot path via
-	// decorateReady; write on the pool-construction path via
-	// SetOutlierScorer.
-	scorer OutlierScorer
+	// leak that goroutine). Held under p.mu.
+	//
+	// hasCustomScorer is the atomic fast-path check consulted by
+	// CheckoutSession's decorateReady: when false (default), decorateReady
+	// short-circuits without acquiring p.mu or iterating ready — zero
+	// hot-path cost when no scorer is plugged in. Only SetOutlierScorer
+	// flips it, so writes are rare (once at pool construction).
+	scorer          OutlierScorer
+	hasCustomScorer atomic.Bool
 }
 
 // noteVRpcOutcome forwards the outcome to the AFE's PeakEwma trackers
@@ -209,13 +214,20 @@ func (p *SessionPoolImpl) noteVRpcOutcome(sh *SessionHandle, e2e, backend time.D
 // startup, so swapping mid-run would leak the previous scorer's
 // background goroutine. Intended plug-point for
 // bigtable.ClientConfig.OutlierScorerFactory.
+//
+// Flips hasCustomScorer so the CheckoutSession hot path can skip
+// decorateReady entirely when no custom scorer is plugged in — the
+// default state pays zero cost per checkout beyond one atomic.Bool
+// load.
 func (p *SessionPoolImpl) SetOutlierScorer(s OutlierScorer) {
 	if s == nil {
 		s = NoopScorer{}
 	}
+	_, isNoop := s.(NoopScorer)
 	p.mu.Lock()
 	p.scorer = s
 	p.mu.Unlock()
+	p.hasCustomScorer.Store(!isNoop)
 }
 
 // AfeSnapshotSource returns the pool's own AFE snapshot source. Passed
@@ -227,11 +239,19 @@ func (p *SessionPoolImpl) AfeSnapshotSource() AfeSnapshotSource {
 }
 
 // decorateReady populates OutlierScore on each snapshot from the
-// currently-installed scorer. Runs on the CheckoutSession hot path once
-// per pick; O(len(ready)) scorer calls. With NoopScorer this loop is a
-// no-op (score field ends up at 1.0), so the branch cost is a single
-// interface call per candidate.
+// currently-installed scorer. Fast-path when no custom scorer is
+// plugged in: a single atomic.Bool.Load and immediate return — no
+// p.mu acquisition, no allocation, no per-candidate loop. That fast
+// path keeps the pool's default behaviour byte-identical to the
+// pre-outlier-framework code, so poolwait latency doesn't regress
+// when the framework is present-but-unused (the common case).
+//
+// Slow path only runs when SetOutlierScorer installed a non-NoopScorer.
+// O(len(ready)) scorer calls under one p.mu take/release.
 func (p *SessionPoolImpl) decorateReady(ready []AfeSnapshot) {
+	if !p.hasCustomScorer.Load() {
+		return
+	}
 	p.mu.Lock()
 	scorer := p.scorer
 	p.mu.Unlock()

--- a/bigtable/internal/transport/session_pool.go
+++ b/bigtable/internal/transport/session_pool.go
@@ -208,7 +208,7 @@ func (p *SessionPoolImpl) noteVRpcOutcome(sh *SessionHandle, e2e, backend time.D
 // invokes LifecycleScorer.Start on the plugged-in scorer during its own
 // startup, so swapping mid-run would leak the previous scorer's
 // background goroutine. Intended plug-point for
-// bigtable.ClientConfig.OutlierScorer.
+// bigtable.ClientConfig.OutlierScorerFactory.
 func (p *SessionPoolImpl) SetOutlierScorer(s OutlierScorer) {
 	if s == nil {
 		s = NoopScorer{}
@@ -216,6 +216,14 @@ func (p *SessionPoolImpl) SetOutlierScorer(s OutlierScorer) {
 	p.mu.Lock()
 	p.scorer = s
 	p.mu.Unlock()
+}
+
+// AfeSnapshotSource returns the pool's own AFE snapshot source. Passed
+// to an OutlierScorerFactory during pool construction so factories can
+// build stateful scorers (e.g. LatencyOutlierScorer) over the pool's
+// live per-AFE state without knowing about *sessionList directly.
+func (p *SessionPoolImpl) AfeSnapshotSource() AfeSnapshotSource {
+	return p.sl
 }
 
 // decorateReady populates OutlierScore on each snapshot from the

--- a/bigtable/internal/transport/session_pool_lifecycle.go
+++ b/bigtable/internal/transport/session_pool_lifecycle.go
@@ -471,6 +471,15 @@ func (p *SessionPoolImpl) Start(ctx context.Context) {
 		p.startAfePruneLoop(ctx)
 		p.startSweepStuckSessionsLoop(ctx)
 		p.startSlowMetricsLoop(ctx)
+		// Bring up the outlier scorer's background loop (if any). Scorers
+		// that don't need background work (NoopScorer, hard-coded score
+		// maps) don't implement LifecycleScorer and are skipped here.
+		p.mu.Lock()
+		scorer := p.scorer
+		p.mu.Unlock()
+		if ls, ok := scorer.(LifecycleScorer); ok {
+			ls.Start(ctx)
+		}
 	})
 }
 

--- a/bigtable/internal/transport/tcp_info_linux.go
+++ b/bigtable/internal/transport/tcp_info_linux.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package internal
+
+import (
+	"errors"
+	"net"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// tcpStateName maps the linux tcp_info state byte to a short human label.
+// Numbers come from include/net/tcp_states.h; TCP_ESTABLISHED=1, etc.
+var tcpStateName = [...]string{
+	1:  "ESTABLISHED",
+	2:  "SYN_SENT",
+	3:  "SYN_RECV",
+	4:  "FIN_WAIT1",
+	5:  "FIN_WAIT2",
+	6:  "TIME_WAIT",
+	7:  "CLOSE",
+	8:  "CLOSE_WAIT",
+	9:  "LAST_ACK",
+	10: "LISTEN",
+	11: "CLOSING",
+	12: "NEW_SYN_RECV",
+}
+
+// caStateName maps tcp_info's ca_state byte to the short CA-state label.
+// Values from include/uapi/linux/tcp.h:
+//
+//	Open     — no loss, normal operation
+//	Disorder — got a dupACK or SACK, kernel is watching for real loss
+//	CWR      — cwnd reduced by ECN CE mark; still cwr'ing
+//	Recovery — fast retransmit in progress
+//	Loss     — RTO fired (worst); cwnd collapsed to 1 MSS
+var caStateName = [...]string{
+	0: "Open",
+	1: "Disorder",
+	2: "CWR",
+	3: "Recovery",
+	4: "Loss",
+}
+
+// readTCPInfo pulls struct tcp_info from the socket via
+// getsockopt(SOL_TCP, TCP_INFO). This is a read-only kernel syscall — it
+// never blocks on the network, never touches the socket's data path, and
+// never takes any userspace lock. Cost is sub-microsecond.
+func readTCPInfo(c *net.TCPConn) (TCPInfoSnapshot, error) {
+	if c == nil {
+		return TCPInfoSnapshot{}, errors.New("nil *net.TCPConn")
+	}
+	raw, err := c.SyscallConn()
+	if err != nil {
+		return TCPInfoSnapshot{}, annotateReadErr("SyscallConn", err)
+	}
+	var info *unix.TCPInfo
+	var soErr error
+	ctrlErr := raw.Control(func(fd uintptr) {
+		info, soErr = unix.GetsockoptTCPInfo(int(fd), unix.IPPROTO_TCP, unix.TCP_INFO)
+	})
+	if ctrlErr != nil {
+		return TCPInfoSnapshot{}, annotateReadErr("raw.Control", ctrlErr)
+	}
+	if soErr != nil {
+		return TCPInfoSnapshot{}, annotateReadErr("getsockopt(TCP_INFO)", soErr)
+	}
+	return tcpInfoToSnapshot(info), nil
+}
+
+// tcpInfoToSnapshot converts the kernel struct into our platform-agnostic
+// snapshot. Kernel unit conventions:
+//   - Rtt / Rttvar / Min_rtt / Rto / Ato : microseconds
+//   - Last_data_recv / Last_data_sent    : milliseconds
+//   - Busy_time / Rwnd_limited / Sndbuf_limited : microseconds
+//   - Total_rto_time                     : milliseconds
+func tcpInfoToSnapshot(info *unix.TCPInfo) TCPInfoSnapshot {
+	state := ""
+	if int(info.State) < len(tcpStateName) {
+		state = tcpStateName[info.State]
+	}
+	caState := ""
+	if int(info.Ca_state) < len(caStateName) {
+		caState = caStateName[info.Ca_state]
+	}
+
+	var retransRatio float64
+	if info.Bytes_sent > 0 {
+		retransRatio = float64(info.Bytes_retrans) / float64(info.Bytes_sent) * 100
+	}
+
+	return TCPInfoSnapshot{
+		State:   state,
+		CAState: caState,
+		Backoff: uint32(info.Backoff),
+
+		RTT:    time.Duration(info.Rtt) * time.Microsecond,
+		RTTVar: time.Duration(info.Rttvar) * time.Microsecond,
+		MinRTT: time.Duration(info.Min_rtt) * time.Microsecond,
+
+		MSS:         info.Snd_mss,
+		PMTU:        info.Pmtu,
+		SndCwnd:     info.Snd_cwnd,
+		SndSsthresh: info.Snd_ssthresh,
+		SndWnd:      info.Snd_wnd,
+		RcvWnd:      info.Rcv_wnd,
+
+		Retransmits:  uint32(info.Retransmits),
+		Retrans:      info.Retrans,
+		TotalRetrans: info.Total_retrans,
+		Lost:         info.Lost,
+		Sacked:       info.Sacked,
+		Unacked:      info.Unacked,
+		Reordering:   info.Reordering,
+		ReordSeen:    info.Reord_seen,
+		DsackDups:    info.Dsack_dups,
+		DeliveredCE:  info.Delivered_ce,
+		RcvOooPack:   info.Rcv_ooopack,
+
+		RTO:                time.Duration(info.Rto) * time.Microsecond,
+		ATO:                time.Duration(info.Ato) * time.Microsecond,
+		Probes:             uint32(info.Probes),
+		TotalRTO:           uint32(info.Total_rto),
+		TotalRTORecoveries: uint32(info.Total_rto_recoveries),
+		TotalRTOTime:       time.Duration(info.Total_rto_time) * time.Millisecond,
+
+		SegsOut:       info.Segs_out,
+		SegsIn:        info.Segs_in,
+		DataSegsOut:   info.Data_segs_out,
+		DataSegsIn:    info.Data_segs_in,
+		BytesSent:     info.Bytes_sent,
+		BytesAcked:    info.Bytes_acked,
+		BytesRetrans:  info.Bytes_retrans,
+		BytesReceived: info.Bytes_received,
+		Delivered:     info.Delivered,
+		DeliveryRate:  info.Delivery_rate,
+		PacingRate:    info.Pacing_rate,
+		NotsentBytes:  info.Notsent_bytes,
+		BusyTime:      time.Duration(info.Busy_time) * time.Microsecond,
+		RwndLimited:   time.Duration(info.Rwnd_limited) * time.Microsecond,
+		SndbufLimited: time.Duration(info.Sndbuf_limited) * time.Microsecond,
+		Rehash:        info.Rehash,
+
+		LastDataRecv: time.Duration(info.Last_data_recv) * time.Millisecond,
+		LastDataSent: time.Duration(info.Last_data_sent) * time.Millisecond,
+
+		RetransRatioPct: retransRatio,
+	}
+}
+
+// isDeadConn recognizes the errno returned when the fd has been closed
+// out from under us — gRPC dropped its ref, the kernel released the fd,
+// and our getsockopt lost the race. Callers (Snapshot) treat these as
+// "prune this entry" rather than "surface error."
+func isDeadConn(err error) bool {
+	return errors.Is(err, unix.EBADF) || errors.Is(err, unix.ENOTCONN) ||
+		errors.Is(err, net.ErrClosed)
+}

--- a/bigtable/internal/transport/tcp_info_other.go
+++ b/bigtable/internal/transport/tcp_info_other.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux
+
+package internal
+
+import "net"
+
+// readTCPInfo returns ErrTCPInfoUnsupported on non-Linux — tcp_info is a
+// Linux-specific socket option. Snapshot() will surface this via the Err
+// field so the tcpz page renders a "unsupported" row rather than
+// panicking or looking empty.
+func readTCPInfo(_ *net.TCPConn) (TCPInfoSnapshot, error) {
+	return TCPInfoSnapshot{}, ErrTCPInfoUnsupported
+}
+
+// isDeadConn is only meaningful on Linux (where errno differentiation
+// exists); on other platforms every read error is "unsupported," which
+// isn't dead-fd, so return false.
+func isDeadConn(_ error) bool { return false }

--- a/bigtable/open_test.go
+++ b/bigtable/open_test.go
@@ -471,6 +471,7 @@ func (f *fakeSessionClient) MeterProvider() metric.MeterProvider           { ret
 func (f *fakeSessionClient) SessionDebug() btransport.SessionDebugProvider { return nil }
 func (f *fakeSessionClient) ChannelDebug() btransport.ChannelDebugProvider { return nil }
 func (f *fakeSessionClient) ConfigDebug() btransport.ConfigDebugProvider   { return nil }
+func (f *fakeSessionClient) OutlierDebug() btransport.OutlierDebugProvider { return nil }
 func (f *fakeSessionClient) AddSessionLoadListener(_ func(load float64)) func() {
 	f.loadListenerSet = true
 	return func() {}

--- a/bigtable/outlier_scorer_config_test.go
+++ b/bigtable/outlier_scorer_config_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigtable
+
+import "testing"
+
+// TestOutlierScorer_PublicAPI is a compile-time check: the public
+// ClientConfig field, factory helper, and type aliases must all resolve
+// to the transport-package types and be usable together in the shape
+// the docstring example promises. If any of the type aliases or the
+// LatencyOutlierFactory signature drift, this test stops compiling.
+func TestOutlierScorer_PublicAPI(t *testing.T) {
+	// Default config is usable directly.
+	def := DefaultLatencyOutlierConfig()
+	if def.LatencyMultiplier == 0 {
+		t.Errorf("DefaultLatencyOutlierConfig().LatencyMultiplier = 0, want non-zero")
+	}
+	if def.PenaltyMultiplier == 0 {
+		t.Errorf("DefaultLatencyOutlierConfig().PenaltyMultiplier = 0, want non-zero")
+	}
+
+	// LatencyOutlierFactory returns a factory that satisfies the
+	// public OutlierScorerFactory type — assign into ClientConfig
+	// exactly as the docstring example shows.
+	cfg := ClientConfig{
+		EnableDebug:          true,
+		OutlierScorerFactory: LatencyOutlierFactory(def),
+	}
+	if cfg.OutlierScorerFactory == nil {
+		t.Fatal("LatencyOutlierFactory returned nil factory")
+	}
+
+	// Invoking the factory with a NoopScorer-shaped source is fine —
+	// the returned scorer must be a *LatencyOutlierScorer implementing
+	// OutlierScorer.
+	scorer := cfg.OutlierScorerFactory(fakeSource{})
+	if scorer == nil {
+		t.Fatal("factory returned nil scorer")
+	}
+	if got := scorer.Name(); got != "latency-outlier" {
+		t.Errorf("scorer.Name() = %q, want %q", got, "latency-outlier")
+	}
+	// Unknown AFE (empty source) → 1.0 (default).
+	if got := scorer.Score(42); got != 1.0 {
+		t.Errorf("scorer.Score(42) on empty source = %v, want 1.0", got)
+	}
+}
+
+// fakeSource satisfies AfeSnapshotSource with zero rows — a placeholder
+// for the compile-check test that only needs the factory to invoke.
+type fakeSource struct{}
+
+func (fakeSource) Snapshot() []AfeSnapshotRow { return nil }

--- a/bigtable/session_debug.go
+++ b/bigtable/session_debug.go
@@ -1,0 +1,164 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigtable
+
+import (
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+)
+
+// The provider interface + struct types live in internal/transport so
+// internal/session.Client can implement them without an import cycle.
+// Re-exported here as type aliases — external names + identity unchanged.
+
+// SessionDebugProvider exposes a snapshot of every session pool the
+// Client currently owns.
+type SessionDebugProvider = btransport.SessionDebugProvider
+
+// ChannelDebugProvider exposes a snapshot of every gRPC channel pool
+// the Client currently owns.
+type ChannelDebugProvider = btransport.ChannelDebugProvider
+
+// ChannelPoolDebug names a single channel pool and carries its snapshot.
+type ChannelPoolDebug = btransport.ChannelPoolDebug
+
+// SessionRef identifies one session for the channelz → sessionz reverse
+// link.
+type SessionRef = btransport.SessionRef
+
+// ConfigDebugProvider exposes a snapshot of the most recent
+// GetClientConfiguration poll outcome.
+type ConfigDebugProvider = btransport.ConfigDebugProvider
+
+// SessionDebug returns a SessionDebugProvider for this Client. Returns
+// nil when the session backend isn't wired (hand-built or emulator-only
+// Clients where sessionImpl is nil) or when session-side debug
+// recorders are disabled.
+//
+// The concrete provider layers the mixed-mode Diverter on top of the
+// session client's own session-only provider. sessionImpl.SessionDebug
+// intentionally returns an empty DiverterSnapshot (per its doc, "only
+// bigtable.Client knows about the classic/session split"); the adapter
+// below overrides Diverter() with the Client's actual Diverter.Snapshot.
+func (c *Client) SessionDebug() SessionDebugProvider {
+	if c.sessionImpl == nil {
+		return nil
+	}
+	base := c.sessionImpl.SessionDebug()
+	if base == nil {
+		return nil
+	}
+	return mixedModeSessionDebug{base: base, diverter: c.diverter}
+}
+
+// mixedModeSessionDebug wraps a session-only provider with the Client's
+// classic/session Diverter. Snapshot + LoadBalancingSnapshots pass
+// through unchanged; only Diverter() overrides.
+type mixedModeSessionDebug struct {
+	base     SessionDebugProvider
+	diverter *btransport.Diverter
+}
+
+func (m mixedModeSessionDebug) Snapshot() []btransport.PoolSnapshot {
+	return m.base.Snapshot()
+}
+
+func (m mixedModeSessionDebug) LoadBalancingSnapshots() []btransport.LoadBalancingSnapshot {
+	return m.base.LoadBalancingSnapshots()
+}
+
+func (m mixedModeSessionDebug) Diverter() btransport.DiverterSnapshot {
+	if m.diverter == nil {
+		return btransport.DiverterSnapshot{}
+	}
+	return m.diverter.Snapshot()
+}
+
+// ChannelDebug returns a ChannelDebugProvider for this Client. Emits
+// exactly one entry for the classic channel pool (Role="classic") and
+// prepends the session channel pool entries when the session backend
+// is wired.
+func (c *Client) ChannelDebug() ChannelDebugProvider {
+	return mixedModeChannelDebug{client: c}
+}
+
+// mixedModeChannelDebug composes the Client's classic channel pool
+// with the session pool contributed by sessionImpl. Emits the classic
+// entry first (Role="classic"), then the session entry (Role="session")
+// when session pooling is enabled and its pool is a
+// *btransport.BigtableChannelPool (skipped otherwise — test fakes may
+// substitute a non-BigtableChannelPool).
+type mixedModeChannelDebug struct {
+	client *Client
+}
+
+func (a mixedModeChannelDebug) Snapshot() []ChannelPoolDebug {
+	out := make([]ChannelPoolDebug, 0, 2)
+	instance := a.client.fullInstanceName()
+	if p := bigtableChannelPool(a.client.mPool.Pool); p != nil {
+		out = append(out, ChannelPoolDebug{
+			Role:         "classic",
+			Snapshot:     p.ChannelPoolSnapshot(),
+			InstanceName: instance,
+			AppProfile:   a.client.appProfile,
+		})
+	}
+	if a.client.sessionImpl != nil {
+		if sp := a.client.sessionImpl.ChannelDebug(); sp != nil {
+			// Session-side entries come pre-labeled with Role="session";
+			// stamp instance / app-profile onto each since the session
+			// package can't reach back to the outer bigtable.Client.
+			for _, e := range sp.Snapshot() {
+				if e.InstanceName == "" {
+					e.InstanceName = instance
+				}
+				if e.AppProfile == "" {
+					e.AppProfile = a.client.appProfile
+				}
+				out = append(out, e)
+			}
+		}
+	}
+	return out
+}
+
+// bigtableChannelPool extracts *btransport.BigtableChannelPool from a
+// gtransport.ConnPool, returning nil if the pool isn't a
+// BigtableChannelPool (e.g. an emulator-only client that uses the
+// simple gtransport.DialPool).
+func bigtableChannelPool(p interface{}) *btransport.BigtableChannelPool {
+	if p == nil {
+		return nil
+	}
+	bp, _ := p.(*btransport.BigtableChannelPool)
+	return bp
+}
+
+// ConfigDebug returns a ConfigDebugProvider for this Client. Returns
+// nil when the session backend isn't wired (no configuration manager
+// is constructed in that mode).
+func (c *Client) ConfigDebug() ConfigDebugProvider {
+	if c.sessionImpl == nil {
+		return nil
+	}
+	return c.sessionImpl.ConfigDebug()
+}
+
+// TCPStats returns the per-connection TCP_INFO collector when
+// ClientConfig.EnableDebug was set at construction, else nil. The
+// returned pointer is safe to hand to bigtable/debugview.Handler for
+// the tcpz page.
+func (c *Client) TCPStats() *TCPStats {
+	return c.tcpStats
+}

--- a/bigtable/session_debug.go
+++ b/bigtable/session_debug.go
@@ -41,6 +41,24 @@ type SessionRef = btransport.SessionRef
 // GetClientConfiguration poll outcome.
 type ConfigDebugProvider = btransport.ConfigDebugProvider
 
+// OutlierDebugProvider exposes per-pool outlier-scorer state (scorer
+// name, config, current per-AFE scores, recent transitions). Consumed
+// by the debugview package to render /debug/outlierz.
+type OutlierDebugProvider = btransport.OutlierDebugProvider
+
+// OutlierPoolSnapshot carries one pool's outlier-scorer state. See
+// btransport.OutlierPoolSnapshot for field details.
+type OutlierPoolSnapshot = btransport.OutlierPoolSnapshot
+
+// OutlierParam is one config knob rendered on the outlierz page.
+type OutlierParam = btransport.OutlierParam
+
+// OutlierScoreRow is one AFE's current score.
+type OutlierScoreRow = btransport.OutlierScoreRow
+
+// OutlierDecision is one entry in a scorer's audit ring.
+type OutlierDecision = btransport.OutlierDecision
+
 // SessionDebug returns a SessionDebugProvider for this Client. Returns
 // nil when the session backend isn't wired (hand-built or emulator-only
 // Clients where sessionImpl is nil) or when session-side debug
@@ -153,6 +171,17 @@ func (c *Client) ConfigDebug() ConfigDebugProvider {
 		return nil
 	}
 	return c.sessionImpl.ConfigDebug()
+}
+
+// OutlierDebug returns an OutlierDebugProvider for this Client. Returns
+// nil when the session backend isn't wired (hand-built or emulator-only
+// Client) or when session-side debug recorders are disabled
+// (EnableDebug=false).
+func (c *Client) OutlierDebug() OutlierDebugProvider {
+	if c.sessionImpl == nil {
+		return nil
+	}
+	return c.sessionImpl.OutlierDebug()
 }
 
 // TCPStats returns the per-connection TCP_INFO collector when

--- a/bigtable/session_debug.go
+++ b/bigtable/session_debug.go
@@ -59,6 +59,67 @@ type OutlierScoreRow = btransport.OutlierScoreRow
 // OutlierDecision is one entry in a scorer's audit ring.
 type OutlierDecision = btransport.OutlierDecision
 
+// OutlierScorer is the plug-point interface for outlier detection —
+// latency-based pickers consult Score(id) on every CheckoutSession.
+// See btransport.OutlierScorer for the full contract.
+type OutlierScorer = btransport.OutlierScorer
+
+// OutlierScorerFactory is the constructor callback ClientConfig invokes
+// once per session pool to build the OutlierScorer for that pool. The
+// factory receives the pool's AFE snapshot source; the returned scorer
+// is installed and (if it implements LifecycleScorer) started with
+// the pool's ctx.
+type OutlierScorerFactory = btransport.OutlierScorerFactory
+
+// AfeSnapshotSource is the minimal read-only view of a pool's AFE
+// state that OutlierScorerFactory receives when a pool is being
+// constructed. Stateful scorers (LatencyOutlierScorer) read from this
+// on their tick loop.
+type AfeSnapshotSource = btransport.AfeSnapshotSource
+
+// AfeSnapshotRow is one row of per-AFE state returned by
+// AfeSnapshotSource.Snapshot(). Same shape as the transport-internal
+// type; aliased so callers implementing custom scorers don't need to
+// import the internal package.
+type AfeSnapshotRow = btransport.AfeSnapshotRow
+
+// LatencyOutlierConfig tunes the built-in LatencyOutlierScorer.
+type LatencyOutlierConfig = btransport.LatencyOutlierConfig
+
+// NoopScorer is the zero-cost default — Score always returns 1.0.
+// Every pool runs this when ClientConfig.OutlierScorerFactory is nil.
+type NoopScorer = btransport.NoopScorer
+
+// LatencyOutlierScorer is the built-in stateful outlier scorer that
+// periodically compares each AFE's PeakEwma latency against the cohort
+// median. See btransport.LatencyOutlierScorer for the full contract.
+type LatencyOutlierScorer = btransport.LatencyOutlierScorer
+
+// DefaultLatencyOutlierConfig returns the calibrated defaults for the
+// built-in latency outlier scorer (30s tick, 3x cohort multiplier,
+// 20ms floor, min-cohort 3, 10x penalty, 500-entry audit ring).
+func DefaultLatencyOutlierConfig() LatencyOutlierConfig {
+	return btransport.DefaultLatencyOutlierConfig()
+}
+
+// LatencyOutlierFactory returns an OutlierScorerFactory that constructs
+// the built-in LatencyOutlierScorer with cfg. Pass into
+// ClientConfig.OutlierScorerFactory for the standard latency-outlier
+// downweight behaviour. Zero-valued fields in cfg pick up defaults from
+// DefaultLatencyOutlierConfig.
+//
+// Example:
+//
+//	cfg := bigtable.ClientConfig{
+//	    EnableDebug:          true,
+//	    OutlierScorerFactory: bigtable.LatencyOutlierFactory(bigtable.DefaultLatencyOutlierConfig()),
+//	}
+func LatencyOutlierFactory(cfg LatencyOutlierConfig) OutlierScorerFactory {
+	return func(src AfeSnapshotSource) OutlierScorer {
+		return btransport.NewLatencyOutlierScorer(src, cfg)
+	}
+}
+
 // SessionDebug returns a SessionDebugProvider for this Client. Returns
 // nil when the session backend isn't wired (hand-built or emulator-only
 // Clients where sessionImpl is nil) or when session-side debug

--- a/bigtable/tcp_stats.go
+++ b/bigtable/tcp_stats.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigtable
+
+import (
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+)
+
+// TCPStats is the opt-in collector for per-connection TCP statistics
+// (RTT, retransmits, cwnd, etc.) from every gRPC dial a bigtable client
+// makes. Create one, pass its ClientOption() into NewClient / NewAdminClient,
+// then hand the same TCPStats to tcpz.Handler to expose a live debug page.
+//
+// The collector never wraps the returned net.Conn — it just records a
+// reference for later TCP_INFO reads. The RPC hot path traverses zero
+// TCPStats code. Cost is limited to one map insert per gRPC dial and one
+// getsockopt(TCP_INFO) per conn per debug-page render.
+//
+// Not compatible with DirectPath. When the client runs over DirectPath
+// (xDS-managed connections) the standard dialer is bypassed, so nothing
+// is registered and Snapshot returns empty.
+//
+// Linux only. On other platforms Snapshot returns entries with Err
+// populated ("tcp_info not supported on this platform"); dialing and
+// registration still work but the numeric fields stay zero.
+type TCPStats struct {
+	reg *btransport.ConnRegistry
+}
+
+// NewTCPStats constructs an empty collector. Call ClientOption() to wire
+// it into a Client, and pass the same *TCPStats to tcpz.Handler.
+func NewTCPStats() *TCPStats {
+	return &TCPStats{reg: btransport.NewConnRegistry()}
+}
+
+// ClientOption returns an option.ClientOption that installs the TCP-stats
+// dialer. Safe to pass to NewClient, NewClientWithConfig, NewAdminClient,
+// etc. — the underlying grpc.WithContextDialer is additive to whatever
+// gRPC options bigtable already applies.
+func (t *TCPStats) ClientOption() option.ClientOption {
+	return option.WithGRPCDialOption(grpc.WithContextDialer(t.reg.Dial))
+}
+
+// Snapshot returns the current per-connection TCP_INFO for every conn the
+// dialer captured, oldest first. Stale entries (fd closed by gRPC) are
+// pruned during Snapshot so this list stays honest.
+func (t *TCPStats) Snapshot() []btransport.TCPInfoSnapshot {
+	return t.reg.Snapshot()
+}
+
+// Len returns the number of currently-registered conns (including any
+// closed-but-not-yet-pruned ones). Useful for a "conns=N" summary.
+func (t *TCPStats) Len() int { return t.reg.Len() }
+
+// DeadConns returns the recently-departed conns the registry still
+// remembers, oldest death first. Used by tcpz to plot conn-lifetime
+// distributions that include already-closed conns. Bounded — very old
+// deaths eventually fall off the ring.
+func (t *TCPStats) DeadConns() []btransport.DeadConnInfo { return t.reg.DeadConns() }


### PR DESCRIPTION
## Summary

Ports the 7-page bigtable debug UI + per-connection TCP_INFO collector from a downstream feature branch onto \`upstream/main\`. Wire the entire tree with a one-liner:

\`\`\`go
client, _ := bigtable.NewClientWithConfig(ctx, "p", "i",
    bigtable.ClientConfig{EnableDebug: true})
http.Handle("/debug/", http.StripPrefix("/debug",
    debugview.Handler(client)))
\`\`\`

This is the debugview-only slice of #20275 — the SessionAwareChannelPool stack (\`session_aware_scale_monitor.go\`, \`ClientConfigurationManager.AddChannelPoolConfigListener\`, \`BigtableChannelPool.TotalStreamCount\`) is intentionally excluded and will land as a follow-up.

## Public API additions

- **\`ClientConfig.EnableDebug bool\`** — opts a Client into the TCPStats collector. Zero cost when false: no dial hook, no allocation. When true, \`NewClientWithConfig\` constructs TCPStats and appends its dial option so every gRPC dial (classic + session pools) registers with the collector.
- **\`Client.SessionDebug\` / \`ChannelDebug\` / \`ConfigDebug\` / \`TCPStats\`** accessors — hand these directly to \`debugview.Handler\`.
- Type aliases in \`bigtable/session_debug.go\` re-export the debug provider interfaces + snapshot types from \`internal/transport\` so \`debugview\` depends only on the public \`bigtable\` package.

## New packages / files

| Path | What |
|---|---|
| \`bigtable/debugview/\` | 8 z-page HTTP handlers (\`sessionz\`, \`afez\`, \`loadz\`, \`channelz\`, \`configz\`, \`tcpz\`, \`debugtagsz\`) behind a single \`Handler(client)\` entry. Every view supports \`?format=json\`. Nil-safe: panels render a "not enabled" banner when the corresponding accessor returns nil. |
| \`bigtable/internal/transport/conn_registry.go\` + \`tcp_info_{linux,other}.go\` | The collector's backing store and OS-specific \`TCP_INFO\` scrape via \`getsockopt\`. |
| \`bigtable/tcp_stats.go\` | Public \`TCPStats\` type + \`NewTCPStats()\` constructor + \`ClientOption()\` returning \`option.WithGRPCDialOption(grpc.WithContextDialer(...))\`. |
| \`bigtable/session_debug.go\` | Public accessors + type aliases so \`debugview\` never has to import \`internal/transport\`. |

## Wiring

- \`bigtable/client.go\` — new \`tcpStats\` field on \`Client\`; \`NewClientWithConfig\` constructs it when \`config.EnableDebug\` is true, appends the ClientOption to the dial option list, threads \`config.EnableDebug\` into \`session.NewClient\`.
- \`bigtable/internal/session/client.go\` — \`NewClient\` signature grows an \`enableDebug bool\` that populates \`Config.EnableDebug\` on the session-side pool.
- \`bigtable/internal/transport/debug_api.go\` — \`ChannelPoolDebug\` grows \`InstanceName\` + \`AppProfile\` so channelz can render the top-line identifier without a reverse lookup.

## What is NOT in this PR

- \`SessionAwareScaleMonitor\` (session-count-driven channel pool sizing) — sits on its own branch and will open as a follow-up.
- \`AddChannelPoolConfigListener\` on \`ClientConfigurationManager\` — SACM's registration hook; ships with SACM.
- \`BigtableChannelPool.TotalStreamCount\` — SACM's input signal; ships with SACM.

## Test plan

- [x] \`go build ./...\` under \`bigtable/\` clean
- [x] \`go vet ./...\` under \`bigtable/\` clean
- [x] \`go test -short -count=1 -timeout=90s ./debugview/ ./internal/transport/ ./internal/session/\` all pass