### PR TITLE
fix(bigtable): translate ctx.Err() to gRPC status in CheckoutSession

### DIFF
--- a/bigtable/internal/transport/session_pool.go
+++ b/bigtable/internal/transport/session_pool.go
@@ -305,7 +305,12 @@ func (p *SessionPoolImpl) CheckoutSession(ctx context.Context) (*SessionHandle, 
 			// Remove from queue so a subsequent free-session wake
 			// doesn't burn on a caller that's already given up.
 			p.removeWaiter(w)
-			return nil, fmt.Errorf("%w: %w", ErrNoSessionsAvailable, ctx.Err())
+			// tagErr wraps ctx.Err() in *vrpcErr, which implements
+			// GRPCStatus — otherwise status.Code(err) returns Unknown
+			// instead of DeadlineExceeded / Canceled and any consumer
+			// keying off the gRPC code (metrics, retry classifiers,
+			// dashboards) misclassifies the attempt.
+			return nil, fmt.Errorf("%w: %w", ErrNoSessionsAvailable, tagErr(StateUncommitted, ctx.Err()))
 		case <-w.ready:
 			p.waitersCount.Add(-1)
 			// A poisoned wake (drainWaitersWithErr) sets w.err before

--- a/bigtable/internal/transport/session_pool_test.go
+++ b/bigtable/internal/transport/session_pool_test.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // newStubStreamFactory returns a streamFactory that hands out fresh
@@ -358,6 +360,14 @@ func TestCheckoutSession_ParkedWaiter_DeadlineExceeded(t *testing.T) {
 	}
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("err = %v (type %T), want unwrappable to context.DeadlineExceeded (was the ctx cause dropped?)", err, err)
+	}
+	// Also pin status.Code — the ctx.Err() must be wrapped through
+	// *vrpcErr's GRPCStatus so callers reading status.Code(err) get
+	// DeadlineExceeded instead of Unknown. Load tests against real
+	// Bigtable showed 99% of tight-deadline checkout-timeouts
+	// misclassified as Unknown before this wrap landed.
+	if code := status.Code(err); code != codes.DeadlineExceeded {
+		t.Errorf("status.Code(err) = %v, want DeadlineExceeded (ctx.Err() must go through *vrpcErr.GRPCStatus)", code)
 	}
 	// Positive proof we parked (independent of timing).
 	select {


### PR DESCRIPTION
## Summary

Complement to #20299 (which fixed the vRPC ctx-cancel path via \`*vrpcErr.GRPCStatus\`). \`CheckoutSession\` has its own ctx-cancel path at \`session_pool.go:297\` for waiters that time out parked on the FIFO queue when the pool is exhausted. The return there wrapped \`ctx.Err()\` via \`fmt.Errorf("%w: %w", ErrNoSessionsAvailable, ctx.Err())\` — neither branch of the wrap implemented \`GRPCStatus\`, so \`status.Code(err)\` returned \`codes.Unknown\`.

## Empirical impact

A 5-minute tight-deadline load probe against \`sushanb-cache\` (32 workers, 3ms per-RPC deadline, 2.8M attempts) showed:

- \`DeadlineExceeded\` = 29,546 (**1.04%**) — the attempts that actually reached \`awaitInvokeResult\` and hit the #20299 wrap path
- \`Unknown\` = 2,806,578 (**98.96%**) — attempts that deadlined in the checkout waiter queue under load and bypassed the vRPC wrap entirely

Only ~1% of ctx-cancel errors carried the correct gRPC code. Cloud Monitoring's \`bigtable/attempt_latencies{status=\"...\"}\` label was misattributed for the vast majority of deadline-under-load attempts.

## Fix

Route the returned \`ctx.Err()\` through \`tagErr(StateUncommitted, ...)\` — same shape #20299 used for the vRPC-side path. \`*vrpcErr\`'s \`GRPCStatus\` method translates the ctx sentinel to \`DeadlineExceeded\` / \`Canceled\`. \`Unwrap\` chain is untouched so \`errors.Is(err, context.DeadlineExceeded)\` and \`errors.Is(err, ErrNoSessionsAvailable)\` both keep working.

Tagged \`StateUncommitted\` because a \`CheckoutSession\` timeout means no session was ever contacted — server saw nothing, safe to retry unconditionally per the \`AttemptState\` semantics.

## Test plan

- [x] Extended \`TestCheckoutSession_ParkedWaiter_DeadlineExceeded\` in \`session_pool_test.go\` with a \`status.Code\` assertion.
- [x] Verified FAIL on \`main\` (\`status.Code(err) = Unknown, want DeadlineExceeded\`) and PASS with this change.
- [x] \`go test ./internal/transport/ ./internal/session/ -count=1 -short -timeout=180s\` — all green (28s / instant).

## Follow-ups (not in this PR)

Four other sites still return raw \`ctx.Err()\`. Audit for whether they surface to callers:

- \`session_throttler.go:107\` — throttler wait
- \`session_lifecycle.go:210\` — session-close wait
- \`connpool.go:1132\` — prime backoff
- \`client_configuration_manager.go:506\` — config poll wait