### PR TITLE
feat(bigtable/accelerator): add resource manager for session handles

### DIFF
--- a/bigtable/internal/accelerator/resourcemanager/resource_manager.go
+++ b/bigtable/internal/accelerator/resourcemanager/resource_manager.go
@@ -16,7 +16,6 @@ package resourcemanager
 
 import (
 	"context"
-	"strings"
 
 	"cloud.google.com/go/bigtable/internal/session"
 	"google.golang.org/api/option"
@@ -37,7 +36,7 @@ var newSessionClient SessionClientFactory = func(
 	project, instance, appProfile string,
 	opts ...option.ClientOption,
 ) (session.Client, error) {
-	return session.NewClient(ctx, project, instance, appProfile, nil, opts...)
+	return session.NewClient(ctx, project, instance, appProfile, nil, nil, opts...)
 }
 
 // TestHookSessionClient swaps the session Client factory used by New for the
@@ -83,50 +82,51 @@ func New(
 // room to reintroduce pooling later without touching callers.
 func noopRelease() {}
 
-// GetSessionTable returns a session.TableAPI for the table named by resource.
+// GetSessionTable returns a session.TableAPI for the table identified by
+// tableID (the leaf segment of a "projects/P/instances/I/tables/T" name).
 //
-// Wire format note: V2 RPCs carry a full table resource name
-// ("projects/P/instances/I/tables/T"). session.Client.OpenTable prepends the
-// project/instance/tables/ prefix itself, so ResourceManager hands it just
-// the leaf segment.
+// The caller (the Channel) is responsible for validating the full V2 resource
+// name against the daemon's own (project, instance) scope and passing the leaf
+// through: session.Client.OpenTable re-prefixes the leaf with the client's own
+// project/instance, so a name from a different tenant must be rejected before
+// it reaches here, not silently rebound.
 //
 // method is accepted for call-site clarity ("ReadRow" / "MutateRow") but does
 // not affect which handle is returned: OpenTable vends a single handle that
 // routes reads and writes to their respective pools internally. The returned
 // release thunk is a no-op.
-func (rm *ResourceManager) GetSessionTable(resource, method string) (session.TableAPI, func(), error) {
-	return rm.sc.OpenTable(resourceLeaf(resource)), noopRelease, nil
+func (rm *ResourceManager) GetSessionTable(tableID, method string) (session.TableAPI, func(), error) {
+	return rm.sc.OpenTable(tableID), noopRelease, nil
 }
 
 // GetSessionAuthorizedView returns a session.TableAPI for the authorized view
-// named by resource.
+// identified by the tableID and viewID leaf segments of a
+// "projects/P/instances/I/tables/T/authorizedViews/V" name.
 //
-// Wire format note: V2 RPCs carry a full authorized-view resource name
-// ("projects/P/instances/I/tables/T/authorizedViews/V").
-// session.Client.OpenAuthorizedView takes the table and view leaf segments and
-// composes the full name itself, so ResourceManager splits them out here.
+// As with GetSessionTable, the caller validates the full name against the
+// daemon's scope and resolves the leaves; session.Client.OpenAuthorizedView
+// re-prefixes them with the client's own project/instance.
 //
 // method is accepted for call-site clarity ("ReadRow" / "MutateRow") and, as
 // with GetSessionTable, does not affect which handle is returned. The returned
 // release thunk is a no-op.
-func (rm *ResourceManager) GetSessionAuthorizedView(resource, method string) (session.TableAPI, func(), error) {
-	table, view := authorizedViewLeaves(resource)
-	return rm.sc.OpenAuthorizedView(table, view), noopRelease, nil
+func (rm *ResourceManager) GetSessionAuthorizedView(tableID, viewID, method string) (session.TableAPI, func(), error) {
+	return rm.sc.OpenAuthorizedView(tableID, viewID), noopRelease, nil
 }
 
 // GetSessionMaterializedView returns a read-only session.TableAPI for the
-// materialized view named by resource.
+// materialized view identified by viewID (the leaf segment of a
+// "projects/P/instances/I/materializedViews/V" name).
 //
-// Wire format note: V2 RPCs carry a full materialized-view resource name
-// ("projects/P/instances/I/materializedViews/V").
-// session.Client.OpenMaterializedView takes the view leaf segment and composes
-// the full name itself. Materialized views are read-only; MutateRow on the
-// returned handle errors.
+// As with GetSessionTable, the caller validates the full name against the
+// daemon's scope and resolves the leaf; session.Client.OpenMaterializedView
+// re-prefixes it with the client's own project/instance. Materialized views
+// are read-only; MutateRow on the returned handle errors.
 //
 // method is accepted for call-site clarity; see GetSessionTable. The returned
 // release thunk is a no-op.
-func (rm *ResourceManager) GetSessionMaterializedView(resource, method string) (session.TableAPI, func(), error) {
-	return rm.sc.OpenMaterializedView(resourceLeaf(resource)), noopRelease, nil
+func (rm *ResourceManager) GetSessionMaterializedView(viewID, method string) (session.TableAPI, func(), error) {
+	return rm.sc.OpenMaterializedView(viewID), noopRelease, nil
 }
 
 // Close closes the underlying session Client, tearing down its pools. Handles
@@ -136,28 +136,4 @@ func (rm *ResourceManager) Close() error {
 		return rm.sc.Close()
 	}
 	return nil
-}
-
-// resourceLeaf extracts the last path segment from a full resource name — e.g.
-// "T" from "projects/P/instances/I/tables/T", or "V" from
-// "projects/P/instances/I/materializedViews/V". Returns the input unchanged if
-// it does not contain a "/" — best-effort.
-func resourceLeaf(fullName string) string {
-	if i := strings.LastIndex(fullName, "/"); i >= 0 {
-		return fullName[i+1:]
-	}
-	return fullName
-}
-
-// authorizedViewLeaves splits a full authorized-view resource name
-// ("projects/P/instances/I/tables/T/authorizedViews/V") into its table ("T")
-// and view ("V") leaf segments, which is what session.Client.OpenAuthorizedView
-// expects. Best-effort: if the "/authorizedViews/" marker is absent, the whole
-// input is treated as the view leaf and table is returned empty.
-func authorizedViewLeaves(fullName string) (table, view string) {
-	const marker = "/authorizedViews/"
-	if i := strings.Index(fullName, marker); i >= 0 {
-		return resourceLeaf(fullName[:i]), resourceLeaf(fullName[i+len(marker):])
-	}
-	return "", resourceLeaf(fullName)
 }

--- a/bigtable/internal/accelerator/resourcemanager/resource_manager.go
+++ b/bigtable/internal/accelerator/resourcemanager/resource_manager.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcemanager
+
+import (
+	"context"
+	"strings"
+
+	"cloud.google.com/go/bigtable/internal/session"
+	"google.golang.org/api/option"
+)
+
+// SessionClientFactory constructs the underlying session Client for a
+// ResourceManager. The default factory wraps session.NewClient.
+type SessionClientFactory = func(
+	ctx context.Context,
+	project, instance, appProfile string,
+	opts ...option.ClientOption,
+) (session.Client, error)
+
+// newSessionClient is the factory ResourceManager.New uses to construct the
+// underlying session Client. Tests override this via TestHookSessionClient.
+var newSessionClient SessionClientFactory = func(
+	ctx context.Context,
+	project, instance, appProfile string,
+	opts ...option.ClientOption,
+) (session.Client, error) {
+	return session.NewClient(ctx, project, instance, appProfile, nil, opts...)
+}
+
+// TestHookSessionClient swaps the session Client factory used by New for the
+// duration of a test. Returns a restore function the test must call (typically
+// via t.Cleanup) to revert. Package-level state mutation is not parallel-safe.
+func TestHookSessionClient(f SessionClientFactory) func() {
+	orig := newSessionClient
+	newSessionClient = f
+	return func() { newSessionClient = orig }
+}
+
+// ResourceManager owns a session Client and vends per-resource
+// session.TableAPI handles to the accelerator's dispatch path.
+//
+// It deliberately does NOT cache the handles. session.Client already
+// dedupes the expensive resource — the per-(resource, permission) read and
+// write session pools — inside sessionClient.getOrCreateSessionPool, so
+// repeated OpenTable calls for the same table share the same underlying
+// pools. The handles OpenTable returns are cheap wrappers whose Close is a
+// no-op today (see internal/session/table.go), so there is nothing worth
+// pooling at this layer.
+type ResourceManager struct {
+	sc session.Client
+}
+
+// New dials Bigtable via internal/session and constructs a ResourceManager
+// scoped to (project, instance, appProfile). The ResourceManager takes
+// ownership of the session Client — Close releases it.
+func New(
+	ctx context.Context,
+	project, instance, appProfile string,
+	opts ...option.ClientOption,
+) (*ResourceManager, error) {
+	sc, err := newSessionClient(ctx, project, instance, appProfile, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &ResourceManager{sc: sc}, nil
+}
+
+// noopRelease is returned by GetSessionTable. Handles are not pooled here, so
+// there is nothing to release; the thunk keeps call sites uniform and leaves
+// room to reintroduce pooling later without touching callers.
+func noopRelease() {}
+
+// GetSessionTable returns a session.TableAPI for the table named by resource.
+//
+// Wire format note: V2 RPCs carry a full table resource name
+// ("projects/P/instances/I/tables/T"). session.Client.OpenTable prepends the
+// project/instance/tables/ prefix itself, so ResourceManager hands it just
+// the leaf segment.
+//
+// method is accepted for call-site clarity ("ReadRow" / "MutateRow") but does
+// not affect which handle is returned: OpenTable vends a single handle that
+// routes reads and writes to their respective pools internally. The returned
+// release thunk is a no-op.
+func (rm *ResourceManager) GetSessionTable(resource, method string) (session.TableAPI, func(), error) {
+	return rm.sc.OpenTable(resourceLeaf(resource)), noopRelease, nil
+}
+
+// GetSessionAuthorizedView returns a session.TableAPI for the authorized view
+// named by resource.
+//
+// Wire format note: V2 RPCs carry a full authorized-view resource name
+// ("projects/P/instances/I/tables/T/authorizedViews/V").
+// session.Client.OpenAuthorizedView takes the table and view leaf segments and
+// composes the full name itself, so ResourceManager splits them out here.
+//
+// method is accepted for call-site clarity ("ReadRow" / "MutateRow") and, as
+// with GetSessionTable, does not affect which handle is returned. The returned
+// release thunk is a no-op.
+func (rm *ResourceManager) GetSessionAuthorizedView(resource, method string) (session.TableAPI, func(), error) {
+	table, view := authorizedViewLeaves(resource)
+	return rm.sc.OpenAuthorizedView(table, view), noopRelease, nil
+}
+
+// GetSessionMaterializedView returns a read-only session.TableAPI for the
+// materialized view named by resource.
+//
+// Wire format note: V2 RPCs carry a full materialized-view resource name
+// ("projects/P/instances/I/materializedViews/V").
+// session.Client.OpenMaterializedView takes the view leaf segment and composes
+// the full name itself. Materialized views are read-only; MutateRow on the
+// returned handle errors.
+//
+// method is accepted for call-site clarity; see GetSessionTable. The returned
+// release thunk is a no-op.
+func (rm *ResourceManager) GetSessionMaterializedView(resource, method string) (session.TableAPI, func(), error) {
+	return rm.sc.OpenMaterializedView(resourceLeaf(resource)), noopRelease, nil
+}
+
+// Close closes the underlying session Client, tearing down its pools. Handles
+// previously returned by GetSessionTable become unusable afterwards.
+func (rm *ResourceManager) Close() error {
+	if rm.sc != nil {
+		return rm.sc.Close()
+	}
+	return nil
+}
+
+// resourceLeaf extracts the last path segment from a full resource name — e.g.
+// "T" from "projects/P/instances/I/tables/T", or "V" from
+// "projects/P/instances/I/materializedViews/V". Returns the input unchanged if
+// it does not contain a "/" — best-effort.
+func resourceLeaf(fullName string) string {
+	if i := strings.LastIndex(fullName, "/"); i >= 0 {
+		return fullName[i+1:]
+	}
+	return fullName
+}
+
+// authorizedViewLeaves splits a full authorized-view resource name
+// ("projects/P/instances/I/tables/T/authorizedViews/V") into its table ("T")
+// and view ("V") leaf segments, which is what session.Client.OpenAuthorizedView
+// expects. Best-effort: if the "/authorizedViews/" marker is absent, the whole
+// input is treated as the view leaf and table is returned empty.
+func authorizedViewLeaves(fullName string) (table, view string) {
+	const marker = "/authorizedViews/"
+	if i := strings.Index(fullName, marker); i >= 0 {
+		return resourceLeaf(fullName[:i]), resourceLeaf(fullName[i+len(marker):])
+	}
+	return "", resourceLeaf(fullName)
+}

--- a/bigtable/internal/accelerator/resourcemanager/resource_manager_test.go
+++ b/bigtable/internal/accelerator/resourcemanager/resource_manager_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcemanager
+
+import (
+	"context"
+	"testing"
+
+	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"cloud.google.com/go/bigtable/internal/session"
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+	"go.opentelemetry.io/otel/metric"
+	"google.golang.org/api/option"
+)
+
+// stubTable is a no-op session.TableAPI; ResourceManager returns it verbatim,
+// so its behaviour is irrelevant — only the args it was opened with matter.
+type stubTable struct{}
+
+func (stubTable) ReadRow(context.Context, *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
+	return nil, nil
+}
+func (stubTable) MutateRow(context.Context, *btpb.SessionMutateRowRequest) (*btpb.SessionMutateRowResponse, error) {
+	return nil, nil
+}
+func (stubTable) Close() error { return nil }
+
+// recordingClient records the leaf arguments the ResourceManager passes to each
+// Open* method so tests can assert the full-resource-name → leaf parsing.
+type recordingClient struct {
+	table session.TableAPI
+
+	openTableArg string
+	avTable      string
+	avView       string
+	mvView       string
+}
+
+func (c *recordingClient) OpenTable(tableID string) session.TableAPI {
+	c.openTableArg = tableID
+	return c.table
+}
+func (c *recordingClient) OpenAuthorizedView(table, view string) session.TableAPI {
+	c.avTable, c.avView = table, view
+	return c.table
+}
+func (c *recordingClient) OpenMaterializedView(view string) session.TableAPI {
+	c.mvView = view
+	return c.table
+}
+func (c *recordingClient) MeterProvider() metric.MeterProvider           { return nil }
+func (c *recordingClient) SessionDebug() btransport.SessionDebugProvider { return nil }
+func (c *recordingClient) ChannelDebug() btransport.ChannelDebugProvider { return nil }
+func (c *recordingClient) ConfigDebug() btransport.ConfigDebugProvider   { return nil }
+func (c *recordingClient) AddSessionLoadListener(func(float64)) func()   { return func() {} }
+func (c *recordingClient) Close() error                                  { return nil }
+
+func newTestManager(t *testing.T) (*ResourceManager, *recordingClient) {
+	t.Helper()
+	rc := &recordingClient{table: stubTable{}}
+	restore := TestHookSessionClient(func(context.Context, string, string, string, ...option.ClientOption) (session.Client, error) {
+		return rc, nil
+	})
+	t.Cleanup(restore)
+
+	rm, err := New(context.Background(), "p", "i", "ap")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { rm.Close() })
+	return rm, rc
+}
+
+func TestGetSessionTable_ExtractsLeaf(t *testing.T) {
+	rm, rc := newTestManager(t)
+
+	tbl, release, err := rm.GetSessionTable("projects/p/instances/i/tables/t", "ReadRow")
+	if err != nil {
+		t.Fatalf("GetSessionTable: %v", err)
+	}
+	if tbl == nil || release == nil {
+		t.Fatal("GetSessionTable returned nil handle or release")
+	}
+	if rc.openTableArg != "t" {
+		t.Errorf("OpenTable leaf = %q; want %q", rc.openTableArg, "t")
+	}
+}
+
+func TestGetSessionAuthorizedView_ExtractsLeaves(t *testing.T) {
+	rm, rc := newTestManager(t)
+
+	if _, _, err := rm.GetSessionAuthorizedView("projects/p/instances/i/tables/t/authorizedViews/v", "ReadRow"); err != nil {
+		t.Fatalf("GetSessionAuthorizedView: %v", err)
+	}
+	if rc.avTable != "t" || rc.avView != "v" {
+		t.Errorf("OpenAuthorizedView(table, view) = (%q, %q); want (%q, %q)", rc.avTable, rc.avView, "t", "v")
+	}
+}
+
+func TestGetSessionMaterializedView_ExtractsLeaf(t *testing.T) {
+	rm, rc := newTestManager(t)
+
+	if _, _, err := rm.GetSessionMaterializedView("projects/p/instances/i/materializedViews/mv", "ReadRow"); err != nil {
+		t.Fatalf("GetSessionMaterializedView: %v", err)
+	}
+	if rc.mvView != "mv" {
+		t.Errorf("OpenMaterializedView view = %q; want %q", rc.mvView, "mv")
+	}
+}
+
+func TestAuthorizedViewLeaves_NoMarker(t *testing.T) {
+	// Best-effort fallback: a bare name with no "/authorizedViews/" marker is
+	// treated wholly as the view leaf.
+	table, view := authorizedViewLeaves("just-a-view")
+	if table != "" || view != "just-a-view" {
+		t.Errorf("authorizedViewLeaves = (%q, %q); want (%q, %q)", table, view, "", "just-a-view")
+	}
+}

--- a/bigtable/internal/accelerator/resourcemanager/resource_manager_test.go
+++ b/bigtable/internal/accelerator/resourcemanager/resource_manager_test.go
@@ -38,7 +38,7 @@ func (stubTable) MutateRow(context.Context, *btpb.SessionMutateRowRequest) (*btp
 func (stubTable) Close() error { return nil }
 
 // recordingClient records the leaf arguments the ResourceManager passes to each
-// Open* method so tests can assert the full-resource-name → leaf parsing.
+// Open* method so tests can assert the leaf IDs are forwarded unchanged.
 type recordingClient struct {
 	table session.TableAPI
 
@@ -83,10 +83,10 @@ func newTestManager(t *testing.T) (*ResourceManager, *recordingClient) {
 	return rm, rc
 }
 
-func TestGetSessionTable_ExtractsLeaf(t *testing.T) {
+func TestGetSessionTable_ForwardsLeaf(t *testing.T) {
 	rm, rc := newTestManager(t)
 
-	tbl, release, err := rm.GetSessionTable("projects/p/instances/i/tables/t", "ReadRow")
+	tbl, release, err := rm.GetSessionTable("t", "ReadRow")
 	if err != nil {
 		t.Fatalf("GetSessionTable: %v", err)
 	}
@@ -98,10 +98,10 @@ func TestGetSessionTable_ExtractsLeaf(t *testing.T) {
 	}
 }
 
-func TestGetSessionAuthorizedView_ExtractsLeaves(t *testing.T) {
+func TestGetSessionAuthorizedView_ForwardsLeaves(t *testing.T) {
 	rm, rc := newTestManager(t)
 
-	if _, _, err := rm.GetSessionAuthorizedView("projects/p/instances/i/tables/t/authorizedViews/v", "ReadRow"); err != nil {
+	if _, _, err := rm.GetSessionAuthorizedView("t", "v", "ReadRow"); err != nil {
 		t.Fatalf("GetSessionAuthorizedView: %v", err)
 	}
 	if rc.avTable != "t" || rc.avView != "v" {
@@ -109,22 +109,13 @@ func TestGetSessionAuthorizedView_ExtractsLeaves(t *testing.T) {
 	}
 }
 
-func TestGetSessionMaterializedView_ExtractsLeaf(t *testing.T) {
+func TestGetSessionMaterializedView_ForwardsLeaf(t *testing.T) {
 	rm, rc := newTestManager(t)
 
-	if _, _, err := rm.GetSessionMaterializedView("projects/p/instances/i/materializedViews/mv", "ReadRow"); err != nil {
+	if _, _, err := rm.GetSessionMaterializedView("mv", "ReadRow"); err != nil {
 		t.Fatalf("GetSessionMaterializedView: %v", err)
 	}
 	if rc.mvView != "mv" {
 		t.Errorf("OpenMaterializedView view = %q; want %q", rc.mvView, "mv")
-	}
-}
-
-func TestAuthorizedViewLeaves_NoMarker(t *testing.T) {
-	// Best-effort fallback: a bare name with no "/authorizedViews/" marker is
-	// treated wholly as the view leaf.
-	table, view := authorizedViewLeaves("just-a-view")
-	if table != "" || view != "just-a-view" {
-		t.Errorf("authorizedViewLeaves = (%q, %q); want (%q, %q)", table, view, "", "just-a-view")
 	}
 }


### PR DESCRIPTION
ResourceManager owns a session.Client scoped to (project, instance, appProfile) and vends per-resource session.TableAPI handles for tables, authorized views, and materialized views to the dispatch path. It does not cache handles: session.Client already dedupes the underlying pools.