### PR TITLE
fix(bigtable): fall back transport_type to "unknown" when PeerInfo absent

### DIFF
--- a/bigtable/internal/metrics/tracer.go
+++ b/bigtable/internal/metrics/tracer.go
@@ -486,13 +486,24 @@ func (mt *Tracer) toOtelMetricAttrs(metricName string) (attribute.Set, error) {
 		case MetricLabelKeyStreamingOperation:
 			attrKeyValues = append(attrKeyValues, attribute.Bool(MetricLabelKeyStreamingOperation, mt.isStreaming))
 		case MetricTransportType:
-			attrKeyValues = append(attrKeyValues, attribute.String(MetricTransportType, mt.currOp.currAttempt.transportType))
+			// Fallback to "unknown" when an attempt errors before
+			// PeerInfo arrives (deadline exceeded, transport failure).
+			// Matches Java's Util.formatTransportType(null peerInfo) →
+			// TRANSPORT_TYPE_UNKNOWN.name() → "unknown".
+			attrKeyValues = append(attrKeyValues, attribute.String(MetricTransportType,
+				FallbackString(mt.currOp.currAttempt.transportType, defaultTransportType)))
 		case MetricTransportRegion:
-			attrKeyValues = append(attrKeyValues, attribute.String(MetricTransportRegion, mt.currOp.currAttempt.transportRegion))
+			// No fallback — Java emits "" here on the empty-PeerInfo
+			// path (Util.formatTransportRegion with null peerInfo).
+			// Kept identical for cross-language label alignment.
+			attrKeyValues = append(attrKeyValues, attribute.String(MetricTransportRegion,
+				mt.currOp.currAttempt.transportRegion))
 		case MetricTransportSubZone:
-			attrKeyValues = append(attrKeyValues, attribute.String(MetricTransportSubZone, mt.currOp.currAttempt.transportSubZone))
+			attrKeyValues = append(attrKeyValues, attribute.String(MetricTransportSubZone,
+				mt.currOp.currAttempt.transportSubZone))
 		case MetricTransportZone:
-			attrKeyValues = append(attrKeyValues, attribute.String(MetricTransportZone, mt.currOp.currAttempt.transportZone))
+			attrKeyValues = append(attrKeyValues, attribute.String(MetricTransportZone,
+				mt.currOp.currAttempt.transportZone))
 		default:
 			return attribute.Set{}, fmt.Errorf("unknown additional attribute: %v", attrKey)
 		}

--- a/bigtable/internal/metrics/util.go
+++ b/bigtable/internal/metrics/util.go
@@ -37,6 +37,19 @@ const (
 	defaultZone    = "global"
 	defaultTable   = "<unspecified>"
 
+	// defaultTransportType is the sentinel stamped on the transport_type
+	// label when an attempt fails before the server's PeerInfo metadata
+	// arrives (e.g. DEADLINE_EXCEEDED on the first attempt, or a
+	// transport-layer error). "unknown" matches the label Java emits
+	// (Util.transportTypeToStringWithoutFallback → TRANSPORT_TYPE_UNKNOWN
+	// case) so cross-language dashboards group these attempts into the
+	// same bucket. The three geographic transport_* labels
+	// (transport_region / transport_zone / transport_subzone) intentionally
+	// have NO fallback here — Java emits them as empty strings on this
+	// path (Util.formatTransport{Region,Zone,Subzone} with null peerInfo);
+	// mirroring keeps the dashboards aligned.
+	defaultTransportType = "unknown"
+
 	// PeerInfoMDKey is the response-metadata key the server uses to
 	// carry the serialized PeerInfo proto once the PeerInfo feature
 	// flag is negotiated on. extractPeerInfo decodes the value.

--- a/bigtable/internal/metrics/util_test.go
+++ b/bigtable/internal/metrics/util_test.go
@@ -366,3 +366,66 @@ func TestToOtelMetricAttrsAttemptLatencies2(t *testing.T) {
 		t.Errorf("attr count = %d, want %d", attrSet.Len(), len(want))
 	}
 }
