### PR TITLE
refactor(bigtable): drop min/max args from NewSessionPoolImpl

### DIFF
--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -702,12 +702,9 @@ func (sc *sessionClient) getOrCreateSessionPool(
 	// it in the human-readable label because (resource, permission)
 	// already uniquely identifies the pool.
 	poolName := key.displayName()
-	// Pool bounds start at 0; NewSessionPoolImpl falls back to
-	// defaultPoolConfig() and ClientConfigurationManager overrides on
-	// first UpdateConfig with server-driven values.
 	pool := btransport.NewSessionPoolImpl(
 		id,
-		poolName, 0, 0, streamFactory, openSessionRequest, md, sessionType,
+		poolName, streamFactory, openSessionRequest, md, sessionType,
 		sc.enableDebug,
 	)
 	mp := &managedSessionPool{pool: pool}

--- a/bigtable/internal/session/client_test.go
+++ b/bigtable/internal/session/client_test.go
@@ -506,7 +506,7 @@ func TestReleaseSessionPool_RemovesEntryAndInvokesUnregister(t *testing.T) {
 	sc := newTestClient(t, &fakeChannelPool{}, Config{})
 	key := poolKey{"table:foo", permissionRead}
 	pool := btransport.NewSessionPoolImpl(
-		1, "test-pool", 0, 0,
+		1, "test-pool",
 		func(ctx context.Context) (btransport.Stream, error) { return nil, errors.New("test never dials") },
 		&btpb.OpenSessionRequest{}, nil,
 		btransport.SessionTypeTable, false,

--- a/bigtable/internal/transport/session_pool.go
+++ b/bigtable/internal/transport/session_pool.go
@@ -197,11 +197,14 @@ func (p *SessionPoolImpl) noteVRpcOutcome(sh *SessionHandle, e2e, backend time.D
 // the pool that owns each session.
 //
 // The sizer/picker/budget/threshold are bootstrapped from the default
-// ClientConfiguration proto (default_client_config.go). Every real
-// caller registers via ClientConfigurationManager, which fires
+// ClientConfiguration proto (default_client_config.go). Production
+// callers register via ClientConfigurationManager, which fires
 // UpdateConfig synchronously and replaces these with server-driven
-// values before the pool serves traffic — so callers that want custom
-// bounds should call pool.UpdateConfig(...) right after construction.
+// values before the pool serves traffic. Callers that want custom
+// bounds without going through a manager (tests) should call
+// pool.UpdateConfig(...) right after construction; a pool that
+// never sees an UpdateConfig will serve traffic with the
+// defaultPoolConfig() values (currently 5/400).
 func NewSessionPoolImpl(id uint64, poolName string, streamFactory func(ctx context.Context) (Stream, error), openSessionRequest *spb.OpenSessionRequest, md metadata.MD, sessionType SessionType, debugEnabled bool) *SessionPoolImpl {
 	poolCtx, poolCancel := context.WithCancel(context.Background())
 	pool := &SessionPoolImpl{

--- a/bigtable/internal/transport/session_pool.go
+++ b/bigtable/internal/transport/session_pool.go
@@ -195,7 +195,14 @@ func (p *SessionPoolImpl) noteVRpcOutcome(sh *SessionHandle, e2e, backend time.D
 // NewSessionPoolImpl creates a new SessionPoolImpl. id is baked into
 // every session log name so channelz/sessionz can reverse-link back to
 // the pool that owns each session.
-func NewSessionPoolImpl(id uint64, poolName string, min, max int, streamFactory func(ctx context.Context) (Stream, error), openSessionRequest *spb.OpenSessionRequest, md metadata.MD, sessionType SessionType, debugEnabled bool) *SessionPoolImpl {
+//
+// The sizer/picker/budget/threshold are bootstrapped from the default
+// ClientConfiguration proto (default_client_config.go). Every real
+// caller registers via ClientConfigurationManager, which fires
+// UpdateConfig synchronously and replaces these with server-driven
+// values before the pool serves traffic — so callers that want custom
+// bounds should call pool.UpdateConfig(...) right after construction.
+func NewSessionPoolImpl(id uint64, poolName string, streamFactory func(ctx context.Context) (Stream, error), openSessionRequest *spb.OpenSessionRequest, md metadata.MD, sessionType SessionType, debugEnabled bool) *SessionPoolImpl {
 	poolCtx, poolCancel := context.WithCancel(context.Background())
 	pool := &SessionPoolImpl{
 		poolName:           poolName,
@@ -213,25 +220,9 @@ func NewSessionPoolImpl(id uint64, poolName string, min, max int, streamFactory 
 	}
 	pool.m.afePickCounts = make(map[AfeID]int64)
 
-	// Bootstrap sizer/picker/budget/threshold from the default
-	// ClientConfiguration proto (default_client_config.go). Fallback
-	// values live in one place instead of as literals scattered here.
-	// Every real caller registers via ClientConfigurationManager, which
-	// fires UpdateConfig synchronously and replaces these with
-	// server-driven values before the pool serves traffic.
 	defaultCfg := defaultPoolConfig()
-	// min/max <= 0 fall back to the same proto defaults the rest of the
-	// bootstrap reads from — otherwise a caller that instantiated the
-	// pool with zero bounds would see the sizer clamp DesiredCapacity to
-	// 0 and never open a session before UpdateConfig arrives.
-	if min <= 0 {
-		min = int(defaultCfg.GetMinSessionCount())
-	}
-	if max <= 0 {
-		max = int(defaultCfg.GetMaxSessionCount())
-	}
 	fetcher := func() *PoolStats { return pool.Stats() }
-	pool.sizer = NewPoolSizer(fetcher, min, max, float64(defaultCfg.GetHeadroom()))
+	pool.sizer = NewPoolSizer(fetcher, int(defaultCfg.GetMinSessionCount()), int(defaultCfg.GetMaxSessionCount()), float64(defaultCfg.GetHeadroom()))
 	pool.picker = pickerFromLoadBalancing(defaultCfg.GetLoadBalancingOptions(), pool.debugEnabled)
 	pool.budget = NewAdaptiveSessionThrottler(
 		int(defaultCfg.GetNewSessionCreationBudget()),

--- a/bigtable/internal/transport/session_pool_debug_disabled_test.go
+++ b/bigtable/internal/transport/session_pool_debug_disabled_test.go
@@ -38,10 +38,13 @@ func TestSessionPool_DebugDisabled_NoRecorderState(t *testing.T) {
 	}
 	p := NewSessionPoolImpl(
 		uint64(1),
-		"test-pool-nodebug", 0, 1, neverDialing,
+		"test-pool-nodebug", neverDialing,
 		&spb.OpenSessionRequest{ProtocolVersion: 1}, nil, SessionTypeTable,
 		false, // debugEnabled — the contract under test
 	)
+	p.sizer.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
+		MinSessionCount: 0, MaxSessionCount: 1,
+	})
 	defer p.Close()
 
 	// Exercise the recorder call sites via direct calls. The pool

--- a/bigtable/internal/transport/session_pool_debug_disabled_test.go
+++ b/bigtable/internal/transport/session_pool_debug_disabled_test.go
@@ -42,7 +42,7 @@ func TestSessionPool_DebugDisabled_NoRecorderState(t *testing.T) {
 		&spb.OpenSessionRequest{ProtocolVersion: 1}, nil, SessionTypeTable,
 		false, // debugEnabled — the contract under test
 	)
-	p.sizer.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
+	p.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
 		MinSessionCount: 0, MaxSessionCount: 1,
 	})
 	defer p.Close()

--- a/bigtable/internal/transport/session_pool_scaling_test.go
+++ b/bigtable/internal/transport/session_pool_scaling_test.go
@@ -228,9 +228,12 @@ func TestTick_CreateSessionPanic_PoolSurvives(t *testing.T) {
 		panic("simulated streamFactory panic")
 	}
 	p := NewSessionPoolImpl(
-		uint64(1), "test-panic-pool", 1, 10, panicFactory,
+		uint64(1), "test-panic-pool", panicFactory,
 		&spb.OpenSessionRequest{ProtocolVersion: 1}, nil, SessionTypeTable, true,
 	)
+	p.sizer.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
+		MinSessionCount: 1, MaxSessionCount: 10,
+	})
 	t.Cleanup(func() { _ = p.Close() })
 
 	// Tick spawns a createSession goroutine; the factory panics inside

--- a/bigtable/internal/transport/session_pool_scaling_test.go
+++ b/bigtable/internal/transport/session_pool_scaling_test.go
@@ -231,7 +231,7 @@ func TestTick_CreateSessionPanic_PoolSurvives(t *testing.T) {
 		uint64(1), "test-panic-pool", panicFactory,
 		&spb.OpenSessionRequest{ProtocolVersion: 1}, nil, SessionTypeTable, true,
 	)
-	p.sizer.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
+	p.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
 		MinSessionCount: 1, MaxSessionCount: 10,
 	})
 	t.Cleanup(func() { _ = p.Close() })

--- a/bigtable/internal/transport/session_pool_test.go
+++ b/bigtable/internal/transport/session_pool_test.go
@@ -128,7 +128,7 @@ func newTestPool(t testing.TB, min, max int) *SessionPoolImpl {
 		nil,
 		SessionTypeTable, true,
 	)
-	p.sizer.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
+	p.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
 		MinSessionCount: int32(min), MaxSessionCount: int32(max),
 	})
 	// Close streams before closing the pool: the pool's Close waits for
@@ -248,7 +248,7 @@ func TestSessionPool_Invoke_RecordsSlowCheckoutFailure(t *testing.T) {
 		nil,
 		SessionTypeTable, true,
 	)
-	p.sizer.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
+	p.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
 		MinSessionCount: 0, MaxSessionCount: 1,
 	})
 	defer p.Close()
