### PR TITLE
feat(bigtable): add ClientConfig.DisableSession to opt out of session backend

### DIFF
--- a/bigtable/client.go
+++ b/bigtable/client.go
@@ -57,14 +57,18 @@ type Client struct {
 	// stays on the classic path until the session backend's
 	// ConfigurationManager bumps the ratio via AddSessionLoadListener.
 	diverter *btransport.Diverter
-	// sessionImpl is the session data-plane client. Always constructed
-	// by NewClientWithConfig so a control-plane session-load bump can
-	// route traffic to it without a client restart. No RPCs actually
-	// travel to the session backend until the diverter's SessionLoad
-	// > 0 — the initial value is 0.0 and only the server-driven
-	// ClientConfigurationManager writes to it. Session pools + streams
-	// are lazily materialized on first use, so an idle client pays
-	// only for one channel pool and one config-poll goroutine.
+	// sessionImpl is the session data-plane client. Constructed by
+	// NewClientWithConfig by default so a control-plane session-load
+	// bump can route traffic to it without a client restart. Nil when
+	// the caller pre-dialed a custom gRPC conn or opted out via
+	// ClientConfig.DisableSession — every downstream reader
+	// (open.go's getOrCreateSession*, Client.Close) nil-guards. When
+	// non-nil, no RPCs actually travel to the session backend until
+	// the diverter's SessionLoad > 0 — the initial value is 0.0 and
+	// only the server-driven ClientConfigurationManager writes to it.
+	// Session pools + streams are lazily materialized on first use,
+	// so an idle client pays only for one channel pool and one
+	// config-poll goroutine.
 	sessionImpl session.Client
 	// sessionTables caches per-resource session.TableAPI handles so
 	// repeat Open* calls return the same handle (and by extension the
@@ -100,6 +104,25 @@ type ClientConfig struct {
 
 	// DisableDirectAccess disables direct access by default.
 	DisableDirectAccess bool
+
+	// DisableSession, when true, tells NewClientWithConfig to skip
+	// constructing the session data-plane client entirely. sessionImpl
+	// and sessionTables are left nil; the client runs classic-only and
+	// pays none of the session infrastructure's per-connection background
+	// goroutines or gRPC-channel cost.
+	//
+	// Effect on Table: Open() returns a *Table whose divertible field is
+	// still built (Diverter is a classic-side concern), but its session
+	// side is nil, so TableShim.useSession() reports false and every
+	// Apply / ReadRow routes to the classic path unconditionally.
+	//
+	// Intended for callers who have specific reasons to opt out of the
+	// session data plane — running against a backend that doesn't
+	// support it, benchmarking classic-only baselines, or resource-
+	// constrained environments where the +N goroutines + +MB RSS of an
+	// idle session pool matter. Default (false) keeps the current
+	// behavior: session client is always constructed.
+	DisableSession bool
 }
 
 // MetricsProvider is a wrapper for the built-in metrics meter provider.
@@ -279,7 +302,13 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 	if uResolver, resErr := internaloption.NewUnsafeResolver(o...); resErr == nil {
 		preDialed = uResolver.ResolvedGRPCConnIsCustom()
 	}
-	if !preDialed {
+	// Skip session-client construction when either (a) caller pre-dialed
+	// a custom conn (session.NewClient can't dial through it) or (b)
+	// caller opted out via ClientConfig.DisableSession. In both cases
+	// sessionImpl + sessionTables stay nil; every downstream caller
+	// (open.go's getOrCreateSession*, Client.Close) already nil-guards
+	// on that state.
+	if !preDialed && !config.DisableSession {
 		// Pass the fully-merged option list (o), not the raw caller
 		// opts. gtransport.Dial needs the DefaultClientOptions merged
 		// in (endpoint, scopes, user-agent, interceptors) — passing

--- a/bigtable/client_disable_session_test.go
+++ b/bigtable/client_disable_session_test.go
@@ -1,0 +1,190 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigtable
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// TestClientConfig_DisableSession_SkipsSessionInit pins the
+// DisableSession=true gate: NewClientWithConfig must NOT construct
+// the session data-plane client, and every downstream sessionImpl /
+// sessionTables field must be nil.
+//
+// The test uses WithContextDialer (not WithGRPCConn) so preDialed
+// stays false — otherwise the preDialed path would also skip
+// session.NewClient and the test would not isolate the DisableSession
+// gate. With DisableSession=true AND preDialed=false, only the
+// DisableSession gate can be responsible for sessionImpl being nil.
+//
+// The bufconn has no server behind it. If the gate is broken,
+// session.NewClient would try to reach a non-responsive backend and
+// the 5-second context would time out — the test would fail with a
+// deadline error, distinguishing "gate broken" from "gate worked."
+func TestClientConfig_DisableSession_SkipsSessionInit(t *testing.T) {
+	lis := bufconn.Listen(1024 * 1024)
+	t.Cleanup(func() { _ = lis.Close() })
+
+	// Serve a minimal fake so the classic pool's Prime (PingAndWarm)
+	// succeeds; without it, mPool never finishes construction and this
+	// test would fail on the classic side, not the DisableSession gate.
+	grpcSrv := grpc.NewServer()
+	t.Cleanup(grpcSrv.Stop)
+	btpb.RegisterBigtableServer(grpcSrv, newFakeBigtableServer(t))
+	go func() { _ = grpcSrv.Serve(lis) }()
+
+	dialer := func(ctx context.Context, _ string) (net.Conn, error) {
+		return lis.DialContext(ctx)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	c, err := NewClientWithConfig(ctx, "test-project", "test-instance", ClientConfig{
+		DisableSession:  true,
+		MetricsProvider: NoopMetricsProvider{},
+	},
+		option.WithEndpoint("passthrough:///bufnet"),
+		option.WithGRPCDialOption(grpc.WithContextDialer(dialer)),
+		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("NewClientWithConfig with DisableSession=true failed: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	if c.sessionImpl != nil {
+		t.Errorf("sessionImpl = %T, want nil (DisableSession=true must skip session.NewClient)", c.sessionImpl)
+	}
+	if c.sessionTables != nil {
+		t.Errorf("sessionTables = %v, want nil (DisableSession=true must skip cache init)", c.sessionTables)
+	}
+}
+
+// TestClientConfig_DisableSession_ClientCloseWorks confirms Client.Close
+// on a DisableSession client is a clean no-op on the session side —
+// every downstream nil-guard fires as intended (client.go:322 comment
+// promises "sessionTables is nil ... the cache's own close() nil-checks
+// for that"; client.go:329 wraps sessionImpl.Close in a nil check).
+func TestClientConfig_DisableSession_ClientCloseWorks(t *testing.T) {
+	lis := bufconn.Listen(1024 * 1024)
+	t.Cleanup(func() { _ = lis.Close() })
+
+	// Serve a minimal fake so the classic pool's Prime (PingAndWarm)
+	// succeeds; without it, mPool never finishes construction and this
+	// test would fail on the classic side, not the DisableSession gate.
+	grpcSrv := grpc.NewServer()
+	t.Cleanup(grpcSrv.Stop)
+	btpb.RegisterBigtableServer(grpcSrv, newFakeBigtableServer(t))
+	go func() { _ = grpcSrv.Serve(lis) }()
+
+	dialer := func(ctx context.Context, _ string) (net.Conn, error) {
+		return lis.DialContext(ctx)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	c, err := NewClientWithConfig(ctx, "test-project", "test-instance", ClientConfig{
+		DisableSession:  true,
+		MetricsProvider: NoopMetricsProvider{},
+	},
+		option.WithEndpoint("passthrough:///bufnet"),
+		option.WithGRPCDialOption(grpc.WithContextDialer(dialer)),
+		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("NewClientWithConfig: %v", err)
+	}
+
+	// Explicit Close — must not panic on the nil sessionImpl / sessionTables.
+	if err := c.Close(); err != nil {
+		t.Errorf("Close on DisableSession client returned err = %v, want nil", err)
+	}
+	// Second Close must also be safe (idempotent per session_pool_lifecycle
+	// / mPool.Close conventions).
+	_ = c.Close()
+}
+
+// TestClientConfig_DisableSession_OpenTableRoutesClassicOnly confirms
+// that on a DisableSession client, TableShim's session side is nil, so
+// useSession() reports false and every Apply / ReadRow routes to the
+// classic path unconditionally — regardless of the Diverter's
+// SessionLoad. This is the load-bearing contract for callers that
+// opt out: they get classic behavior even if some future code path
+// bumps the Diverter.
+func TestClientConfig_DisableSession_OpenTableRoutesClassicOnly(t *testing.T) {
+	lis := bufconn.Listen(1024 * 1024)
+	t.Cleanup(func() { _ = lis.Close() })
+
+	// Serve a minimal fake so the classic pool's Prime (PingAndWarm)
+	// succeeds; without it, mPool never finishes construction and this
+	// test would fail on the classic side, not the DisableSession gate.
+	grpcSrv := grpc.NewServer()
+	t.Cleanup(grpcSrv.Stop)
+	btpb.RegisterBigtableServer(grpcSrv, newFakeBigtableServer(t))
+	go func() { _ = grpcSrv.Serve(lis) }()
+
+	dialer := func(ctx context.Context, _ string) (net.Conn, error) {
+		return lis.DialContext(ctx)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	c, err := NewClientWithConfig(ctx, "test-project", "test-instance", ClientConfig{
+		DisableSession:  true,
+		MetricsProvider: NoopMetricsProvider{},
+	},
+		option.WithEndpoint("passthrough:///bufnet"),
+		option.WithGRPCDialOption(grpc.WithContextDialer(dialer)),
+		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("NewClientWithConfig: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	// Force the Diverter into session-preferring mode. If DisableSession
+	// works as advertised, useSession() still reports false because
+	// TableShim.session is nil.
+	if c.diverter != nil {
+		c.diverter.SetSessionLoad(1.0)
+	}
+
+	tblAPI := c.OpenTable("mytable")
+	shim, ok := tblAPI.(*TableShim)
+	if !ok {
+		t.Fatalf("OpenTable returned %T, want *TableShim", tblAPI)
+	}
+	if shim.session != nil {
+		t.Errorf("shim.session = %T, want nil (DisableSession clients must not wire a session TableAPI)", shim.session)
+	}
+	if shim.useSession() {
+		t.Error("shim.useSession() = true, want false (nil session side must gate to classic)")
+	}
+}

--- a/bigtable/open.go
+++ b/bigtable/open.go
@@ -64,9 +64,12 @@ func (c *Client) buildDivertible(t *Table, openSession func() session.TableAPI) 
 // OpenTable opens a table. Returns a TableShim that routes each RPC via
 // the Client's Diverter — with sessionLoad=0.0 every call lands on the
 // classic path. The session TableAPI is wired from the Client's
-// sessionImpl (always constructed by NewClientWithConfig); server-driven
-// SessionLoad updates from ClientConfigurationManager retarget traffic
-// without re-opening the table.
+// sessionImpl when present; it's nil when the caller pre-dialed a
+// custom gRPC conn or opted out via ClientConfig.DisableSession, in
+// which case the shim runs classic-only and useSession() reports
+// false. Server-driven SessionLoad updates from
+// ClientConfigurationManager retarget traffic without re-opening the
+// table.
 func (c *Client) OpenTable(table string) TableAPI {
 	classic := &tableImpl{Table{
 		c:     c,


### PR DESCRIPTION
1. This option will be deprecated. 
2. Keeping this ClientOption as a hatch in the client release. In future, we will create the session client regardless of this flag. so it should be fine.

