### PR TITLE
fix(bigtable): translate ctx errors to gRPC status on session vRPC

### DIFF
--- a/bigtable/internal/transport/attempt_outcome.go
+++ b/bigtable/internal/transport/attempt_outcome.go
@@ -14,7 +14,12 @@
 
 package internal
 
-import "errors"
+import (
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
 
 // AttemptState classifies how far a single vRPC attempt progressed before
 // terminating. RetryingVRpc consumes this instead of raw gRPC codes so
@@ -72,6 +77,32 @@ type vrpcErr struct {
 
 func (e *vrpcErr) Error() string { return e.outcome.Err.Error() }
 func (e *vrpcErr) Unwrap() error { return e.outcome.Err }
+
+// GRPCStatus makes vrpcErr satisfy the grpc-go interface that
+// status.Code / status.FromError look for via errors.As. Without this,
+// tagged wrappers around stdlib ctx errors (context.DeadlineExceeded /
+// context.Canceled) would surface as codes.Unknown to callers reading
+// status.Code(err) — the classic gRPC unary path gets the translation
+// from grpc-go's client-side interceptor, but the session vRPC path
+// bypasses that interceptor and has to translate on its own.
+//
+// Preference order: an already-status error wins verbatim; otherwise
+// interpret stdlib ctx errors via status.FromContextError (returns
+// DeadlineExceeded / Canceled as appropriate); otherwise Unknown with
+// the underlying message. Unwrap() still yields the raw wrapped error
+// so errors.Is(err, context.DeadlineExceeded) etc. keep working.
+func (e *vrpcErr) GRPCStatus() *status.Status {
+	if e.outcome.Err == nil {
+		return status.New(codes.OK, "")
+	}
+	if s, ok := status.FromError(e.outcome.Err); ok {
+		return s
+	}
+	if s := status.FromContextError(e.outcome.Err); s.Code() != codes.Unknown {
+		return s
+	}
+	return status.New(codes.Unknown, e.outcome.Err.Error())
+}
 
 // tagErr wraps err with the given AttemptState. Returns nil for nil err so
 // call sites can compose without extra guards.

--- a/bigtable/internal/transport/attempt_outcome.go
+++ b/bigtable/internal/transport/attempt_outcome.go
@@ -78,23 +78,15 @@ type vrpcErr struct {
 func (e *vrpcErr) Error() string { return e.outcome.Err.Error() }
 func (e *vrpcErr) Unwrap() error { return e.outcome.Err }
 
-// GRPCStatus makes vrpcErr satisfy the grpc-go interface that
-// status.Code / status.FromError look for via errors.As. Without this,
-// tagged wrappers around stdlib ctx errors (context.DeadlineExceeded /
-// context.Canceled) would surface as codes.Unknown to callers reading
-// status.Code(err) — the classic gRPC unary path gets the translation
-// from grpc-go's client-side interceptor, but the session vRPC path
-// bypasses that interceptor and has to translate on its own.
+// GRPCStatus lets status.Code / status.FromError see through a tagged
+// wrapper. Needed because the session vRPC path is bidi and bypasses
+// grpc-go's client-side unary interceptor, which is where ctx.Err() →
+// gRPC status translation normally happens.
 //
-// Preference order: an already-status error wins verbatim; otherwise
-// interpret stdlib ctx errors via status.FromContextError (returns
-// DeadlineExceeded / Canceled as appropriate); otherwise Unknown with
-// the underlying message. Unwrap() still yields the raw wrapped error
-// so errors.Is(err, context.DeadlineExceeded) etc. keep working.
+// Preference: existing gRPC status wins verbatim; else translate via
+// status.FromContextError; else Unknown. Unwrap() is untouched so
+// errors.Is(err, context.DeadlineExceeded) still walks through.
 func (e *vrpcErr) GRPCStatus() *status.Status {
-	if e.outcome.Err == nil {
-		return status.New(codes.OK, "")
-	}
 	if s, ok := status.FromError(e.outcome.Err); ok {
 		return s
 	}
@@ -121,8 +113,10 @@ func tagErr(state AttemptState, err error) error {
 // fake Invoker must tag its errors the same way for the RetryingVRpc
 // interceptor's default classification to see them.
 //
-// Returns nil for nil err. Wraps unwrap()-transparently — errors.Is and
-// status.FromError continue to see the underlying err.
+// Returns nil for nil err. errors.Is sees the underlying err via
+// Unwrap. status.FromError returns the wrapper's gRPC status — an
+// existing status passes through, a stdlib ctx error is translated to
+// DeadlineExceeded / Canceled, anything else surfaces as Unknown.
 func TagErr(state AttemptState, err error) error { return tagErr(state, err) }
 
 // ClassifyErr returns the outcome for any error. Untagged errors fall

--- a/bigtable/internal/transport/attempt_outcome.go
+++ b/bigtable/internal/transport/attempt_outcome.go
@@ -77,18 +77,21 @@ type vrpcErr struct {
 func (e *vrpcErr) Error() string { return e.outcome.Err.Error() }
 func (e *vrpcErr) Unwrap() error { return e.outcome.Err }
 
-// GRPCStatus translates the wrapped error to a gRPC status. Session
-// vRPC bypasses grpc-go's unary client interceptor, so ctx.Err() →
-// gRPC status translation has to happen here or status.Code returns
-// Unknown. Unwrap() intentionally stays raw so errors.Is walks through.
-func (e *vrpcErr) GRPCStatus() *status.Status {
-	if s, ok := status.FromError(e.outcome.Err); ok {
+// GRPCStatus lets status.Code / status.FromError see through the tagged
+// wrapper. Session vRPC bypasses grpc-go's unary client interceptor —
+// the place where ctx.Err() → gRPC status translation normally happens
+// — so we do it here. Unwrap() stays raw so errors.Is walks through.
+func (e *vrpcErr) GRPCStatus() *status.Status { return statusOf(e.outcome.Err) }
+
+// statusOf returns err's gRPC status: existing status wins, else
+// stdlib ctx errors get translated to DeadlineExceeded / Canceled,
+// else Unknown-with-message. Shared by vrpcErr.GRPCStatus and the
+// pool's slow-op labelers so ctx-err → status logic lives in one place.
+func statusOf(err error) *status.Status {
+	if s, ok := status.FromError(err); ok {
 		return s
 	}
-	// FromContextError translates ctx errors to DeadlineExceeded /
-	// Canceled and falls back to Unknown-with-message for anything else,
-	// which is the fallback we want anyway.
-	return status.FromContextError(e.outcome.Err)
+	return status.FromContextError(err)
 }
 
 // tagErr wraps err with the given AttemptState. Returns nil for nil err so

--- a/bigtable/internal/transport/attempt_outcome.go
+++ b/bigtable/internal/transport/attempt_outcome.go
@@ -17,7 +17,6 @@ package internal
 import (
 	"errors"
 
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
@@ -86,10 +85,10 @@ func (e *vrpcErr) GRPCStatus() *status.Status {
 	if s, ok := status.FromError(e.outcome.Err); ok {
 		return s
 	}
-	if s := status.FromContextError(e.outcome.Err); s.Code() != codes.Unknown {
-		return s
-	}
-	return status.New(codes.Unknown, e.outcome.Err.Error())
+	// FromContextError translates ctx errors to DeadlineExceeded /
+	// Canceled and falls back to Unknown-with-message for anything else,
+	// which is the fallback we want anyway.
+	return status.FromContextError(e.outcome.Err)
 }
 
 // tagErr wraps err with the given AttemptState. Returns nil for nil err so

--- a/bigtable/internal/transport/attempt_outcome.go
+++ b/bigtable/internal/transport/attempt_outcome.go
@@ -78,14 +78,10 @@ type vrpcErr struct {
 func (e *vrpcErr) Error() string { return e.outcome.Err.Error() }
 func (e *vrpcErr) Unwrap() error { return e.outcome.Err }
 
-// GRPCStatus lets status.Code / status.FromError see through a tagged
-// wrapper. Needed because the session vRPC path is bidi and bypasses
-// grpc-go's client-side unary interceptor, which is where ctx.Err() →
-// gRPC status translation normally happens.
-//
-// Preference: existing gRPC status wins verbatim; else translate via
-// status.FromContextError; else Unknown. Unwrap() is untouched so
-// errors.Is(err, context.DeadlineExceeded) still walks through.
+// GRPCStatus translates the wrapped error to a gRPC status. Session
+// vRPC bypasses grpc-go's unary client interceptor, so ctx.Err() →
+// gRPC status translation has to happen here or status.Code returns
+// Unknown. Unwrap() intentionally stays raw so errors.Is walks through.
 func (e *vrpcErr) GRPCStatus() *status.Status {
 	if s, ok := status.FromError(e.outcome.Err); ok {
 		return s
@@ -113,10 +109,8 @@ func tagErr(state AttemptState, err error) error {
 // fake Invoker must tag its errors the same way for the RetryingVRpc
 // interceptor's default classification to see them.
 //
-// Returns nil for nil err. errors.Is sees the underlying err via
-// Unwrap. status.FromError returns the wrapper's gRPC status — an
-// existing status passes through, a stdlib ctx error is translated to
-// DeadlineExceeded / Canceled, anything else surfaces as Unknown.
+// Returns nil for nil err. Unwrap exposes the raw err (errors.Is walks
+// through); GRPCStatus returns the translated gRPC status.
 func TagErr(state AttemptState, err error) error { return tagErr(state, err) }
 
 // ClassifyErr returns the outcome for any error. Untagged errors fall

--- a/bigtable/internal/transport/attempt_outcome_test.go
+++ b/bigtable/internal/transport/attempt_outcome_test.go
@@ -15,9 +15,14 @@
 package internal
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestAttemptState_String(t *testing.T) {
@@ -102,5 +107,64 @@ func TestClassifyErr_FindsThroughWrapper(t *testing.T) {
 	out := ClassifyErr(outer)
 	if out.State != StateUncommitted {
 		t.Errorf("ClassifyErr(outer-wrapped).State = %v, want StateUncommitted", out.State)
+	}
+}
+
+// TestVRPCErr_GRPCStatus pins the three preference branches of
+// vrpcErr.GRPCStatus. This is the wrapper method that status.Code /
+// status.FromError find via errors.As — see the doc comment in
+// attempt_outcome.go for why translation lives on the wrapper.
+//
+// A wrapped-ctx case is included because real call sites (e.g.
+// session_vrpc.go:163 "send vRPC request: %w") produce that shape;
+// if a future grpc-go bump swaps FromContextError's errors.Is walk
+// for identity comparison the branch would silently regress to
+// Unknown and this test catches it.
+func TestVRPCErr_GRPCStatus(t *testing.T) {
+	tests := []struct {
+		name    string
+		inner   error
+		wantCode codes.Code
+		wantMsg  string // required substring in status message
+	}{
+		{
+			name:     "wrapped err already carries gRPC status wins verbatim",
+			inner:    status.Error(codes.FailedPrecondition, "table not ready"),
+			wantCode: codes.FailedPrecondition,
+			wantMsg:  "table not ready",
+		},
+		{
+			name:     "context.DeadlineExceeded translates to DeadlineExceeded",
+			inner:    context.DeadlineExceeded,
+			wantCode: codes.DeadlineExceeded,
+		},
+		{
+			name:     "context.Canceled translates to Canceled",
+			inner:    context.Canceled,
+			wantCode: codes.Canceled,
+		},
+		{
+			name:     "fmt.Errorf-wrapped ctx err still translates via errors.Is walk",
+			inner:    fmt.Errorf("send vRPC request: %w", context.DeadlineExceeded),
+			wantCode: codes.DeadlineExceeded,
+		},
+		{
+			name:     "plain non-status non-ctx err surfaces as Unknown",
+			inner:    errors.New("something else broke"),
+			wantCode: codes.Unknown,
+			wantMsg:  "something else broke",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &vrpcErr{outcome: AttemptOutcome{State: StateTransportFailure, Err: tt.inner}}
+			s := e.GRPCStatus()
+			if s.Code() != tt.wantCode {
+				t.Errorf("GRPCStatus().Code = %v, want %v", s.Code(), tt.wantCode)
+			}
+			if tt.wantMsg != "" && !strings.Contains(s.Message(), tt.wantMsg) {
+				t.Errorf("GRPCStatus().Message = %q, want to contain %q", s.Message(), tt.wantMsg)
+			}
+		})
 	}
 }

--- a/bigtable/internal/transport/attempt_outcome_test.go
+++ b/bigtable/internal/transport/attempt_outcome_test.go
@@ -116,8 +116,8 @@ func TestClassifyErr_FindsThroughWrapper(t *testing.T) {
 // silently regress that branch to Unknown.
 func TestVRPCErr_GRPCStatus(t *testing.T) {
 	tests := []struct {
-		name    string
-		inner   error
+		name     string
+		inner    error
 		wantCode codes.Code
 		wantMsg  string // required substring in status message
 	}{

--- a/bigtable/internal/transport/attempt_outcome_test.go
+++ b/bigtable/internal/transport/attempt_outcome_test.go
@@ -110,16 +110,10 @@ func TestClassifyErr_FindsThroughWrapper(t *testing.T) {
 	}
 }
 
-// TestVRPCErr_GRPCStatus pins the three preference branches of
-// vrpcErr.GRPCStatus. This is the wrapper method that status.Code /
-// status.FromError find via errors.As — see the doc comment in
-// attempt_outcome.go for why translation lives on the wrapper.
-//
-// A wrapped-ctx case is included because real call sites (e.g.
-// session_vrpc.go:163 "send vRPC request: %w") produce that shape;
-// if a future grpc-go bump swaps FromContextError's errors.Is walk
-// for identity comparison the branch would silently regress to
-// Unknown and this test catches it.
+// The fmt.Errorf-wrapped-ctx case is deliberate: real call sites wrap
+// ctx.Err in fmt.Errorf, and a future grpc-go bump swapping
+// FromContextError's errors.Is walk for identity comparison would
+// silently regress that branch to Unknown.
 func TestVRPCErr_GRPCStatus(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/bigtable/internal/transport/session_pool.go
+++ b/bigtable/internal/transport/session_pool.go
@@ -597,17 +597,7 @@ func (p *SessionPoolImpl) Invoke(ctx context.Context, desc VRpcDescriptor, req i
 		ev.Peer = peerInfoToSnapshot(sh.session.PeerInfo())
 		ev.RemoteAddr = sh.session.RemoteAddr()
 		if invokeErr != nil {
-			// stdlib context errors don't implement GRPCStatus, so
-			// status.Code returns Unknown — classify explicitly so
-			// deadline/cancel rows label correctly.
-			switch {
-			case errors.Is(invokeErr, context.DeadlineExceeded):
-				ev.ErrCode = "DeadlineExceeded"
-			case errors.Is(invokeErr, context.Canceled):
-				ev.ErrCode = "Canceled"
-			default:
-				ev.ErrCode = status.Code(invokeErr).String()
-			}
+			ev.ErrCode = status.Code(invokeErr).String()
 			btopt.Debugf(nil, "POOL %s slow vRPC failed method=%s session=%s rpc_id=%d code=%s latency=%v session_age=%v backend=%v raw_err=%v",
 				p.poolName, ev.Method, ev.Session, ev.RPCIDOnSession, ev.ErrCode, ev.Latency, ev.SessionAge, ev.BackendLatency, invokeErr)
 		}

--- a/bigtable/internal/transport/session_pool.go
+++ b/bigtable/internal/transport/session_pool.go
@@ -597,7 +597,7 @@ func (p *SessionPoolImpl) Invoke(ctx context.Context, desc VRpcDescriptor, req i
 		ev.Peer = peerInfoToSnapshot(sh.session.PeerInfo())
 		ev.RemoteAddr = sh.session.RemoteAddr()
 		if invokeErr != nil {
-			ev.ErrCode = status.Code(invokeErr).String()
+			ev.ErrCode = statusOf(invokeErr).Code().String()
 			btopt.Debugf(nil, "POOL %s slow vRPC failed method=%s session=%s rpc_id=%d code=%s latency=%v session_age=%v backend=%v raw_err=%v",
 				p.poolName, ev.Method, ev.Session, ev.RPCIDOnSession, ev.ErrCode, ev.Latency, ev.SessionAge, ev.BackendLatency, invokeErr)
 		}

--- a/bigtable/internal/transport/session_pool_debug.go
+++ b/bigtable/internal/transport/session_pool_debug.go
@@ -19,15 +19,12 @@
 package internal
 
 import (
-	"context"
-	"errors"
 	"math/bits"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	btopt "cloud.google.com/go/bigtable/internal/option"
-	"google.golang.org/grpc/status"
 )
 
 // poolMetrics owns every observability-only field for SessionPoolImpl:
@@ -333,14 +330,7 @@ func (p *SessionPoolImpl) recordCheckoutFailure(checkoutStart time.Time, desc VR
 		Latency:  poolWait,
 		PoolWait: poolWait,
 	}
-	switch {
-	case errors.Is(err, context.DeadlineExceeded):
-		ev.ErrCode = "DeadlineExceeded"
-	case errors.Is(err, context.Canceled):
-		ev.ErrCode = "Canceled"
-	default:
-		ev.ErrCode = status.Code(err).String()
-	}
+	ev.ErrCode = statusOf(err).Code().String()
 	btopt.Debugf(nil, "POOL %s slow checkout failed method=%s pool_wait=%v code=%s raw_err=%v",
 		p.poolName, ev.Method, poolWait, ev.ErrCode, err)
 	p.recordSlowVRpc(ev)

--- a/bigtable/internal/transport/session_vrpc_test.go
+++ b/bigtable/internal/transport/session_vrpc_test.go
@@ -373,6 +373,14 @@ func TestHandleVRPCResponse_LateResponseAfterCtxDone_FlagsCancelledDrained(t *te
 		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatalf("Invoke err = %v, want DeadlineExceeded", err)
 		}
+		// Also pins the gRPC status code — awaitInvokeResult must
+		// translate ctx.Err() to a status.Error(DeadlineExceeded, ...)
+		// so callers reading status.Code(err) get the right code
+		// after fmt.Errorf(...:%w) wraps at the dispatch layer.
+		// Without translation, status.Code returns Unknown.
+		if code := status.Code(err); code != codes.DeadlineExceeded {
+			t.Errorf("status.Code(err) = %v, want DeadlineExceeded (ctx.Err() must be translated to a gRPC status before wrap)", code)
+		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Invoke did not return within outer bound")
 	}
@@ -462,6 +470,9 @@ func TestInvoke_SecondInvokeAfterCtxDoneRejectedUncommitted(t *testing.T) {
 	case err := <-done1:
 		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatalf("Invoke #1 err = %v, want DeadlineExceeded", err)
+		}
+		if code := status.Code(err); code != codes.DeadlineExceeded {
+			t.Errorf("Invoke #1 status.Code = %v, want DeadlineExceeded", code)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Invoke #1 did not return within outer bound")

--- a/bigtable/internal/transport/session_vrpc_test.go
+++ b/bigtable/internal/transport/session_vrpc_test.go
@@ -373,13 +373,8 @@ func TestHandleVRPCResponse_LateResponseAfterCtxDone_FlagsCancelledDrained(t *te
 		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatalf("Invoke err = %v, want DeadlineExceeded", err)
 		}
-		// Also pins the gRPC status code — awaitInvokeResult must
-		// translate ctx.Err() to a status.Error(DeadlineExceeded, ...)
-		// so callers reading status.Code(err) get the right code
-		// after fmt.Errorf(...:%w) wraps at the dispatch layer.
-		// Without translation, status.Code returns Unknown.
 		if code := status.Code(err); code != codes.DeadlineExceeded {
-			t.Errorf("status.Code(err) = %v, want DeadlineExceeded (ctx.Err() must be translated to a gRPC status before wrap)", code)
+			t.Errorf("status.Code(err) = %v, want DeadlineExceeded", code)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Invoke did not return within outer bound")


### PR DESCRIPTION
## Summary

`awaitInvokeResult`'s `ctx.Done` branch (`bigtable/internal/transport/session_vrpc.go:242`) wraps `ctx.Err()` in `tagErr(...)` → `*vrpcErr`. Neither `context.DeadlineExceeded` nor `*vrpcErr` implemented `GRPCStatus()`, so `status.Code(err)` on the returned error surfaced as `codes.Unknown` even when the actual cause was a client-side deadline or cancellation.

Observable symptom: a tight-deadline probe against real Bigtable (10ms per-RPC ctx, `CBT_FORCE_SESSION=true`) produced errors that read `session ReadRow vRPC: context deadline exceeded` — but `status.Code(err)` reported `UNKNOWN`, misleading any consumer keying off the gRPC code (retry classifiers, dashboards, log labels).

The classic gRPC unary path never hits this: grpc-go's client-side interceptor auto-translates `ctx.Err()` to a `*status.Status` before returning. The session vRPC path is a bidi stream with hand-managed request routing and bypasses that interceptor, so the translation has to happen in-package.

## The fix

Add `GRPCStatus()` to `*vrpcErr` in `attempt_outcome.go`:

- Preserves an existing gRPC status if the wrapped error already carries one.
- Otherwise runs `status.FromContextError(...)` — translates `context.DeadlineExceeded` → `DeadlineExceeded`, `context.Canceled` → `Canceled`.
- Falls back to `Unknown` with the underlying message.

Placed on `*vrpcErr` (not at the specific call site) because every ctx-cancel error path in the transport package flows through `tagErr` → `*vrpcErr`, and this also covers the `sendErr` path at `session_vrpc.go:163` if a synchronous send ever surfaces a ctx-based error.

`Unwrap()` is untouched, so `errors.Is(err, context.DeadlineExceeded)` at `session_pool.go:604` and `session_pool_debug.go:337` keeps working.

## Test plan

- [x] Extended the two existing ctx-deadline tests in `session_vrpc_test.go` (`TestHandleVRPCResponse_LateResponseAfterCtxDone_FlagsCancelledDrained`, `TestInvoke_SecondInvokeAfterCtxDoneRejectedUncommitted`) with `status.Code == DeadlineExceeded` assertions alongside the existing `errors.Is` checks.
- [x] Verified both FAIL on `main` (`status.Code(err) = Unknown, want DeadlineExceeded`) and PASS with this change.
- [x] `go test ./internal/transport/ -count=1 -short -timeout=180s` — all green (21s).
- [x] `go vet ./internal/transport/` — clean.