@@ -311,7 +311,7 @@ func TestCheckoutSession_ParkedWaiter_DeadlineExceeded(t *testing.T) {
 		nil,
 		SessionTypeTable, true,
 	)
-	p.sizer.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
+	p.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
 		MinSessionCount: 0, MaxSessionCount: 1,
 	})
 	defer p.Close()
@@ -652,9 +652,11 @@ func TestUpdateConfig_SwapsPickerAndBounds(t *testing.T) {
 	if got := p.picker.Name(); got != "least-latency" {
 		t.Errorf("after PeakEwma swap, picker = %q, want least-latency", got)
 	}
-	// listenerFires counter bumps once per UpdateConfig.
-	if got := p.m.listenerFires.Load(); got != 2 {
-		t.Errorf("listenerFires = %d, want 2 (one per UpdateConfig)", got)
+	// listenerFires counter bumps once per UpdateConfig. Expect 3:
+	// one from newTestPool's bootstrap UpdateConfig plus the two in
+	// this test body.
+	if got := p.m.listenerFires.Load(); got != 3 {
+		t.Errorf("listenerFires = %d, want 3 (one per UpdateConfig)", got)
 	}
 }
 

--- a/bigtable/internal/transport/session_pool_test.go
+++ b/bigtable/internal/transport/session_pool_test.go
@@ -123,13 +123,14 @@ func newTestPool(t testing.TB, min, max int) *SessionPoolImpl {
 	p := NewSessionPoolImpl(
 		uint64(1),
 		"test-pool",
-		min,
-		max,
 		factory,
 		&spb.OpenSessionRequest{ProtocolVersion: 1},
 		nil,
 		SessionTypeTable, true,
 	)
+	p.sizer.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
+		MinSessionCount: int32(min), MaxSessionCount: int32(max),
+	})
 	// Close streams before closing the pool: the pool's Close waits for
 	// per-session teardown, which requires the readLoop goroutines to
 	// exit — and they won't while parked on fakeStream.Recv.