+
+// TestToOtelMetricAttrsAttemptLatencies2_EmptyLabelsFallback pins the
+// deadline-exceeded / transport-failure path: when an attempt errors
+// BEFORE the server's PeerInfo metadata arrives, every location and
+// transport_* field on the AttemptTracer is left as its zero value
+// (empty string). toOtelMetricAttrs mirrors Java's fallbacks:
+//
+//	cluster_id       → "<unspecified>" (defaultCluster) — Java parity
+//	zone_id          → "global"        (defaultZone)    — Java parity
+//	transport_type   → "unknown"       (defaultTransportType, matches
+//	                   Java's Util.formatTransportType(null peerInfo))
+//	transport_region → ""              (Java emits empty on this path)
+//	transport_zone   → ""              (Java emits empty on this path)
+//	transport_subzone → ""             (Java emits empty on this path)
+func TestToOtelMetricAttrsAttemptLatencies2_EmptyLabelsFallback(t *testing.T) {
+	tracer := &Tracer{
+		method:      metricMethodPrefix + "ReadRows",
+		tableName:   "test-table",
+		isStreaming: true,
+		clientAttributes: []attribute.KeyValue{
+			attribute.String(MetricLabelKeyProject, "test-project"),
+		},
+		currOp: OpTracer{
+			status: "DEADLINE_EXCEEDED",
+			currAttempt: AttemptTracer{
+				status: "DEADLINE_EXCEEDED",
+				// clusterID, zoneID, transport* all zero-value
+				// (empty string) — simulates PeerInfo never arriving.
+			},
+		},
+	}
+
+	attrSet, err := tracer.toOtelMetricAttrs(MetricNameAttemptLatencies2)
+	if err != nil {
+		t.Fatalf("toOtelMetricAttrs: %v", err)
+	}
+	want := map[attribute.Key]attribute.Value{
+		MetricLabelKeyMethod:             attribute.StringValue("Bigtable.ReadRows"),
+		MetricLabelKeyTable:              attribute.StringValue("test-table"),
+		MetricLabelKeyCluster:            attribute.StringValue(defaultCluster),       // <unspecified>
+		MetricLabelKeyZone:               attribute.StringValue(defaultZone),          // global
+		MetricLabelKeyProject:            attribute.StringValue("test-project"),
+		MetricLabelKeyStatus:             attribute.StringValue("DEADLINE_EXCEEDED"),
+		MetricLabelKeyStreamingOperation: attribute.BoolValue(true),
+		MetricTransportType:              attribute.StringValue(defaultTransportType), // unknown
+		MetricTransportRegion:            attribute.StringValue(""),                   // Java parity: empty
+		MetricTransportZone:              attribute.StringValue(""),                   // Java parity: empty
+		MetricTransportSubZone:           attribute.StringValue(""),                   // Java parity: empty
+	}
+	for key, expected := range want {
+		val, ok := attrSet.Value(key)
+		if !ok {
+			t.Errorf("missing attribute %v", key)
+			continue
+		}
+		if val != expected {
+			t.Errorf("attr[%v] = %v, want %v", key, val.Emit(), expected.Emit())
+		}
+	}
+	if attrSet.Len() != len(want) {
+		t.Errorf("attr count = %d, want %d", attrSet.Len(), len(want))
+	}
+}


### PR DESCRIPTION
## Summary

When an attempt errors BEFORE the server's PeerInfo metadata arrives (deadline exceeded on the first attempt, transport-layer failure), the per-attempt tracer's \`transportType\` field is left as its zero value (empty string). Previously that empty string reached \`toOtelMetricAttrs\` and Cloud Monitoring emitted an attempt-latency point with \`transport_type=\"\"\`, fragmenting cross-language dashboards. Java emits \`\"unknown\"\` on the same path.

Apply the same fallback shape already used for \`cluster_id\` (→ \`\"<unspecified>\"\`) and \`zone_id\` (→ \`\"global\"\`): if \`transportType\` is empty, stamp it as \`\"unknown\"\`.

## Java parity

Verified against \`Util.transportTypeToStringWithoutFallback\` in java-bigtable's \`internal/csm/attributes/Util.java\`:

| Java call | Java result |
|---|---|
| \`TRANSPORT_TYPE_UNKNOWN.name()\` mapping | \`\"unknown\"\` |
| \`Util.formatTransportType(null peerInfo)\` | \`\"unknown\"\` |

Full label alignment with Java (verified line-by-line in \`Util.java\`):

| label | Java default (no PeerInfo/ClusterInformation) | this PR |
|---|---|---|
| \`cluster_id\` | \`\"<unspecified>\"\` | unchanged, already matches |
| \`zone_id\` | \`\"global\"\` | unchanged, already matches |
| \`transport_type\` | \`\"unknown\"\` | **new fallback — this PR** |
| \`transport_region\` | \`\"\"\` (empty) | unchanged, keeps empty |
| \`transport_zone\` | \`\"\"\` (empty) | unchanged, keeps empty |
| \`transport_subzone\` | \`\"\"\` (empty) | unchanged, keeps empty |

The three geographic transport_* labels intentionally keep their empty-string emission — Java emits them empty on the same path (\`Util.formatTransport{Region,Zone,Subzone}\` with null peerInfo). Mirroring keeps the dashboards aligned across both clients.

## Test plan

- [x] New \`TestToOtelMetricAttrsAttemptLatencies2_EmptyLabelsFallback\` — pins a \`DEADLINE_EXCEEDED\`-shaped path (every location + transport field left zero-value) and asserts the full label map matches what Java would emit.
- [x] Existing \`TestToOtelMetricAttrsAttemptLatencies2\` unchanged (populated-labels case).
- [x] \`go test ./internal/metrics/ -count=1 -short\` clean.
- [x] \`go vet ./internal/metrics/\` clean.