### PR TITLE
feat(storage): add retry backoff spans and OTel attributes

### DIFF
--- a/storage/client.go
+++ b/storage/client.go
@@ -289,6 +289,8 @@ type openWriterParams struct {
 	// progress callback for reporting upload progress - see `Writer.progress`.
 	// Required.
 	progress func(int64)
+	// onChunkRequest callback for reporting start of chunk upload request.
+	onChunkRequest func()
 	// setObj callback for reporting the resulting object - see `Writer.obj`.
 	// Required.
 	setObj func(*ObjectAttrs)

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -4115,3 +4115,55 @@ func TestOTelReaderAndWriterAttributesEmulated(t *testing.T) {
 		}
 	})
 }
+
+func TestOTelRetryBackoffTracingEmulated(t *testing.T) {
+	transportClientTest(context.Background(), t, func(t *testing.T, ctx context.Context, project, bucket string, client storageClient) {
+		te := testutil.NewOpenTelemetryTestExporter()
+		t.Cleanup(func() {
+			te.Unregister(ctx)
+		})
+		t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+		// Create bucket using emulator client.
+		_, err := client.CreateBucket(ctx, project, bucket, &BucketAttrs{
+			Name: bucket,
+		}, nil)
+		if err != nil {
+			t.Fatalf("client.CreateBucket: %v", err)
+		}
+
+		// Setup retry test for Bucket.Attrs (storage.buckets.get).
+		instructions := map[string][]string{
+			"storage.buckets.get": {"return-503", "return-503"},
+		}
+		testID := createRetryTest(t, client, instructions)
+		ctxRetry := callctx.SetHeaders(ctx, "x-retry-test-id", testID)
+
+		vc := &Client{tc: client}
+		if _, err := vc.Bucket(bucket).Attrs(ctxRetry); err != nil {
+			t.Fatalf("vc.Bucket.Attrs: %v", err)
+		}
+
+		// Verify exported spans.
+		spans := te.Spans()
+		var parentSpan tracetest.SpanStub
+		var retryBackoffCount int
+		for _, s := range spans {
+			if strings.HasSuffix(s.Name, "RetryBackoff") {
+				retryBackoffCount++
+			} else if strings.HasSuffix(s.Name, "Bucket.Attrs") {
+				parentSpan = s
+			}
+		}
+
+		if parentSpan.Name == "" {
+			t.Fatalf("Bucket.Attrs parent span not found in %d spans", len(spans))
+		}
+		if retryBackoffCount != 2 {
+			t.Errorf("expected 2 RetryBackoff child spans, got %d", retryBackoffCount)
+		}
+		if len(parentSpan.Events) != 2 {
+			t.Errorf("expected 2 storage.retry.backoff trace events on parent span, got %d", len(parentSpan.Events))
+		}
+	})
+}

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -34,12 +34,14 @@ import (
 	"time"
 
 	"cloud.google.com/go/iam/apiv1/iampb"
+	"cloud.google.com/go/internal/testutil"
 	"cloud.google.com/go/storage/experimental"
 	"cloud.google.com/go/storage/internal/apiv2/storagepb"
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/gax-go/v2"
 	"github.com/googleapis/gax-go/v2/apierror"
 	"github.com/googleapis/gax-go/v2/callctx"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
@@ -4003,4 +4005,200 @@ func setBidiReads(t *testing.T, client storageClient) {
 			c.config.grpcBidiReads = false
 		})
 	}
+}
+
+func TestOTelReaderAndWriterAttributesEmulated(t *testing.T) {
+	transportClientTest(context.Background(), t, func(t *testing.T, ctx context.Context, project, bucket string, client storageClient) {
+		te := testutil.NewOpenTelemetryTestExporter()
+		t.Cleanup(func() {
+			te.Unregister(ctx)
+		})
+		t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+		// Create bucket using emulator client
+		_, err := client.CreateBucket(ctx, project, bucket, &BucketAttrs{
+			Name: bucket,
+		}, nil)
+		if err != nil {
+			t.Fatalf("client.CreateBucket: %v", err)
+		}
+
+		objName := fmt.Sprintf("test-trace-attrs-obj-%d.txt", time.Now().Nanosecond())
+		obj := veneerClient.Bucket(bucket).Object(objName)
+
+		// 1. Write an object
+		w := obj.NewWriter(ctx)
+		w.ChunkSize = 256 * 1024
+		if _, err := w.Write([]byte("Hello emulated tracing!")); err != nil {
+			t.Fatalf("w.Write: %v", err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatalf("w.Close: %v", err)
+		}
+
+		// 2. Read the object with a range
+		r, err := obj.NewRangeReader(ctx, 0, 5)
+		if err != nil {
+			t.Fatalf("NewRangeReader: %v", err)
+		}
+		if _, err := io.ReadAll(r); err != nil && err != io.EOF {
+			t.Fatalf("io.ReadAll: %v", err)
+		}
+		r.Close()
+
+		// 3. Verify writer and reader spans
+		spans := te.Spans()
+		var writerSpan, readerSpan tracetest.SpanStub
+		for _, s := range spans {
+			if s.Name == "cloud.google.com/go/storage.Object.Writer" {
+				writerSpan = s
+			} else if s.Name == "cloud.google.com/go/storage.Object.Reader" {
+				readerSpan = s
+			}
+		}
+		if writerSpan.Name == "" {
+			t.Fatalf("Object.Writer span not found in %d spans", len(spans))
+		}
+		if readerSpan.Name == "" {
+			t.Fatalf("Object.Reader span not found in %d spans", len(spans))
+		}
+
+		// Verify Writer mode attribute
+		foundWriteMode := false
+		for _, a := range writerSpan.Attributes {
+			if string(a.Key) == "storage.write.mode" {
+				foundWriteMode = true
+				if got, want := a.Value.AsString(), "resumable"; got != want {
+					t.Errorf("writer storage.write.mode = %q, want %q", got, want)
+				}
+			}
+		}
+		if !foundWriteMode {
+			t.Errorf("storage.write.mode attribute not found on Object.Writer span")
+		}
+
+		// Verify Reader mode attribute
+		foundReadMode := false
+		for _, a := range readerSpan.Attributes {
+			if string(a.Key) == "storage.read.mode" {
+				foundReadMode = true
+				if got, want := a.Value.AsString(), "range"; got != want {
+					t.Errorf("reader storage.read.mode = %q, want %q", got, want)
+				}
+			}
+		}
+		if !foundReadMode {
+			t.Errorf("storage.read.mode attribute not found on Object.Reader span")
+		}
+	})
+}
+
+func TestOTelRetryBackoffTracingEmulated(t *testing.T) {
+	transportClientTest(context.Background(), t, func(t *testing.T, ctx context.Context, project, bucket string, client storageClient) {
+		te := testutil.NewOpenTelemetryTestExporter()
+		t.Cleanup(func() {
+			te.Unregister(ctx)
+		})
+		t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+		// Create bucket using emulator client
+		_, err := client.CreateBucket(ctx, project, bucket, &BucketAttrs{
+			Name: bucket,
+		}, nil)
+		if err != nil {
+			t.Fatalf("client.CreateBucket: %v", err)
+		}
+
+		// Setup retry test for Bucket.Attrs (storage.buckets.get)
+		instructions := map[string][]string{
+			"storage.buckets.get": {"return-503", "return-503"},
+		}
+		testID := createRetryTest(t, client, instructions)
+		ctxRetry := callctx.SetHeaders(ctx, "x-retry-test-id", testID)
+
+		vc := &Client{tc: client}
+		if _, err := vc.Bucket(bucket).Attrs(ctxRetry); err != nil {
+			t.Fatalf("vc.Bucket.Attrs: %v", err)
+		}
+
+		// Verify exported spans
+		spans := te.Spans()
+		var parentSpan tracetest.SpanStub
+		var retryBackoffCount int
+		for _, s := range spans {
+			if strings.HasSuffix(s.Name, "RetryBackoff") {
+				retryBackoffCount++
+			} else if strings.HasSuffix(s.Name, "Bucket.Attrs") {
+				parentSpan = s
+			}
+		}
+
+		if parentSpan.Name == "" {
+			t.Fatalf("Bucket.Attrs parent span not found in %d spans", len(spans))
+		}
+		if retryBackoffCount != 2 {
+			t.Errorf("expected 2 RetryBackoff child spans, got %d", retryBackoffCount)
+		}
+		if len(parentSpan.Events) != 2 {
+			t.Errorf("expected 2 storage.retry.backoff trace events on parent span, got %d", len(parentSpan.Events))
+		}
+	})
+}
+
+func TestOTelListObjectsGroupingEmulated(t *testing.T) {
+	transportClientTest(context.Background(), t, func(t *testing.T, ctx context.Context, project, bucket string, client storageClient) {
+		te := testutil.NewOpenTelemetryTestExporter()
+		t.Cleanup(func() {
+			te.Unregister(ctx)
+		})
+		t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+		// Create bucket using emulator client
+		_, err := client.CreateBucket(ctx, project, bucket, &BucketAttrs{
+			Name: bucket,
+		}, nil)
+		if err != nil {
+			t.Fatalf("client.CreateBucket: %v", err)
+		}
+
+		// Setup retry test for ListObjects (storage.objects.list)
+		instructions := map[string][]string{
+			"storage.objects.list": {"return-503", "return-503"},
+		}
+		testID := createRetryTest(t, client, instructions)
+		ctxRetry := callctx.SetHeaders(ctx, "x-retry-test-id", testID)
+
+		vc := &Client{tc: client}
+		it := vc.Bucket(bucket).Objects(ctxRetry, nil)
+		if _, err := it.Next(); err != iterator.Done && err != nil {
+			t.Fatalf("ListObjects Next: %v", err)
+		}
+
+		// Verify that RetryBackoff spans are children of ObjectsListCall
+		spans := te.Spans()
+		var listCallSpan tracetest.SpanStub
+		var retryBackoffSpans []tracetest.SpanStub
+		for _, s := range spans {
+			if strings.HasSuffix(s.Name, "ObjectsListCall") {
+				listCallSpan = s
+			} else if strings.HasSuffix(s.Name, "RetryBackoff") {
+				retryBackoffSpans = append(retryBackoffSpans, s)
+			}
+		}
+
+		if listCallSpan.Name == "" {
+			t.Fatalf("ObjectsListCall span not found in %d spans", len(spans))
+		}
+		if len(retryBackoffSpans) != 2 {
+			t.Fatalf("expected 2 RetryBackoff child spans, got %d", len(retryBackoffSpans))
+		}
+		for i, s := range retryBackoffSpans {
+			if got, want := s.Parent.TraceID(), listCallSpan.SpanContext.TraceID(); got != want {
+				t.Errorf("RetryBackoff span %d traceID = %v, want %v", i, got, want)
+			}
+			if got, want := s.Parent.SpanID(), listCallSpan.SpanContext.SpanID(); got != want {
+				t.Errorf("RetryBackoff span %d parentID = %v, want listCallSpan ID %v", i, got, want)
+			}
+		}
+	})
 }

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -34,12 +34,14 @@ import (
 	"time"
 
 	"cloud.google.com/go/iam/apiv1/iampb"
+	"cloud.google.com/go/internal/testutil"
 	"cloud.google.com/go/storage/experimental"
 	"cloud.google.com/go/storage/internal/apiv2/storagepb"
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/gax-go/v2"
 	"github.com/googleapis/gax-go/v2/apierror"
 	"github.com/googleapis/gax-go/v2/callctx"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
@@ -4003,4 +4005,113 @@ func setBidiReads(t *testing.T, client storageClient) {
 			c.config.grpcBidiReads = false
 		})
 	}
