### PR TITLE
fix(auth): validate ES256 signature length

### DIFF
--- a/auth/credentials/idtoken/validate.go
+++ b/auth/credentials/idtoken/validate.go
@@ -36,7 +36,8 @@ import (
 )
 
 const (
-	es256KeySize int = 32
+	es256KeySize       int = 32
+	es256SignatureSize     = 2 * es256KeySize
 	// googleIAPCertsURL is used for ES256 Certs.
 	googleIAPCertsURL string = "https://www.gstatic.com/iap/verify/public_key-jwk"
 	// googleSACertsURL is used for RS256 Certs.
@@ -215,6 +216,9 @@ func (v *Validator) rs256CertsURL() string {
 }
 
 func (v *Validator) validateES256(ctx context.Context, keyID string, hashedContent []byte, sig []byte) error {
+	if len(sig) != es256SignatureSize {
+		return fmt.Errorf("idtoken: invalid ES256 signature length: got %d, want %d", len(sig), es256SignatureSize)
+	}
 	certResp, err := v.client.getCert(ctx, v.es256CertsURL())
 	if err != nil {
 		return err

--- a/auth/credentials/idtoken/validate_test.go
+++ b/auth/credentials/idtoken/validate_test.go
@@ -29,6 +29,7 @@ import (
 	"io"
 	"math/big"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -188,6 +189,7 @@ func TestValidateES256(t *testing.T) {
 		x            *big.Int
 		y            *big.Int
 		nowFunc      func() time.Time
+		signature    []byte
 		wantErr      bool
 		wantCertsURL string
 	}{
@@ -209,6 +211,15 @@ func TestValidateES256(t *testing.T) {
 			nowFunc:      beforeExp,
 			wantErr:      false,
 			wantCertsURL: "http://example.com",
+		},
+		{
+			name:      "invalid signature length",
+			keyID:     keyID,
+			x:         pk.X,
+			y:         pk.Y,
+			nowFunc:   beforeExp,
+			signature: make([]byte, es256SignatureSize-1),
+			wantErr:   true,
 		},
 		{
 			name:         "no matching key",
@@ -276,9 +287,15 @@ func TestValidateES256(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewValidator(...) = %q, want nil", err)
 			}
-			payload, err := v.Validate(context.Background(), idToken, testAudience)
+
+			token := idToken
+			if tt.signature != nil {
+				i := strings.LastIndexByte(token, '.')
+				token = token[:i+1] + base64.RawURLEncoding.EncodeToString(tt.signature)
+			}
+			payload, err := v.Validate(context.Background(), token, testAudience)
 			if !tt.wantErr && err != nil {
-				t.Fatalf("Validate(ctx, %s, %s) = %q, want nil", idToken, testAudience, err)
+				t.Fatalf("Validate(ctx, %s, %s) = %q, want nil", token, testAudience, err)
 			}
 			if !tt.wantErr && payload.Audience != testAudience {
 				t.Fatalf("got %v, want %v", payload.Audience, testAudience)


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/53275#pullrequestreview-4842997598
- originally reported as https://issuetracker.google.com/issues/542131568, but was rejected, so opening as regular bug fix; 

Reject ES256 signatures that are not exactly 64 bytes before splitting them into the R and S components. This prevents a panic on malformed signatures and enforces the required ES256 encoding.