@@ -242,12 +243,14 @@ func TestSessionPool_Invoke_RecordsSlowCheckoutFailure(t *testing.T) {
 	p := NewSessionPoolImpl(
 		uint64(1),
 		"test-pool",
-		0, 1,
 		neverDialing,
 		&spb.OpenSessionRequest{ProtocolVersion: 1},
 		nil,
 		SessionTypeTable, true,
 	)
+	p.sizer.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
+		MinSessionCount: 0, MaxSessionCount: 1,
+	})
 	defer p.Close()
 
 	// 50ms ctx budget vs the 10ms defaultSlowThreshold means the checkout
@@ -303,12 +306,14 @@ func TestCheckoutSession_ParkedWaiter_DeadlineExceeded(t *testing.T) {
 	p := NewSessionPoolImpl(
 		uint64(1),
 		"test-pool",
-		0, 1,
 		neverDialing,
 		&spb.OpenSessionRequest{ProtocolVersion: 1},
 		nil,
 		SessionTypeTable, true,
 	)
+	p.sizer.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
+		MinSessionCount: 0, MaxSessionCount: 1,
+	})
 	defer p.Close()
 
 	// Short deadline so the test doesn't loiter, long enough that the
@@ -447,7 +452,7 @@ func TestNewSessionPoolImpl_Identity(t *testing.T) {
 
 	p := NewSessionPoolImpl(
 		uint64(42),
-		"test-pool", 1, 10, factory, &spb.OpenSessionRequest{ProtocolVersion: 1}, nil, SessionTypeTable, true,
+		"test-pool", factory, &spb.OpenSessionRequest{ProtocolVersion: 1}, nil, SessionTypeTable, true,
 	)
 	if p.poolID != 42 {
 		t.Errorf("poolID = %d, want 42", p.poolID)

--- a/bigtable/internal/transport/session_snapshot_test.go
+++ b/bigtable/internal/transport/session_snapshot_test.go
@@ -130,8 +130,11 @@ func TestSessionHandle_Snapshot(t *testing.T) {
 func TestPoolSnapshot_AggregatesSessions(t *testing.T) {
 	pool := NewSessionPoolImpl(
 		uint64(1),
-		"test:read", 1, 5, nil, nil, nil, SessionTypeTable, true,
+		"test:read", nil, nil, nil, SessionTypeTable, true,
 	)
+	pool.sizer.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
+		MinSessionCount: 1, MaxSessionCount: 5,
+	})
 
 	// Two active sessions, one with traffic.
 	handles := make([]*SessionHandle, 0, 2)

--- a/bigtable/internal/transport/session_snapshot_test.go
+++ b/bigtable/internal/transport/session_snapshot_test.go
@@ -132,7 +132,7 @@ func TestPoolSnapshot_AggregatesSessions(t *testing.T) {
 		uint64(1),
 		"test:read", nil, nil, nil, SessionTypeTable, true,
 	)
-	pool.sizer.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
+	pool.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
 		MinSessionCount: 1, MaxSessionCount: 5,
 	})
 