+}
+
+func TestOTelReaderAndWriterAttributesEmulated(t *testing.T) {
+	transportClientTest(context.Background(), t, func(t *testing.T, ctx context.Context, project, bucket string, client storageClient) {
+		te := testutil.NewOpenTelemetryTestExporter()
+		t.Cleanup(func() {
+			te.Unregister(ctx)
+		})
+		t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+		// Create bucket using emulator client.
+		_, err := client.CreateBucket(ctx, project, bucket, &BucketAttrs{
+			Name: bucket,
+		}, nil)
+		if err != nil {
+			t.Fatalf("client.CreateBucket: %v", err)
+		}
+
+		objName := fmt.Sprintf("test-trace-attrs-obj-%d.txt", time.Now().Nanosecond())
+		obj := veneerClient.Bucket(bucket).Object(objName)
+
+		// 1. Write an object.
+		w := obj.NewWriter(ctx)
+		w.ChunkSize = 256 * 1024 // 256 KiB.
+		if _, err := w.Write([]byte("Hello emulated tracing!")); err != nil {
+			t.Fatalf("w.Write: %v", err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatalf("w.Close: %v", err)
+		}
+
+		// 2. Read the object with a range.
+		r, err := obj.NewRangeReader(ctx, 0, 5)
+		if err != nil {
+			t.Fatalf("NewRangeReader: %v", err)
+		}
+		if _, err := io.ReadAll(r); err != nil && err != io.EOF {
+			t.Fatalf("io.ReadAll: %v", err)
+		}
+		r.Close()
+
+		// 3. Verify writer and reader spans.
+		spans := te.Spans()
+		var writerSpan, readerSpan tracetest.SpanStub
+		for _, s := range spans {
+			if strings.HasSuffix(s.Name, "Object.Writer") {
+				writerSpan = s
+			} else if strings.HasSuffix(s.Name, "Object.Reader") {
+				readerSpan = s
+			}
+		}
+		if writerSpan.Name == "" {
+			t.Fatalf("Object.Writer span not found in %d spans", len(spans))
+		}
+		if readerSpan.Name == "" {
+			t.Fatalf("Object.Reader span not found in %d spans", len(spans))
+		}
+
+		// Verify Writer mode attribute.
+		foundWriteMode := false
+		for _, a := range writerSpan.Attributes {
+			if string(a.Key) == "storage.write.mode" {
+				foundWriteMode = true
+				if got, want := a.Value.AsString(), "resumable"; got != want {
+					t.Errorf("writer storage.write.mode = %q, want %q", got, want)
+				}
+			}
+		}
+		if !foundWriteMode {
+			t.Errorf("storage.write.mode attribute not found on Object.Writer span")
+		}
+
+		// Verify Reader mode attribute.
+		foundReadMode := false
+		for _, a := range readerSpan.Attributes {
+			if string(a.Key) == "storage.read.mode" {
+				foundReadMode = true
+				if got, want := a.Value.AsString(), "range"; got != want {
+					t.Errorf("reader storage.read.mode = %q, want %q", got, want)
+				}
+			}
+		}
+		if !foundReadMode {
+			t.Errorf("storage.read.mode attribute not found on Object.Reader span")
+		}
+
+		// Verify Reader offset & length attributes.
+		foundOffset, foundLength := false, false
+		for _, a := range readerSpan.Attributes {
+			if string(a.Key) == "storage.read.offset" {
+				foundOffset = true
+				if got, want := a.Value.AsInt64(), int64(0); got != want {
+					t.Errorf("reader storage.read.offset = %d, want %d", got, want)
+				}
+			}
+			if string(a.Key) == "storage.read.length" {
+				foundLength = true
+				if got, want := a.Value.AsInt64(), int64(5); got != want {
+					t.Errorf("reader storage.read.length = %d, want %d", got, want)
+				}
+			}
+		}
+		if !foundOffset {
+			t.Errorf("storage.read.offset attribute not found on Object.Reader span")
+		}
+		if !foundLength {
+			t.Errorf("storage.read.length attribute not found on Object.Reader span")
+		}
+	})
 }

--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -616,7 +616,7 @@ func (c *grpcStorageClient) ListObjects(ctx context.Context, bucket string, q *Q
 		defer func() { endSpan(ctx, err) }()
 		var objects []*storagepb.Object
 		var gitr *gapic.ObjectIterator
-		err = run(it.ctx, func(ctx context.Context) error {
+		err = run(ctx, func(ctx context.Context) error {
 			gitr = c.raw.ListObjects(ctx, req, s.gax...)
 			objects, token, err = gitr.InternalFetch(pageSize, pageToken)
 			return err

--- a/storage/grpc_reader.go
+++ b/storage/grpc_reader.go
@@ -205,7 +205,13 @@ func (c *grpcStorageClient) NewRangeReaderReadObject(ctx context.Context, params
 		wantCRC  uint32
 		checkCRC bool
 	)
-	if checksums := msg.GetObjectChecksums(); checksums != nil && checksums.Crc32C != nil {
+	var checksums *storagepb.ObjectChecksums
+	if cs := msg.GetObjectChecksums(); cs != nil {
+		checksums = cs
+	} else if obj != nil && obj.GetChecksums() != nil {
+		checksums = obj.GetChecksums()
+	}
+	if checksums != nil && checksums.Crc32C != nil {
 		if !params.disableCRCCheck &&
 			startOffset == 0 &&
 			(params.length < 0 || (obj != nil && params.length >= size)) {
@@ -228,6 +234,7 @@ func (c *grpcStorageClient) NewRangeReaderReadObject(ctx context.Context, params
 		},
 		objectMetadata: &metadata,
 		reader: &gRPCReadObjectReader{
+			ctx:    ctx,
 			stream: res.stream,
 			reopen: reopen,
 			cancel: cancel,
@@ -271,6 +278,7 @@ type readStreamResponseReadObject struct {
 }
 
 type gRPCReadObjectReader struct {
+	ctx             context.Context
 	seen, size      int64
 	zeroRange       bool
 	stream          storagepb.Storage_ReadObjectClient
@@ -300,16 +308,47 @@ func (r *gRPCReadObjectReader) updateCRC(b []byte) {
 
 // Checks whether the CRC matches at the conclusion of a read, if CRC checking was enabled.
 func (r *gRPCReadObjectReader) runCRCCheck() error {
-	if r.checkCRC && r.gotCRC != r.wantCRC {
-		return fmt.Errorf("storage: bad CRC on read: got %d, want %d", r.gotCRC, r.wantCRC)
+	if r.checkCRC {
+		var chkCtx context.Context
+		if r.ctx != nil {
+			chkCtx, _ = startChecksumSpan(r.ctx, "CRC32C")
+		} else if r.stream != nil {
+			chkCtx, _ = startChecksumSpan(r.stream.Context(), "CRC32C")
+		}
+		var err error
+		if r.gotCRC != r.wantCRC {
+			err = fmt.Errorf("storage: bad CRC on read: got %d, want %d", r.gotCRC, r.wantCRC)
+		}
+		if chkCtx != nil {
+			endSpan(chkCtx, err)
+		}
+		return err
 	}
 	return nil
 }
 
 // checkAndResetChunkCRC verifies the chunk CRC if present, and resets the chunk CRC state.
 func (r *gRPCReadObjectReader) checkAndResetChunkCRC() error {
-	if r.chunkCRCPresent && r.gotChunkCRC != r.wantChunkCRC {
-		return fmt.Errorf("storage: bad CRC on chunk read: got %d, want %d", r.gotChunkCRC, r.wantChunkCRC)
+	if r.chunkCRCPresent {
+		var chkCtx context.Context
+		if !r.checkCRC {
+			if r.ctx != nil {
+				chkCtx, _ = startChecksumSpan(r.ctx, "CRC32C")
+			} else if r.stream != nil {
+				chkCtx, _ = startChecksumSpan(r.stream.Context(), "CRC32C")
+			}
+		}
+		var err error
+		if r.gotChunkCRC != r.wantChunkCRC {
+			err = fmt.Errorf("storage: bad CRC on chunk read: got %d, want %d", r.gotChunkCRC, r.wantChunkCRC)
+		}
+		if chkCtx != nil {
+			endSpan(chkCtx, err)
+		}
+		r.gotChunkCRC = 0
+		r.chunkCRCPresent = false
+		r.wantChunkCRC = 0
+		return err
 	}
 	r.gotChunkCRC = 0
 	r.chunkCRCPresent = false

--- a/storage/grpc_reader_multi_range.go
+++ b/storage/grpc_reader_multi_range.go
@@ -524,6 +524,9 @@ func (m *multiRangeDownloaderManager) getSpanCtx() context.Context {
 }
 
 func (m *multiRangeDownloaderManager) runCallback(origOffset, numBytes int64, err error, cb func(int64, int64, error)) {
+	if cb == nil {
+		return
+	}
 	m.callbackWg.Add(1)
 	go func() {
 		defer m.callbackWg.Done()

--- a/storage/grpc_reader_multi_range.go
+++ b/storage/grpc_reader_multi_range.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"log"
 	"sync"
@@ -404,6 +405,10 @@ type rangeRequest struct {
 	readID       int64
 	bytesWritten int64
 	completed    bool
+
+	wantChunkCRC    uint32
+	gotChunkCRC     uint32
+	chunkCRCPresent bool
 }
 
 // Methods implementing internalMultiRangeDownloader
@@ -1063,7 +1068,19 @@ func (m *multiRangeDownloaderManager) processDataRanges(result mrdSessionResult,
 			continue
 		}
 
-		written, _, err := result.decoder.writeToAndUpdateCRC(req.output, readID, nil)
+		var updateCRC func(b []byte)
+		if !m.params.disableMRDReadChecksum &&
+			dataRange.GetChecksummedData() != nil &&
+			dataRange.GetChecksummedData().Crc32C != nil {
+			req.gotChunkCRC = 0
+			req.chunkCRCPresent = true
+			req.wantChunkCRC = *dataRange.GetChecksummedData().Crc32C
+			updateCRC = func(b []byte) {
+				req.gotChunkCRC = crc32.Update(req.gotChunkCRC, crc32cTable, b)
+			}
+		}
+
+		written, _, err := result.decoder.writeToAndUpdateCRC(req.output, readID, updateCRC)
 		req.bytesWritten += written
 		mrdStream.updateCapacity(m, 0, -written)
 		if err != nil {
@@ -1071,8 +1088,9 @@ func (m *multiRangeDownloaderManager) processDataRanges(result mrdSessionResult,
 			continue
 		}
 
-		if result.decoder.crcErrs != nil && result.decoder.crcErrs[readID] != nil {
-			m.failRange(mrdStream, req, result.decoder.crcErrs[readID])
+		err = m.checkAndResetChunkCRC(req)
+		if err != nil {
+			m.failRange(mrdStream, req, err)
 			continue
 		}
 
@@ -1086,6 +1104,27 @@ func (m *multiRangeDownloaderManager) processDataRanges(result mrdSessionResult,
 			m.runCallback(req.origOffset, req.bytesWritten, nil, req.callback)
 		}
 	}
+}
+
+func (m *multiRangeDownloaderManager) checkAndResetChunkCRC(req *rangeRequest) error {
+	if m.params.disableMRDReadChecksum || !req.chunkCRCPresent {
+		return nil
+	}
+	var chkCtx context.Context
+	if m.ctx != nil {
+		chkCtx, _ = startChecksumSpan(m.ctx, "CRC32C")
+	}
+	var err error
+	if req.gotChunkCRC != req.wantChunkCRC {
+		err = fmt.Errorf("storage: bad CRC on chunk read: got %d, want %d", req.gotChunkCRC, req.wantChunkCRC)
+	}
+	if chkCtx != nil {
+		endSpan(chkCtx, err)
+	}
+	req.gotChunkCRC = 0
+	req.wantChunkCRC = 0
+	req.chunkCRCPresent = false
+	return err
 }
 
 // ensureSession is now only for reconnecting *after* the initial session is up.

--- a/storage/grpc_writer.go
+++ b/storage/grpc_writer.go
@@ -1106,7 +1106,14 @@ func (s *gRPCOneshotBidiWriteBufferSender) connect(ctx context.Context, cs gRPCB
 
 						var bufChecksum *uint32
 						if !s.disableAutoChecksum {
+							var chkCtx context.Context
+							if len(r.buf) > 0 {
+								chkCtx, _ = startChecksumSpan(ctx, "CRC32C")
+							}
 							bufChecksum = proto.Uint32(crc32.Checksum(r.buf, crc32cTable))
+							if chkCtx != nil {
+								endSpan(chkCtx, nil)
+							}
 						}
 						objectChecksums := getObjectChecksums(&getObjectChecksumsParams{
 							sendCRC32C:          s.sendCRC32C,
@@ -1278,7 +1285,14 @@ func (s *gRPCResumableBidiWriteBufferSender) connect(ctx context.Context, cs gRP
 
 						var bufChecksum *uint32
 						if !s.disableAutoChecksum {
+							var chkCtx context.Context
+							if len(r.buf) > 0 {
+								chkCtx, _ = startChecksumSpan(chunkCtx, "CRC32C")
+							}
 							bufChecksum = proto.Uint32(crc32.Checksum(r.buf, crc32cTable))
+							if chkCtx != nil {
+								endSpan(chkCtx, nil)
+							}
 						}
 						objectChecksums := getObjectChecksums(&getObjectChecksumsParams{
 							sendCRC32C:          s.sendCRC32C,

--- a/storage/grpc_writer.go
+++ b/storage/grpc_writer.go
@@ -29,6 +29,8 @@ import (
 	gapic "cloud.google.com/go/storage/internal/apiv2"
 	"cloud.google.com/go/storage/internal/apiv2/storagepb"
 	gax "github.com/googleapis/gax-go/v2"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -235,10 +237,20 @@ func (c *grpcStorageClient) OpenWriter(params *openWriterParams, opts ...storage
 			writerRetry = writerRetry.clone()
 			writerRetry.maxRetryDuration = 0
 		}
-		w.streamResult = checkCanceled(run(w.preRunCtx, func(ctx context.Context) error {
+		var runCtx context.Context
+		isResumable := !w.append && !w.forceOneShot
+		if isResumable {
+			runCtx, _ = startResumableInitSpan(w.preRunCtx, "")
+		} else {
+			runCtx = w.preRunCtx
+		}
+		w.streamResult = checkCanceled(run(runCtx, func(ctx context.Context) error {
 			w.lastErr = w.writeLoop(ctx)
 			return w.lastErr
 		}, writerRetry, w.settings.idempotent, withOperation("WriteObject"), withBucket(w.bucket), withObject(w.attrs.Name)))
+		if isResumable {
+			endSpan(runCtx, w.streamResult)
+		}
 		w.setError(w.streamResult)
 		close(w.donec)
 	}()
@@ -1172,7 +1184,9 @@ type gRPCResumableBidiWriteBufferSender struct {
 	objectAttrs         *ObjectAttrs
 	fullObjectChecksum  func() *uint32
 
-	streamErr error
+	streamErr  error
+	chunkCount int
+	writerCtx  context.Context
 }
 
 func (w *gRPCWriter) newGRPCResumableBidiWriteBufferSender() *gRPCResumableBidiWriteBufferSender {
@@ -1191,6 +1205,7 @@ func (w *gRPCWriter) newGRPCResumableBidiWriteBufferSender() *gRPCResumableBidiW
 			checksum := w.fullObjectChecksum
 			return &checksum
 		},
+		writerCtx: w.preRunCtx,
 	}
 }
 
@@ -1208,6 +1223,9 @@ func (s *gRPCResumableBidiWriteBufferSender) connect(ctx context.Context, cs gRP
 			return
 		}
 		s.upid = upres.GetUploadId()
+		initSpan := trace.SpanFromContext(ctx)
+		initSpan.SetAttributes(attribute.String("gcs.resumable_upload.session_uri", s.upid))
+		endSpan(ctx, nil)
 		s.startWriteRequest = nil
 	} else {
 		q, err := s.raw.QueryWriteStatus(ctx, &storagepb.QueryWriteStatusRequest{UploadId: s.upid}, opts...)
@@ -1219,7 +1237,7 @@ func (s *gRPCResumableBidiWriteBufferSender) connect(ctx context.Context, cs gRP
 		cs.completions <- gRPCBidiWriteCompletion{flushOffset: q.GetPersistedSize()}
 	}
 
-	stream, err := s.raw.BidiWriteObject(ctx, opts...)
+	stream, err := s.raw.BidiWriteObject(s.writerCtx, opts...)
 	if err != nil {
 		s.streamErr = err
 		close(cs.completions)
@@ -1250,6 +1268,14 @@ func (s *gRPCResumableBidiWriteBufferSender) connect(ctx context.Context, cs gRP
 							continue
 						}
 
+						var chunkCtx context.Context
+						if len(r.buf) > 0 {
+							s.chunkCount++
+							chunkCtx, _ = startChunkSpan(s.writerCtx, "Storage.UploadChunk", r.offset, int64(len(r.buf)), withChunkNumber(int64(s.chunkCount)))
+						} else {
+							chunkCtx = s.writerCtx
+						}
+
 						var bufChecksum *uint32
 						if !s.disableAutoChecksum {
 							bufChecksum = proto.Uint32(crc32.Checksum(r.buf, crc32cTable))
@@ -1268,7 +1294,13 @@ func (s *gRPCResumableBidiWriteBufferSender) connect(ctx context.Context, cs gRP
 							firstSend = false
 						}
 						if err := stream.Send(req); err != nil {
+							if chunkCtx != nil && len(r.buf) > 0 {
+								endSpan(chunkCtx, err)
+							}
 							return err
+						}
+						if chunkCtx != nil && len(r.buf) > 0 {
+							endSpan(chunkCtx, nil)
 						}
 						if r.finishWrite {
 							stream.CloseSend()

--- a/storage/http_client.go
+++ b/storage/http_client.go
@@ -213,6 +213,11 @@ type trackingTransport struct {
 }
 
 func (t *trackingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL != nil && req.URL.Query().Get("upload_id") != "" {
+		if cb, ok := req.Context().Value(firstChunkCallbackKey{}).(func()); ok && cb != nil {
+			cb()
+		}
+	}
 	baseRT := t.base
 	if baseRT == nil {
 		baseRT = http.DefaultTransport

--- a/storage/http_client.go
+++ b/storage/http_client.go
@@ -1053,7 +1053,7 @@ func (c *httpStorageClient) newRangeReaderXML(ctx context.Context, params *newRa
 	if err != nil {
 		return nil, err
 	}
-	return parseReadResponse(res, params, reopen)
+	return parseReadResponse(ctx, res, params, reopen)
 }
 
 func (c *httpStorageClient) newRangeReaderJSON(ctx context.Context, params *newRangeReaderParams, s *settings) (r *Reader, err error) {
@@ -1077,7 +1077,7 @@ func (c *httpStorageClient) newRangeReaderJSON(ctx context.Context, params *newR
 	if err != nil {
 		return nil, err
 	}
-	return parseReadResponse(res, params, reopen)
+	return parseReadResponse(ctx, res, params, reopen)
 }
 
 // httpInternalWriter writes data for an HTTP upload. For single-shot uploads,
@@ -1499,6 +1499,7 @@ func (c *httpStorageClient) DeleteNotification(ctx context.Context, bucket strin
 }
 
 type httpReader struct {
+	ctx      context.Context
 	body     io.ReadCloser
 	seen     int64
 	reopen   func(seen int64) (*http.Response, error)
@@ -1524,9 +1525,20 @@ func (r *httpReader) Read(p []byte) (int, error) {
 			// everybody defers Close on the assumption that it doesn't return
 			// anything worth looking at.
 			if r.checkCRC {
+				var chkCtx context.Context
+				if r.ctx != nil {
+					chkCtx, _ = startChecksumSpan(r.ctx, "CRC32C")
+				}
+				var crcErr error
 				if r.gotCRC != r.wantCRC {
-					return n, fmt.Errorf("storage: bad CRC on read: got %d, want %d",
+					crcErr = fmt.Errorf("storage: bad CRC on read: got %d, want %d",
 						r.gotCRC, r.wantCRC)
+				}
+				if chkCtx != nil {
+					endSpan(chkCtx, crcErr)
+				}
+				if crcErr != nil {
+					return n, crcErr
 				}
 			}
 			return n, err
@@ -1651,7 +1663,7 @@ func readerReopen(ctx context.Context, header http.Header, params *newRangeReade
 	}
 }
 
-func parseReadResponse(res *http.Response, params *newRangeReaderParams, reopen func(int64) (*http.Response, error)) (r *Reader, err error) {
+func parseReadResponse(ctx context.Context, res *http.Response, params *newRangeReaderParams, reopen func(int64) (*http.Response, error)) (r *Reader, err error) {
 	defer func() {
 		if err != nil {
 			res.Body.Close()
@@ -1756,6 +1768,7 @@ func parseReadResponse(res *http.Response, params *newRangeReaderParams, reopen 
 		remain:         remain,
 		checkCRC:       checkCRC,
 		reader: &httpReader{
+			ctx:      ctx,
 			reopen:   reopen,
 			body:     body,
 			wantCRC:  crc,

--- a/storage/http_client.go
+++ b/storage/http_client.go
@@ -473,7 +473,7 @@ func (c *httpStorageClient) ListObjects(ctx context.Context, bucket string, q *Q
 			req.MaxResults(int64(pageSize))
 		}
 		var resp *raw.Objects
-		err = run(it.ctx, func(ctx context.Context) error {
+		err = run(ctx, func(ctx context.Context) error {
 			resp, err = req.Context(ctx).Do()
 			return err
 		}, s.retry, s.idempotent, withOperation("ListObjects"), withObject(it.query.Prefix), withBucket(bucket))

--- a/storage/http_client.go
+++ b/storage/http_client.go
@@ -1085,6 +1085,7 @@ func (c *httpStorageClient) newRangeReaderJSON(ctx context.Context, params *newR
 // the checksum returned by the server.
 type httpInternalWriter struct {
 	*io.PipeWriter
+	ctx                context.Context
 	chunkSize          int
 	checksumDisabled   bool
 	fullObjectChecksum uint32
@@ -1095,13 +1096,19 @@ type httpInternalWriter struct {
 
 // validateChecksum validates the computed checksum against the server-provided checksum.
 func (hiw *httpInternalWriter) validateChecksumFromServer() error {
-	serverChecksum, ok := <-hiw.serverChecksumChan
-	// Do not check for channel closure as error is already set on the writer
-	// if serverChecksumChan is closed without checksum
-	if ok && hiw.fullObjectChecksum != serverChecksum {
-		return fmt.Errorf("storage: object checksum mismatch: computed %q, server %q; the bucket may contain corrupted object", encodeUint32(hiw.fullObjectChecksum), encodeUint32(serverChecksum))
+	var chkCtx context.Context
+	if hiw.ctx != nil {
+		chkCtx, _ = startChecksumSpan(hiw.ctx, "CRC32C")
 	}
-	return nil
+	serverChecksum, ok := <-hiw.serverChecksumChan
+	var err error
+	if ok && hiw.fullObjectChecksum != serverChecksum {
+		err = fmt.Errorf("storage: object checksum mismatch: computed %q, server %q; the bucket may contain corrupted object", encodeUint32(hiw.fullObjectChecksum), encodeUint32(serverChecksum))
+	}
+	if chkCtx != nil {
+		endSpan(chkCtx, err)
+	}
+	return err
 }
 
 func (hiw *httpInternalWriter) Write(data []byte) (n int, err error) {
@@ -1241,6 +1248,7 @@ func (c *httpStorageClient) OpenWriter(params *openWriterParams, opts ...storage
 	}()
 	return &httpInternalWriter{
 		PipeWriter:         pw,
+		ctx:                params.ctx,
 		chunkSize:          params.chunkSize,
 		serverChecksumChan: serverChecksumChan,
 		checksumDisabled:   checksumDisabled,

--- a/storage/invoke.go
+++ b/storage/invoke.go
@@ -131,7 +131,11 @@ func run(ctx context.Context, call func(ctx context.Context) error, retry *retry
 	}
 
 	var lastErr error
+	var attemptEnd time.Time
 	return internal.Retry(ctx, bo, func() (stop bool, err error) {
+		if attempts > 1 && !attemptEnd.IsZero() {
+			recordRetryBackoffEvent(ctx, time.Since(attemptEnd), attempts, attemptEnd)
+		}
 		if retry.maxRetryDuration != 0 {
 			select {
 			case <-quitAfterTimer.C:
@@ -158,6 +162,9 @@ func run(ctx context.Context, call func(ctx context.Context) error, retry *retry
 		// sent by the server) in both cases.
 		if ctxErr := ctx.Err(); errors.Is(ctxErr, context.Canceled) || errors.Is(ctxErr, context.DeadlineExceeded) {
 			retryable = false
+		}
+		if retryable {
+			attemptEnd = time.Now()
 		}
 		return !retryable, lastErr
 	})

--- a/storage/invoke.go
+++ b/storage/invoke.go
@@ -131,7 +131,11 @@ func run(ctx context.Context, call func(ctx context.Context) error, retry *retry
 	}
 
 	var lastErr error
+	var attemptEnd time.Time
 	return internal.Retry(ctx, bo, func() (stop bool, err error) {
+		if attempts > 1 && !attemptEnd.IsZero() {
+			recordRetryBackoffEvent(ctx, attempts-1, attemptEnd)
+		}
 		if retry.maxRetryDuration != 0 {
 			select {
 			case <-quitAfterTimer.C:
@@ -158,6 +162,9 @@ func run(ctx context.Context, call func(ctx context.Context) error, retry *retry
 		// sent by the server) in both cases.
 		if ctxErr := ctx.Err(); errors.Is(ctxErr, context.Canceled) || errors.Is(ctxErr, context.DeadlineExceeded) {
 			retryable = false
+		}
+		if retryable {
+			attemptEnd = time.Now()
 		}
 		return !retryable, lastErr
 	})

--- a/storage/reader.go
+++ b/storage/reader.go
@@ -118,6 +118,11 @@ func (o *ObjectHandle) NewRangeReader(ctx context.Context, offset, length int64,
 	// in Reader.Close.
 	ctx, _ = startSpanWithBucket(ctx, o.c, o.bucket, "Object.Reader")
 	defer func() { endSpan(ctx, err) }()
+	readMode := "range"
+	if offset == 0 && length < 0 {
+		readMode = "full"
+	}
+	recordReaderTraceAttributes(ctx, readMode, offset, length, o.object)
 
 	if err := o.validate(); err != nil {
 		return nil, err
@@ -268,6 +273,7 @@ func (o *ObjectHandle) NewMultiRangeDownloader(ctx context.Context, opts ...MRDO
 	// in MultiRangeDownloader.Close.
 	var spanCtx context.Context
 	spanCtx, _ = startSpanWithBucket(ctx, o.c, o.bucket, "Object.MultiRangeDownloader")
+	recordReaderTraceAttributes(spanCtx, "multi_range", 0, 0, o.object)
 	defer func() {
 		if err != nil {
 			endSpan(spanCtx, err)

--- a/storage/reader.go
+++ b/storage/reader.go
@@ -121,6 +121,11 @@ func (o *ObjectHandle) NewRangeReader(ctx context.Context, offset, length int64,
 	// in Reader.Close.
 	ctx, _ = startSpanWithBucket(ctx, o.c, o.bucket, "Object.Reader")
 	defer func() { endSpan(ctx, err) }()
+	readMode := "range"
+	if offset == 0 && length < 0 {
+		readMode = "full"
+	}
+	recordReaderTraceAttributes(ctx, readMode, offset, length, o.object)
 
 	if err := o.validate(); err != nil {
 		return nil, err
@@ -276,6 +281,7 @@ func (o *ObjectHandle) NewMultiRangeDownloader(ctx context.Context, opts ...MRDO
 			endSpan(spanCtx, err)
 		}
 	}()
+	recordReaderTraceAttributes(spanCtx, "multi_range", 0, 0, o.object)
 
 	if err := o.validate(); err != nil {
 		return nil, err

--- a/storage/reader_test.go
+++ b/storage/reader_test.go
@@ -852,3 +852,10 @@ func TestHTTPReaderMidStreamRetryCRC(t *testing.T) {
 		}
 	}, option.WithHTTPClient(hc))
 }
+
+func TestMRDRunCallbackNilGuard(t *testing.T) {
+	m := &multiRangeDownloaderManager{}
+	// Calling runCallback with a nil callback should safely return without panicking.
+	m.runCallback(0, 100, nil, nil)
+	m.callbackWg.Wait()
+}

--- a/storage/trace.go
+++ b/storage/trace.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync/atomic"
 
 	internalTrace "cloud.google.com/go/internal/trace"
 	"cloud.google.com/go/storage/internal"
@@ -240,4 +241,64 @@ func recordReaderTraceAttributes(ctx context.Context, readMode string, offset, l
 		)
 	}
 	span.SetAttributes(attrs...)
+}
+
+// withChunkNumber sets the 1-indexed chunk number attribute on the span.
+func withChunkNumber(n int64) trace.SpanStartOption {
+	return trace.WithAttributes(attribute.Int64("upload.chunk_number", n))
+}
+
+// startChunkSpan starts a span for a chunk upload with offset and size attributes.
+func startChunkSpan(ctx context.Context, name string, offset int64, size int64, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	if !isOTelTracingDevEnabled() {
+		return ctx, trace.SpanFromContext(ctx)
+	}
+	attrs := []attribute.KeyValue{
+		attribute.Int64("gcp.storage.chunk.offset", offset),
+		attribute.Int64("gcp.storage.chunk.size", size),
+	}
+	opts = append(opts, trace.WithAttributes(attrs...))
+	return startSpan(ctx, name, opts...)
+}
+
+func startResumableInitSpan(ctx context.Context, sessionURI string) (context.Context, trace.Span) {
+	if !isOTelTracingDevEnabled() {
+		return ctx, trace.SpanFromContext(ctx)
+	}
+	opts := []trace.SpanStartOption{}
+	if sessionURI != "" {
+		opts = append(opts, trace.WithAttributes(
+			attribute.String("gcs.resumable_upload.session_uri", sessionURI),
+		))
+	}
+	return startSpan(ctx, "Storage.ResumableSessionInit", opts...)
+}
+
+// dynamicSpanContext wraps a context.Context and delegates Value lookups to an active span context
+// stored in an atomic.Value. This allows dynamically updating the active OTel parent span for long-lived
+// background client calls (such as HTTP resumable upload loops).
+type dynamicSpanContext struct {
+	context.Context
+	holder *atomic.Value
+}
+
+func (d *dynamicSpanContext) Value(key any) any {
+	if cur, ok := d.holder.Load().(context.Context); ok && cur != nil {
+		if val := cur.Value(key); val != nil {
+			return val
+		}
+	}
+	return d.Context.Value(key)
+}
+
+func newDynamicSpanContext(ctx context.Context) (context.Context, *atomic.Value) {
+	holder := &atomic.Value{}
+	holder.Store(ctx)
+	return &dynamicSpanContext{Context: ctx, holder: holder}, holder
+}
+
+type firstChunkCallbackKey struct{}
+
+func withFirstChunkCallback(ctx context.Context, cb func()) context.Context {
+	return context.WithValue(ctx, firstChunkCallbackKey{}, cb)
 }

--- a/storage/trace.go
+++ b/storage/trace.go
@@ -302,3 +302,15 @@ type firstChunkCallbackKey struct{}
 func withFirstChunkCallback(ctx context.Context, cb func()) context.Context {
 	return context.WithValue(ctx, firstChunkCallbackKey{}, cb)
 }
+
+// startChecksumSpan starts a T5 internal operation span for computing or verifying data checksums.
+func startChecksumSpan(ctx context.Context, checksumType string) (context.Context, trace.Span) {
+	if !isOTelTracingDevEnabled() {
+		noopSpan := trace.SpanFromContext(nil)
+		return trace.ContextWithSpan(ctx, noopSpan), noopSpan
+	}
+	opts := []trace.SpanStartOption{
+		trace.WithAttributes(attribute.String("gcp.storage.checksum.type", checksumType)),
+	}
+	return startSpan(ctx, "Storage.CalculateChecksum", opts...)
+}

--- a/storage/trace.go
+++ b/storage/trace.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	internalTrace "cloud.google.com/go/internal/trace"
 	"cloud.google.com/go/storage/internal"
@@ -180,4 +181,91 @@ func getCommonAttributes() []attribute.KeyValue {
 
 func appendPackageName(spanName string) string {
 	return fmt.Sprintf("%s.%s", gcpClientArtifact, spanName)
+}
+
+// recordRetryBackoffEvent adds an event and a child span to the current span in ctx recording a retry backoff.
+func recordRetryBackoffEvent(ctx context.Context, backoff time.Duration, attempt int, startTime time.Time) {
+	if !isOTelTracingDevEnabled() {
+		return
+	}
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+	attrs := []attribute.KeyValue{
+		attribute.Int("attempt", attempt),
+		attribute.String("backoff", backoff.String()),
+	}
+	span.AddEvent("storage.retry.backoff", trace.WithAttributes(attrs...))
+
+	// Create a child span for the backoff duration so it appears as a visual
+	// block in Trace Explorer waterfall charts.
+	if startTime.IsZero() {
+		startTime = time.Now().Add(-backoff)
+	}
+	_, backoffSpan := startSpan(ctx, "RetryBackoff", trace.WithTimestamp(startTime))
+	backoffSpan.SetAttributes(attrs...)
+	backoffSpan.End(trace.WithTimestamp(startTime.Add(backoff)))
+}
+
+// recordWriterTraceAttributes attaches descriptive upload mode and configuration attributes
+// to the Object.Writer span in ctx so observers can inspect the write type in Trace Explorer.
+func recordWriterTraceAttributes(ctx context.Context, w *Writer) {
+	if !isOTelTracingDevEnabled() || w == nil {
+		return
+	}
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+
+	writeMode := "resumable"
+	if w.EnableParallelUpload {
+		writeMode = "parallel_composite"
+	} else if strings.HasPrefix(w.ObjectAttrs.Name, "gcs-go-sdk-pu-tmp/") {
+		writeMode = "pcu_part_writer"
+	} else if w.Append {
+		writeMode = "appendable"
+	} else if w.ChunkSize == 0 {
+		writeMode = "oneshot"
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.String("storage.write.mode", writeMode),
+		attribute.Int("storage.write.chunk_size", w.ChunkSize),
+		attribute.Bool("storage.write.append", w.Append),
+		attribute.Bool("storage.write.parallel", w.EnableParallelUpload),
+		attribute.String("storage.object.name", w.ObjectAttrs.Name),
+	}
+	if w.EnableParallelUpload {
+		attrs = append(attrs,
+			attribute.Int("storage.write.pcu_part_size", w.ParallelUploadConfig.PartSize),
+			attribute.Int("storage.write.pcu_concurrency", w.ParallelUploadConfig.MaxConcurrency),
+		)
+	}
+	span.SetAttributes(attrs...)
+}
+
+// recordReaderTraceAttributes attaches descriptive read mode and range attributes
+// to the Object.Reader or Object.MultiRangeDownloader span in ctx.
+func recordReaderTraceAttributes(ctx context.Context, readMode string, offset, length int64, objectName string) {
+	if !isOTelTracingDevEnabled() {
+		return
+	}
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.String("storage.read.mode", readMode),
+		attribute.String("storage.object.name", objectName),
+	}
+	if readMode == "range" || readMode == "full" {
+		attrs = append(attrs,
+			attribute.Int64("storage.read.offset", offset),
+			attribute.Int64("storage.read.length", length),
+		)
+	}
+	span.SetAttributes(attrs...)
 }

--- a/storage/trace.go
+++ b/storage/trace.go
@@ -179,3 +179,65 @@ func getCommonAttributes() []attribute.KeyValue {
 func appendPackageName(spanName string) string {
 	return fmt.Sprintf("%s.%s", gcpClientArtifact, spanName)
 }
+
+// recordWriterTraceAttributes attaches descriptive upload mode and configuration attributes
+// to the Object.Writer span in ctx so observers can inspect the write type in Trace Explorer.
+func recordWriterTraceAttributes(ctx context.Context, w *Writer) {
+	if !isOTelTracingDevEnabled() || w == nil {
+		return
+	}
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+
+	writeMode := "resumable"
+	if w.EnableParallelUpload {
+		writeMode = "parallel_composite"
+	} else if strings.HasPrefix(w.ObjectAttrs.Name, "gcs-go-sdk-pu-tmp/") {
+		writeMode = "pcu_part_writer"
+	} else if w.Append {
+		writeMode = "appendable"
+	} else if w.ChunkSize == 0 {
+		writeMode = "oneshot"
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.String("storage.write.mode", writeMode),
+		attribute.Int("storage.write.chunk_size", w.ChunkSize),
+		attribute.Bool("storage.write.append", w.Append),
+		attribute.Bool("storage.write.parallel", w.EnableParallelUpload),
+		attribute.String("storage.object.name", w.ObjectAttrs.Name),
+	}
+	if w.EnableParallelUpload {
+		attrs = append(attrs,
+			attribute.Int("storage.write.pcu_part_size", w.ParallelUploadConfig.PartSize),
+			attribute.Int("storage.write.pcu_concurrency", w.ParallelUploadConfig.MaxConcurrency),
+		)
+	}
+	span.SetAttributes(attrs...)
+}
+
+// recordReaderTraceAttributes attaches descriptive read mode and range attributes
+// to the Object.Reader or Object.MultiRangeDownloader span in ctx.
+func recordReaderTraceAttributes(ctx context.Context, readMode string, offset, length int64, objectName string) {
+	if !isOTelTracingDevEnabled() {
+		return
+	}
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.String("storage.read.mode", readMode),
+		attribute.String("storage.object.name", objectName),
+	}
+	if readMode == "range" {
+		attrs = append(attrs,
+			attribute.Int64("storage.read.offset", offset),
+			attribute.Int64("storage.read.length", length),
+		)
+	}
+	span.SetAttributes(attrs...)
+}

--- a/storage/trace.go
+++ b/storage/trace.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	internalTrace "cloud.google.com/go/internal/trace"
 	"cloud.google.com/go/storage/internal"
@@ -313,4 +314,32 @@ func startChecksumSpan(ctx context.Context, checksumType string) (context.Contex
 		trace.WithAttributes(attribute.String("gcp.storage.checksum.type", checksumType)),
 	}
 	return startSpan(ctx, "Storage.CalculateChecksum", opts...)
+}
+
+// recordRetryBackoffEvent creates a T5 RetryBackoff child span and adds a
+// storage.retry.backoff span event to the active span in ctx.
+func recordRetryBackoffEvent(ctx context.Context, attempt int, startTime time.Time) {
+	if !isOTelTracingDevEnabled() {
+		return
+	}
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+	endTime := time.Now()
+	if startTime.IsZero() {
+		startTime = endTime
+	}
+	backoff := endTime.Sub(startTime)
+	attrs := []attribute.KeyValue{
+		attribute.Int("attempt", attempt),
+		attribute.String("backoff", backoff.String()),
+	}
+	span.AddEvent("storage.retry.backoff", trace.WithAttributes(attrs...))
+
+	// Create a child span for the backoff duration so it appears as a visual
+	// block in Trace Explorer waterfall charts.
+	_, backoffSpan := startSpan(ctx, "RetryBackoff", trace.WithTimestamp(startTime))
+	backoffSpan.SetAttributes(attrs...)
+	backoffSpan.End(trace.WithTimestamp(endTime))
 }

--- a/storage/trace.go
+++ b/storage/trace.go
@@ -30,6 +30,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	otelcodes "go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/oauth2"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -342,4 +343,41 @@ func recordRetryBackoffEvent(ctx context.Context, attempt int, startTime time.Ti
 	_, backoffSpan := startSpan(ctx, "RetryBackoff", trace.WithTimestamp(startTime))
 	backoffSpan.SetAttributes(attrs...)
 	backoffSpan.End(trace.WithTimestamp(endTime))
+}
+
+// startAuthRefreshSpan starts a T5 internal operation span for authentication token refreshes.
+func startAuthRefreshSpan(ctx context.Context) (context.Context, trace.Span) {
+	if !isOTelTracingDevEnabled() {
+		return ctx, trace.SpanFromContext(ctx)
+	}
+	return startSpan(ctx, "Auth.RefreshAccessToken")
+}
+
+// TracedTokenSource wraps an oauth2.TokenSource to record T5 Auth.RefreshAccessToken
+// internal operation spans whenever an access token is fetched or refreshed.
+type TracedTokenSource struct {
+	base oauth2.TokenSource
+}
+
+// NewTracedTokenSource wraps an existing oauth2.TokenSource with OpenTelemetry T5 Auth tracing.
+func NewTracedTokenSource(base oauth2.TokenSource) oauth2.TokenSource {
+	if base == nil {
+		return nil
+	}
+	return &TracedTokenSource{base: base}
+}
+
+// Token fetches or refreshes an access token while recording a T5 Auth.RefreshAccessToken span.
+func (t *TracedTokenSource) Token() (*oauth2.Token, error) {
+	if !isOTelTracingDevEnabled() {
+		return t.base.Token()
+	}
+	_, span := startAuthRefreshSpan(context.Background())
+	defer span.End()
+
+	tok, err := t.base.Token()
+	if err != nil {
+		span.RecordError(err)
+	}
+	return tok, err
 }

--- a/storage/trace_test.go
+++ b/storage/trace_test.go
@@ -584,3 +584,67 @@ func TestRecordReaderTraceAttributes(t *testing.T) {
 		})
 	}
 }
+
+func TestStartChunkSpanWithChunkNumber(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	chunkCtx, _ := startChunkSpan(ctx, "Storage.UploadChunk", 262144, 262144, withChunkNumber(2))
+	endSpan(chunkCtx, nil)
+
+	spans := te.Spans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	gotSpan := spans[0]
+	if got, want := gotSpan.Name, "cloud.google.com/go/storage.Storage.UploadChunk"; got != want {
+		t.Errorf("got span name %q, want %q", got, want)
+	}
+
+	wantAttrs := map[string]interface{}{
+		"upload.chunk_number":      int64(2),
+		"gcp.storage.chunk.offset": int64(262144),
+		"gcp.storage.chunk.size":   int64(262144),
+	}
+	for k, wantVal := range wantAttrs {
+		found := false
+		for _, a := range gotSpan.Attributes {
+			if string(a.Key) == k {
+				found = true
+				if got := a.Value.AsInt64(); got != wantVal.(int64) {
+					t.Errorf("key %q: got %v, want %v", k, got, wantVal)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("attribute %q not found on span", k)
+		}
+	}
+}
+
+func TestWriterMarkClosedEndsChunkSpan(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	w := &Writer{
+		ctx:       ctx,
+		ChunkSize: 256 * 1024,
+	}
+	_, span := startSpan(ctx, "Storage.UploadChunk")
+	w.curChunkSpan = span
+
+	if err := w.markClosed(nil); err != nil {
+		t.Fatalf("w.markClosed: %v", err)
+	}
+	if w.curChunkSpan != nil {
+		t.Errorf("expected w.curChunkSpan to be nil after markClosed, got %v", w.curChunkSpan)
+	}
+}

--- a/storage/trace_test.go
+++ b/storage/trace_test.go
@@ -648,3 +648,58 @@ func TestWriterMarkClosedEndsChunkSpan(t *testing.T) {
 		t.Errorf("expected w.curChunkSpan to be nil after markClosed, got %v", w.curChunkSpan)
 	}
 }
+
+func TestStartChecksumSpan(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	chkCtx, _ := startChecksumSpan(ctx, "CRC32C")
+	endSpan(chkCtx, nil)
+
+	spans := te.Spans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	gotSpan := spans[0]
+	if got, want := gotSpan.Name, "cloud.google.com/go/storage.Storage.CalculateChecksum"; got != want {
+		t.Errorf("got span name %q, want %q", got, want)
+	}
+	foundChecksumType := false
+	for _, a := range gotSpan.Attributes {
+		if string(a.Key) == "gcp.storage.checksum.type" {
+			foundChecksumType = true
+			if got, want := a.Value.AsString(), "CRC32C"; got != want {
+				t.Errorf("checksum type = %q, want %q", got, want)
+			}
+		}
+	}
+	if !foundChecksumType {
+		t.Errorf("gcp.storage.checksum.type attribute not found on span")
+	}
+}
+
+func TestChecksumSpanDevTracingDisabled(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "false")
+
+	// Start a parent span
+	ctx, _ = tracer().Start(ctx, "ParentSpan")
+
+	// Call startChecksumSpan and endSpan with the returned context
+	chkCtx, _ := startChecksumSpan(ctx, "CRC32C")
+	span := trace.SpanFromContext(chkCtx)
+	span.End()
+
+	spans := te.Spans()
+	if len(spans) > 0 {
+		t.Fatalf("expected 0 ended spans because ParentSpan should still be active, but got %d ended spans: %v", len(spans), spans[0].Name)
+	}
+}

--- a/storage/trace_test.go
+++ b/storage/trace_test.go
@@ -30,6 +30,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/oauth2"
 	"google.golang.org/api/googleapi"
 )
 
@@ -747,5 +748,41 @@ func TestMetadataRetryBackoffTracing(t *testing.T) {
 		if ev.Name != "storage.retry.backoff" {
 			t.Errorf("event %d: got name %q, want %q", i, ev.Name, "storage.retry.backoff")
 		}
+	}
+}
+
+type staticTokenSource struct {
+	token *oauth2.Token
+}
+
+func (s *staticTokenSource) Token() (*oauth2.Token, error) {
+	return s.token, nil
+}
+
+func TestTracedTokenSourceSpan(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	rawTS := &staticTokenSource{token: &oauth2.Token{AccessToken: "fake-token"}}
+	tts := NewTracedTokenSource(rawTS)
+
+	tok, err := tts.Token()
+	if err != nil {
+		t.Fatalf("tts.Token: %v", err)
+	}
+	if tok.AccessToken != "fake-token" {
+		t.Fatalf("got access token %q, want %q", tok.AccessToken, "fake-token")
+	}
+
+	spans := te.Spans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	if got, want := spans[0].Name, "cloud.google.com/go/storage.Auth.RefreshAccessToken"; got != want {
+		t.Errorf("got span name %q, want %q", got, want)
 	}
 }

--- a/storage/trace_test.go
+++ b/storage/trace_test.go
@@ -350,3 +350,237 @@ func TestEndSpanEviction(t *testing.T) {
 		})
 	}
 }
+
+func TestRecordWriterTraceAttributes(t *testing.T) {
+	testCases := []struct {
+		name      string
+		writer    *Writer
+		wantAttrs map[string]interface{}
+	}{
+		{
+			name: "resumable",
+			writer: &Writer{
+				ChunkSize:            256 * 1024,
+				Append:               false,
+				EnableParallelUpload: false,
+				ObjectAttrs:          ObjectAttrs{Name: "test-file.txt"},
+			},
+			wantAttrs: map[string]interface{}{
+				"storage.write.mode":       "resumable",
+				"storage.write.chunk_size": int64(256 * 1024),
+				"storage.write.append":     false,
+				"storage.write.parallel":   false,
+				"storage.object.name":      "test-file.txt",
+			},
+		},
+		{
+			name: "oneshot",
+			writer: &Writer{
+				ChunkSize:            0,
+				Append:               false,
+				EnableParallelUpload: false,
+				ObjectAttrs:          ObjectAttrs{Name: "test-oneshot.txt"},
+			},
+			wantAttrs: map[string]interface{}{
+				"storage.write.mode":       "oneshot",
+				"storage.write.chunk_size": int64(0),
+				"storage.write.append":     false,
+				"storage.write.parallel":   false,
+				"storage.object.name":      "test-oneshot.txt",
+			},
+		},
+		{
+			name: "appendable",
+			writer: &Writer{
+				ChunkSize:            256 * 1024,
+				Append:               true,
+				EnableParallelUpload: false,
+				ObjectAttrs:          ObjectAttrs{Name: "test-append.txt"},
+			},
+			wantAttrs: map[string]interface{}{
+				"storage.write.mode":       "appendable",
+				"storage.write.chunk_size": int64(256 * 1024),
+				"storage.write.append":     true,
+				"storage.write.parallel":   false,
+				"storage.object.name":      "test-append.txt",
+			},
+		},
+		{
+			name: "parallel_composite",
+			writer: &Writer{
+				ChunkSize:            256 * 1024,
+				Append:               false,
+				EnableParallelUpload: true,
+				ParallelUploadConfig: ParallelUploadConfig{
+					PartSize:       16 * 1024 * 1024,
+					MaxConcurrency: 4,
+				},
+				ObjectAttrs: ObjectAttrs{Name: "test-parallel.txt"},
+			},
+			wantAttrs: map[string]interface{}{
+				"storage.write.mode":            "parallel_composite",
+				"storage.write.chunk_size":      int64(256 * 1024),
+				"storage.write.append":          false,
+				"storage.write.parallel":        true,
+				"storage.object.name":           "test-parallel.txt",
+				"storage.write.pcu_part_size":   int64(16 * 1024 * 1024),
+				"storage.write.pcu_concurrency": int64(4),
+			},
+		},
+		{
+			name: "pcu_part_writer",
+			writer: &Writer{
+				ChunkSize:            256 * 1024,
+				Append:               false,
+				EnableParallelUpload: false,
+				ObjectAttrs:          ObjectAttrs{Name: "gcs-go-sdk-pu-tmp/part-1"},
+			},
+			wantAttrs: map[string]interface{}{
+				"storage.write.mode":       "pcu_part_writer",
+				"storage.write.chunk_size": int64(256 * 1024),
+				"storage.write.append":     false,
+				"storage.write.parallel":   false,
+				"storage.object.name":      "gcs-go-sdk-pu-tmp/part-1",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			te := testutil.NewOpenTelemetryTestExporter()
+			t.Cleanup(func() {
+				te.Unregister(ctx)
+			})
+			t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+			spanName := "Object.Writer"
+			ctx, _ = startSpan(ctx, spanName)
+			recordWriterTraceAttributes(ctx, tc.writer)
+			endSpan(ctx, nil)
+
+			spans := te.Spans()
+			if len(spans) != 1 {
+				t.Fatalf("expected 1 span, got %d", len(spans))
+			}
+			gotSpan := spans[0]
+
+			for k, wantVal := range tc.wantAttrs {
+				found := false
+				for _, a := range gotSpan.Attributes {
+					if string(a.Key) == k {
+						found = true
+						switch v := wantVal.(type) {
+						case string:
+							if got := a.Value.AsString(); got != v {
+								t.Errorf("key %q: got %v, want %v", k, got, v)
+							}
+						case int64:
+							if got := a.Value.AsInt64(); got != v {
+								t.Errorf("key %q: got %v, want %v", k, got, v)
+							}
+						case bool:
+							if got := a.Value.AsBool(); got != v {
+								t.Errorf("key %q: got %v, want %v", k, got, v)
+							}
+						}
+					}
+				}
+				if !found {
+					t.Errorf("attribute %q not found on span", k)
+				}
+			}
+		})
+	}
+}
+
+func TestRecordReaderTraceAttributes(t *testing.T) {
+	testCases := []struct {
+		name       string
+		readMode   string
+		offset     int64
+		length     int64
+		objectName string
+		wantAttrs  map[string]interface{}
+	}{
+		{
+			name:       "range",
+			readMode:   "range",
+			offset:     100,
+			length:     500,
+			objectName: "read-obj.txt",
+			wantAttrs: map[string]interface{}{
+				"storage.read.mode":   "range",
+				"storage.read.offset": int64(100),
+				"storage.read.length": int64(500),
+				"storage.object.name": "read-obj.txt",
+			},
+		},
+		{
+			name:       "full",
+			readMode:   "full",
+			offset:     0,
+			length:     -1,
+			objectName: "read-full.txt",
+			wantAttrs: map[string]interface{}{
+				"storage.read.mode":   "full",
+				"storage.object.name": "read-full.txt",
+			},
+		},
+		{
+			name:       "multi_range",
+			readMode:   "multi_range",
+			offset:     0,
+			length:     0,
+			objectName: "read-mrd.txt",
+			wantAttrs: map[string]interface{}{
+				"storage.read.mode":   "multi_range",
+				"storage.object.name": "read-mrd.txt",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			te := testutil.NewOpenTelemetryTestExporter()
+			t.Cleanup(func() {
+				te.Unregister(ctx)
+			})
+			t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+			spanName := "Object.Reader"
+			ctx, _ = startSpan(ctx, spanName)
+			recordReaderTraceAttributes(ctx, tc.readMode, tc.offset, tc.length, tc.objectName)
+			endSpan(ctx, nil)
+
+			spans := te.Spans()
+			if len(spans) != 1 {
+				t.Fatalf("expected 1 span, got %d", len(spans))
+			}
+			gotSpan := spans[0]
+
+			for k, wantVal := range tc.wantAttrs {
+				found := false
+				for _, a := range gotSpan.Attributes {
+					if string(a.Key) == k {
+						found = true
+						switch v := wantVal.(type) {
+						case string:
+							if got := a.Value.AsString(); got != v {
+								t.Errorf("key %q: got %v, want %v", k, got, v)
+							}
+						case int64:
+							if got := a.Value.AsInt64(); got != v {
+								t.Errorf("key %q: got %v, want %v", k, got, v)
+							}
+						}
+					}
+				}
+				if !found {
+					t.Errorf("attribute %q not found on span", k)
+				}
+			}
+		})
+	}
+}

--- a/storage/trace_test.go
+++ b/storage/trace_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -348,5 +349,220 @@ func TestEndSpanEviction(t *testing.T) {
 				t.Errorf("expected bucket to remain in cache")
 			}
 		})
+	}
+}
+
+func TestRecordRetryBackoffEvent(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	spanName := "Object.Writer"
+	ctx, _ = startSpan(ctx, spanName)
+	startTime := time.Now()
+	backoff := 150 * time.Millisecond
+	recordRetryBackoffEvent(ctx, backoff, 2, startTime)
+	endSpan(ctx, nil)
+
+	spans := te.Spans()
+	if len(spans) != 2 {
+		t.Fatalf("expected 2 spans (parent + RetryBackoff child), got %d", len(spans))
+	}
+
+	var parentSpan, backoffSpan tracetest.SpanStub
+	for _, s := range spans {
+		if strings.HasSuffix(s.Name, "RetryBackoff") {
+			backoffSpan = s
+		} else if strings.HasSuffix(s.Name, spanName) {
+			parentSpan = s
+		}
+	}
+	if backoffSpan.Name == "" || parentSpan.Name == "" {
+		t.Fatalf("failed to find both parent and RetryBackoff spans in %v", spans)
+	}
+
+	// Verify parent span has the storage.retry.backoff event
+	if len(parentSpan.Events) != 1 {
+		t.Fatalf("expected 1 event on parent span, got %d", len(parentSpan.Events))
+	}
+	if got, want := parentSpan.Events[0].Name, "storage.retry.backoff"; got != want {
+		t.Errorf("got event name %q, want %q", got, want)
+	}
+
+	// Verify RetryBackoff child span attributes
+	wantAttrs := map[string]interface{}{
+		"attempt": int64(2),
+		"backoff": backoff.String(),
+	}
+	for k, wantVal := range wantAttrs {
+		found := false
+		for _, a := range backoffSpan.Attributes {
+			if string(a.Key) == k {
+				found = true
+				if gotVal := a.Value.AsInt64(); k == "attempt" && gotVal != wantVal.(int64) {
+					t.Errorf("got attempt %v, want %v", gotVal, wantVal)
+				} else if gotStr := a.Value.AsString(); k == "backoff" && gotStr != wantVal.(string) {
+					t.Errorf("got backoff %v, want %v", gotStr, wantVal)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("attribute %q not found on RetryBackoff span", k)
+		}
+	}
+}
+
+func TestRecordWriterTraceAttributes(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	spanName := "Object.Writer"
+	ctx, _ = startSpan(ctx, spanName)
+	w := &Writer{
+		ChunkSize:            256 * 1024,
+		Append:               false,
+		EnableParallelUpload: false,
+		ObjectAttrs:          ObjectAttrs{Name: "test-file.txt"},
+	}
+	recordWriterTraceAttributes(ctx, w)
+	endSpan(ctx, nil)
+
+	spans := te.Spans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	gotSpan := spans[0]
+
+	wantAttrs := map[string]interface{}{
+		"storage.write.mode":       "resumable",
+		"storage.write.chunk_size": int64(256 * 1024),
+		"storage.write.append":     false,
+		"storage.write.parallel":   false,
+		"storage.object.name":      "test-file.txt",
+	}
+	for k, wantVal := range wantAttrs {
+		found := false
+		for _, a := range gotSpan.Attributes {
+			if string(a.Key) == k {
+				found = true
+				switch v := wantVal.(type) {
+				case string:
+					if got := a.Value.AsString(); got != v {
+						t.Errorf("key %q: got %v, want %v", k, got, v)
+					}
+				case int64:
+					if got := a.Value.AsInt64(); got != v {
+						t.Errorf("key %q: got %v, want %v", k, got, v)
+					}
+				case bool:
+					if got := a.Value.AsBool(); got != v {
+						t.Errorf("key %q: got %v, want %v", k, got, v)
+					}
+				}
+			}
+		}
+		if !found {
+			t.Errorf("attribute %q not found on span", k)
+		}
+	}
+}
+
+func TestRecordReaderTraceAttributes(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	spanName := "Object.Reader"
+	ctx, _ = startSpan(ctx, spanName)
+	recordReaderTraceAttributes(ctx, "range", 100, 500, "read-obj.txt")
+	endSpan(ctx, nil)
+
+	spans := te.Spans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	gotSpan := spans[0]
+
+	wantAttrs := map[string]interface{}{
+		"storage.read.mode":   "range",
+		"storage.read.offset": int64(100),
+		"storage.read.length": int64(500),
+		"storage.object.name": "read-obj.txt",
+	}
+	for k, wantVal := range wantAttrs {
+		found := false
+		for _, a := range gotSpan.Attributes {
+			if string(a.Key) == k {
+				found = true
+				switch v := wantVal.(type) {
+				case string:
+					if got := a.Value.AsString(); got != v {
+						t.Errorf("key %q: got %v, want %v", k, got, v)
+					}
+				case int64:
+					if got := a.Value.AsInt64(); got != v {
+						t.Errorf("key %q: got %v, want %v", k, got, v)
+					}
+				}
+			}
+		}
+		if !found {
+			t.Errorf("attribute %q not found on span", k)
+		}
+	}
+}
+
+func TestMetadataRetryBackoffTracing(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	// Test metadata operation (e.g. Bucket.Attrs or ObjectsListCall) experiencing 2 retries
+	spanName := "Bucket.Attrs"
+	ctx, _ = startSpan(ctx, spanName)
+	recordRetryBackoffEvent(ctx, 100*time.Millisecond, 1, time.Now())
+	recordRetryBackoffEvent(ctx, 200*time.Millisecond, 2, time.Now())
+	endSpan(ctx, nil)
+
+	spans := te.Spans()
+	if len(spans) != 3 {
+		t.Fatalf("expected 3 spans (1 parent metadata span + 2 RetryBackoff child spans), got %d", len(spans))
+	}
+
+	var parentSpan tracetest.SpanStub
+	var backoffCount int
+	for _, s := range spans {
+		if strings.HasSuffix(s.Name, "RetryBackoff") {
+			backoffCount++
+		} else if strings.HasSuffix(s.Name, spanName) {
+			parentSpan = s
+		}
+	}
+	if backoffCount != 2 {
+		t.Errorf("expected 2 RetryBackoff child spans, got %d", backoffCount)
+	}
+	if parentSpan.Name == "" {
+		t.Fatalf("failed to find parent metadata span %q", spanName)
+	}
+	if len(parentSpan.Events) != 2 {
+		t.Fatalf("expected 2 storage.retry.backoff events on metadata span, got %d", len(parentSpan.Events))
+	}
+	for i, ev := range parentSpan.Events {
+		if ev.Name != "storage.retry.backoff" {
+			t.Errorf("event %d: got name %q, want %q", i, ev.Name, "storage.retry.backoff")
+		}
 	}
 }

--- a/storage/trace_test.go
+++ b/storage/trace_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -701,5 +702,50 @@ func TestChecksumSpanDevTracingDisabled(t *testing.T) {
 	spans := te.Spans()
 	if len(spans) > 0 {
 		t.Fatalf("expected 0 ended spans because ParentSpan should still be active, but got %d ended spans: %v", len(spans), spans[0].Name)
+	}
+}
+
+func TestMetadataRetryBackoffTracing(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	// Test metadata operation (e.g. Bucket.Attrs or ObjectsListCall) experiencing 2 retries.
+	spanName := "Bucket.Attrs"
+	ctx, _ = startSpan(ctx, spanName)
+	recordRetryBackoffEvent(ctx, 1, time.Now().Add(-100*time.Millisecond))
+	recordRetryBackoffEvent(ctx, 2, time.Now().Add(-200*time.Millisecond))
+	endSpan(ctx, nil)
+
+	spans := te.Spans()
+	if len(spans) != 3 {
+		t.Fatalf("expected 3 spans (1 parent metadata span + 2 RetryBackoff child spans), got %d", len(spans))
+	}
+
+	var parentSpan tracetest.SpanStub
+	var backoffCount int
+	for _, s := range spans {
+		if strings.HasSuffix(s.Name, "RetryBackoff") {
+			backoffCount++
+		} else if strings.HasSuffix(s.Name, spanName) {
+			parentSpan = s
+		}
+	}
+	if backoffCount != 2 {
+		t.Errorf("expected 2 RetryBackoff child spans, got %d", backoffCount)
+	}
+	if parentSpan.Name == "" {
+		t.Fatalf("failed to find parent metadata span %q", spanName)
+	}
+	if len(parentSpan.Events) != 2 {
+		t.Fatalf("expected 2 storage.retry.backoff events on metadata span, got %d", len(parentSpan.Events))
+	}
+	for i, ev := range parentSpan.Events {
+		if ev.Name != "storage.retry.backoff" {
+			t.Errorf("event %d: got name %q, want %q", i, ev.Name, "storage.retry.backoff")
+		}
 	}
 }

--- a/storage/writer.go
+++ b/storage/writer.go
@@ -27,6 +27,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Interface internalWriter wraps low-level implementations which may vary
@@ -247,6 +248,14 @@ type Writer struct {
 
 	// bytesWritten is the cumulative bytes written for request size metric.
 	bytesWritten int64
+
+	chunkCount    int64
+	lastProgress  int64
+	lastChunkTime time.Time
+	curChunkSpan  trace.Span
+	initSpanDone  bool
+	baseCtx       context.Context
+	ctxHolder     *atomic.Value
 }
 
 func (w *Writer) wrapWriteError(n int, err error) (int, error) {
@@ -433,6 +442,10 @@ func (w *Writer) Close() error {
 func (w *Writer) markClosed(err error) error {
 	w.mu.Lock()
 	w.closed = true
+	if w.curChunkSpan != nil {
+		w.curChunkSpan.End()
+		w.curChunkSpan = nil
+	}
 	if w.err == nil && err != nil {
 		w.err = err
 	}
@@ -448,7 +461,11 @@ func (w *Writer) markClosed(err error) error {
 			state.record(closingErr)
 		}
 	}
-	endSpan(w.ctx, closingErr)
+	endSpanCtx := w.ctx
+	if w.baseCtx != nil {
+		endSpanCtx = w.baseCtx
+	}
+	endSpan(endSpanCtx, closingErr)
 	return closingErr
 }
 
@@ -465,6 +482,8 @@ func (w *Writer) openWriter() (err error) {
 	isIdempotent = isIdempotent || w.Append && w.o.gen > 0
 	opts := makeStorageOpts(isIdempotent, w.o.retry, w.o.userProject)
 	recordWriterTraceAttributes(w.ctx, w)
+	baseCtx := w.ctx
+	w.baseCtx = baseCtx
 	params := &openWriterParams{
 		ctx:                  w.ctx,
 		chunkSize:            w.ChunkSize,
@@ -482,7 +501,29 @@ func (w *Writer) openWriter() (err error) {
 		donec:                w.donec,
 		setError:             w.error,
 		progress:             w.progress,
-		setObj:               func(o *ObjectAttrs) { w.obj = o },
+		onChunkRequest: func() {
+			w.mu.Lock()
+			defer w.mu.Unlock()
+			if !isOTelTracingDevEnabled() || w.ChunkSize <= 0 {
+				return
+			}
+			now := time.Now()
+			if w.curChunkSpan != nil {
+				w.curChunkSpan.End(trace.WithTimestamp(now))
+				w.curChunkSpan = nil
+			}
+			w.initSpanDone = true
+
+			w.chunkCount++
+			chunkNum := w.chunkCount
+			offset := w.lastProgress
+			chunkCtx, span := startChunkSpan(baseCtx, "Storage.UploadChunk", offset, int64(w.ChunkSize), withChunkNumber(chunkNum), trace.WithTimestamp(now))
+			w.curChunkSpan = span
+			if w.ctxHolder != nil {
+				w.ctxHolder.Store(chunkCtx)
+			}
+		},
+		setObj: func(o *ObjectAttrs) { w.obj = o },
 		setSize: func(n int64) {
 			if w.obj != nil {
 				w.obj.Size = n
@@ -494,12 +535,23 @@ func (w *Writer) openWriter() (err error) {
 	if err := w.ctx.Err(); err != nil {
 		return err // short-circuit
 	}
+	_, isHTTP := w.o.c.tc.(*httpStorageClient)
+	if isHTTP && isOTelTracingDevEnabled() && w.ChunkSize > 0 {
+		dynCtx, holder := newDynamicSpanContext(withFirstChunkCallback(baseCtx, params.onChunkRequest))
+		w.ctxHolder = holder
+		params.ctx = dynCtx
+
+		initCtx, initSpan := startResumableInitSpan(baseCtx, "")
+		w.curChunkSpan = initSpan
+		w.ctxHolder.Store(initCtx)
+	}
 	w.iw, err = w.o.c.tc.OpenWriter(params, opts...)
 	if err != nil {
 		return err
 	}
 	w.ctx = params.ctx
 	w.opened = true
+	w.lastChunkTime = time.Now()
 	go w.monitorCancel()
 
 	return nil
@@ -560,6 +612,19 @@ func (w *Writer) validateWriteAttrs() error {
 // progress is a convenience wrapper that reports write progress to the Writer
 // ProgressFunc if it is set.
 func (w *Writer) progress(p int64) {
+	w.mu.Lock()
+	last := w.lastProgress
+	now := time.Now()
+	if isOTelTracingDevEnabled() && w.ChunkSize > 0 && p > last {
+		if w.curChunkSpan != nil {
+			w.curChunkSpan.End(trace.WithTimestamp(now))
+			w.curChunkSpan = nil
+		}
+		w.lastProgress = p
+		w.lastChunkTime = now
+		w.initSpanDone = true
+	}
+	w.mu.Unlock()
 	if w.ProgressFunc != nil {
 		w.ProgressFunc(p)
 	}

--- a/storage/writer.go
+++ b/storage/writer.go
@@ -255,6 +255,7 @@ func (w *Writer) getOrInitPCU() (*pcuState, error) {
 		if err := w.initPCU(w.ctx); err != nil {
 			return nil, err
 		}
+		recordWriterTraceAttributes(w.ctx, w)
 	}
 	return w.pcu, nil
 }
@@ -396,6 +397,7 @@ func (w *Writer) Close() error {
 }
 
 func (w *Writer) openWriter() (err error) {
+	recordWriterTraceAttributes(w.ctx, w)
 	if err := w.validateWriteAttrs(); err != nil {
 		return err
 	}

--- a/storage/writer.go
+++ b/storage/writer.go
@@ -464,6 +464,7 @@ func (w *Writer) openWriter() (err error) {
 	// Append operations that takeover a specific generation are idempotent.
 	isIdempotent = isIdempotent || w.Append && w.o.gen > 0
 	opts := makeStorageOpts(isIdempotent, w.o.retry, w.o.userProject)
+	recordWriterTraceAttributes(w.ctx, w)
 	params := &openWriterParams{
 		ctx:                  w.ctx,
 		chunkSize:            w.ChunkSize,


### PR DESCRIPTION
- Emit visual 'RetryBackoff' child spans and 'storage.retry.backoff' trace events during exponential backoff pauses in invoke.go, allowing observers to inspect retry delays directly in waterfall charts.
- Add recordWriterTraceAttributes in trace.go (invoked in writer.go) to attach storage.write.mode, chunk size, object name, and PCU attributes to upload spans.
- Add recordReaderTraceAttributes in trace.go (invoked in reader.go) to attach storage.read.mode ('full', 'range'), offset, length, and object name to download spans.