### PR TITLE
fix(bigtable/internal/transport): drop redundant defer p.Close() in AFE picker tests

### DIFF
--- a/bigtable/internal/transport/session_pool_afe_test.go
+++ b/bigtable/internal/transport/session_pool_afe_test.go
@@ -74,7 +74,6 @@ func checkoutAndRelease(t *testing.T, p *SessionPoolImpl, recordLatency time.Dur
 // every AFE has the same number of idle sessions.
 func TestPool_LeastInFlight_FansOutAcrossAFEs(t *testing.T) {
 	p := newTestPool(t, 1, 30)
-	defer p.Close()
 
 	// 3 AFEs × 2 sessions each = 6 sessions total.
 	afes := []AfeID{101, 202, 303}
@@ -104,7 +103,6 @@ func TestPool_LeastInFlight_FansOutAcrossAFEs(t *testing.T) {
 // with a much lower latency history.
 func TestPool_LeastLatency_PrefersLowCostAFE(t *testing.T) {
 	p := newTestPool(t, 1, 20)
-	defer p.Close()
 
 	// Switch picker to LeastLatency (subset-size = 2 = both AFEs).
 	p.picker = NewLeastLatencyAfePicker(2, true)
@@ -142,7 +140,6 @@ func TestPool_LeastLatency_PrefersLowCostAFE(t *testing.T) {
 // (SessionList.java:181-187).
 func TestPool_LeastLatency_IgnoresFailingAFELatency(t *testing.T) {
 	p := newTestPool(t, 1, 20)
-	defer p.Close()
 
 	p.picker = NewLeastLatencyAfePicker(2, true)
 
@@ -191,7 +188,6 @@ func TestPool_LeastLatency_IgnoresFailingAFELatency(t *testing.T) {
 // sessions still get picked, just from the shared unknown bucket.
 func TestPool_UnknownAFE_BucketedAtZero(t *testing.T) {
 	p := newTestPool(t, 1, 20)
-	defer p.Close()
 
 	// injectActiveSession (no On-Afe variant) — leaves PeerInfo nil so
 	// AfeID() returns 0.


### PR DESCRIPTION
## Summary

Four AFE picker tests in `session_pool_afe_test.go` each declared `defer p.Close()` on a pool returned by `newTestPool`. That defer runs **before** the `t.Cleanup` registered by `newTestPool`, which is `closeStreams(); _ = p.Close()`. When `Tick` fires during the checkout loop and spawns a fresh session via the stub factory, the new session's readLoop parks on `fakeStream.Recv`. The test-body defer then calls `p.Close()`, which waits on `p.spawns` for the `createSession` goroutine, which waits on `Session.WaitGoroutines` for the readLoop — but the readLoop only exits when `closeStreams` closes the recv channel, and `closeStreams` is inside the `t.Cleanup` that hasn't run yet. Deadlock; test hangs to timeout.

`newTestPool`'s `t.Cleanup` already runs `closeStreams` first, then `Close`, in the correct order — the per-test `defer p.Close()` was redundant and actively wrong. Dropping it fixes the deadlock.

Fixes #20308.

## Test plan

- [x] Reproduced the hang: `go test -run '^TestPool_LeastInFlight_FansOutAcrossAFEs$' -count=50 -race -timeout=45s` — passes iters 1–3, hangs on iter 4 with goroutine dump showing `defer p.Close()` → `p.spawns.Wait()` → stuck on `Session.WaitGoroutines` → stuck on `fakeStream.Recv`.
- [x] Verified fix: same command with `-count=200 -race -timeout=90s` — passes in ~3s.
- [x] `go test -count=1 -timeout=60s ./bigtable/internal/transport/...` — full transport suite green.