### PR DESCRIPTION
## Summary

The production caller of \`NewSessionPoolImpl\` at \`session/client.go:708\` passed \`0, 0\` and relied on the constructor's fallback path that bootstraps from \`defaultPoolConfig()\`. The only other callers were tests. The fallback branches were dead weight and the \`min, max int\` arguments were misleading — every real caller registers with \`ClientConfigurationManager\`, which \`UpdateConfig\`-overwrites the sizer's min/max with server-driven values before the pool serves traffic.

## Change

- \`NewSessionPoolImpl\` signature loses \`(min, max int)\`. Now always bootstraps the sizer from \`defaultPoolConfig()\`.
- Tests that need custom sizer bounds call \`pool.sizer.UpdateConfig(...)\` right after construction — the same path \`ClientConfigurationManager\` uses in production.
- The constructor doc comment now spells out the \"callers register via \`ClientConfigurationManager\` which replaces these\" contract, so future readers know where to put custom bounds.

## Test plan

- [x] \`go build ./...\` — clean.
- [x] \`go test ./internal/transport/ ./internal/session/ -count=1 -short -timeout=180s\` — green (37s / instant).
- [x] \`go vet ./internal/transport/ ./internal/session/\` — clean.
- [x] \`goimports -l ./internal/{transport,session}/\` — clean.

Behavior-preserving refactor. No production runtime change: the production caller already got \`defaultPoolConfig()\` bootstrap values by passing \`0, 0\`. Test bounds now come via \`UpdateConfig\` right after construction, which is what happens in production anyway.