### PR TITLE
feat(bigtable/accelerator): dispatch MutateRow and single-row ReadRow…

### DIFF
--- a/bigtable/internal/accelerator/accelerator_core.go
+++ b/bigtable/internal/accelerator/accelerator_core.go
@@ -17,11 +17,12 @@
 // internal/session.
 //
 // Channel is scoped to one (project, instance, appProfile). It owns a
-// session.Client and dispatches each RPC by opening a per-resource
-// session.TableAPI on it. session.Client already dedupes the expensive
-// resource — the per-(resource, permission) read/write session pools — so
-// opening a handle per call is cheap and nothing is cached at this layer.
-// Close tears down the session.Client and all its pools.
+// session.Client and a session.TableCache, and dispatches each RPC by
+// resolving a per-resource session.TableAPI through the cache. Handles are kept
+// warm for reuse and evicted on idle TTL, so a long-lived daemon reclaims idle
+// resources' session pools instead of accumulating one per resource forever.
+// Close tears down the cache (releasing cached handles' pools) and then the
+// session.Client.
 package accelerator
 
 import (
@@ -114,9 +115,14 @@ var newSessionClient = func(
 // name targets this daemon's scope against it, then strips it to the leaf ID
 // session.Client expects (see resourcename.go). It is the only retained form of
 // the (project, instance) the channel is scoped to.
+//
+// sessionTables caches per-resource session.TableAPI handles keyed by the
+// fully-qualified V2 resource name, so repeated RPCs to the same resource share
+// one warm handle and idle resources' pools are reclaimed by its TTL sweeper.
 type Channel struct {
-	sc          session.Client
-	scopePrefix string
+	sc            session.Client
+	scopePrefix   string
+	sessionTables *session.TableCache
 }
 
 // NewChannel constructs an Channel scoped to
@@ -144,45 +150,61 @@ func NewChannel(
 		return nil, err
 	}
 	return &Channel{
-		sc:          sc,
-		scopePrefix: scopePrefixFor(project, instance),
+		sc:            sc,
+		scopePrefix:   scopePrefixFor(project, instance),
+		sessionTables: session.NewTableCache(session.DefaultTableCacheTTL, session.DefaultTableCacheSweepInterval, nil /* time.Now */),
 	}, nil
 }
 
-// openHandle routes an extracted resource to a session.TableAPI based on its
-// kind. The adapter already determined the kind from the populated V2 name
-// field; here the full name is validated against this daemon's scope and
-// reduced to the leaf ID(s) session.Client expects, which re-prefixes them with
-// its own project/instance. A name targeting a different project/instance is
-// rejected rather than silently served from this daemon's scope.
+// openHandle resolves an extracted resource to a per-resource, cached
+// session.TableAPI based on its kind. The adapter already determined the kind
+// from the populated V2 name field; here the full name is validated against
+// this daemon's scope and reduced to the leaf ID(s) session.Client expects,
+// which re-prefixes them with its own project/instance. A name targeting a
+// different project/instance is rejected rather than silently served from this
+// daemon's scope.
 //
-// The underlying read/write session pools are deduped inside session.Client,
-// so opening a handle per call is cheap and nothing is cached here.
+// Validation runs before the cache lookup, so an out-of-scope name is rejected
+// without ever creating or caching a handle. In-scope names resolve through the
+// TableCache keyed by the full V2 name, so repeated RPCs to the same resource
+// share one warm handle; the cache's sweeper evicts idle handles (releasing
+// their pools) on TTL.
 func (c *Channel) openHandle(res adapters.Resource) (session.TableAPI, error) {
+	var open func() session.TableAPI
 	switch res.Kind {
 	case adapters.ResourceTable:
 		tableID, err := c.parseTableName(res.Name)
 		if err != nil {
 			return nil, err
 		}
-		return c.sc.OpenTable(tableID), nil
+		open = func() session.TableAPI { return c.sc.OpenTable(tableID) }
 	case adapters.ResourceAuthorizedView:
 		tableID, viewID, err := c.parseAuthorizedViewName(res.Name)
 		if err != nil {
 			return nil, err
 		}
-		return c.sc.OpenAuthorizedView(tableID, viewID), nil
+		open = func() session.TableAPI { return c.sc.OpenAuthorizedView(tableID, viewID) }
 	case adapters.ResourceMaterializedView:
 		viewID, err := c.parseMaterializedViewName(res.Name)
 		if err != nil {
 			return nil, err
 		}
-		return c.sc.OpenMaterializedView(viewID), nil
+		open = func() session.TableAPI { return c.sc.OpenMaterializedView(viewID) }
 	default:
 		// Kind is set by the adapter from the populated V2 name field, so an
 		// unrecognized kind is an internal invariant violation, not bad input.
 		return nil, status.Errorf(codes.Internal, "accelerator: unknown resource kind %v", res.Kind)
 	}
+
+	// Key on the full V2 name (the identity Cloud Bigtable uses on the wire),
+	// so table / authorized-view / materialized-view keys never collide. A nil
+	// handle means the cache has been Closed (Channel.Close), so the channel is
+	// no longer usable.
+	tbl := c.sessionTables.GetOrOpen(res.Name, open)
+	if tbl == nil {
+		return nil, status.Error(codes.Unavailable, "accelerator: channel is closed")
+	}
+	return tbl, nil
 }
 
 // Invoke implements grpc.ClientConnInterface for unary V2 RPCs.
@@ -215,9 +237,9 @@ func (c *Channel) mutateRowImpl(ctx context.Context, args, reply interface{}) er
 		return err
 	}
 
-	// Open a fresh handle per call, routed to a table or authorized view by the
-	// resource kind; the underlying read/write session pools are deduped inside
-	// session.Client, so this is cheap.
+	// Resolve a cached handle for the resource, routed to a table or authorized
+	// view by the resource kind; repeated calls to the same resource reuse one
+	// warm handle from the TableCache.
 	tbl, err := c.openHandle(resource)
 	if err != nil {
 		return err
@@ -253,12 +275,15 @@ func (c *Channel) NewStream(ctx context.Context, _ *grpc.StreamDesc, method stri
 	}
 }
 
-// Close releases resources held by the channel by closing the underlying
-// session.Client and all its pools.
+// Close releases resources held by the channel. It closes the per-resource
+// TableCache first — stopping its sweeper and Close()ing every cached handle so
+// each releases its session pools — then tears down the session.Client that
+// owns those pools.
 func (c *Channel) Close() error {
 	if c.sc == nil {
 		return nil
 	}
+	c.sessionTables.Close()
 	return c.sc.Close()
 }
 

--- a/bigtable/internal/accelerator/accelerator_core.go
+++ b/bigtable/internal/accelerator/accelerator_core.go
@@ -17,16 +17,21 @@
 // internal/session.
 //
 // Channel is scoped to one (project, instance, appProfile). It owns a
-// session.Client for the daemon's lifetime; Close tears it down along with all
-// its pools. This file establishes that lifecycle. The per-RPC dispatch that
-// translates individual V2 calls into session vRPCs is layered on top: until
-// it is wired in, Invoke and NewStream report Unimplemented.
+// session.Client and dispatches each RPC by opening a per-resource
+// session.TableAPI on it. session.Client already dedupes the expensive
+// resource — the per-(resource, permission) read/write session pools — so
+// opening a handle per call is cheap and nothing is cached at this layer.
+// Close tears down the session.Client and all its pools.
 package accelerator
 
 import (
+	"bytes"
 	"context"
+	"io"
 
+	v2pb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
 	"cloud.google.com/go/bigtable/internal"
+	"cloud.google.com/go/bigtable/internal/accelerator/adapters"
 	metrics "cloud.google.com/go/bigtable/internal/metrics"
 	btopt "cloud.google.com/go/bigtable/internal/option"
 	"cloud.google.com/go/bigtable/internal/session"
@@ -34,7 +39,9 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	gmetadata "google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 // Default data-plane dial parameters. These mirror the unexported
@@ -98,13 +105,13 @@ var newSessionClient = func(
 }
 
 // Channel is an in-process grpc.ClientConnInterface backed by
-// internal/session. It owns a session.Client for its lifetime. One channel per
+// internal/session. It owns a session.Client and opens a per-resource
+// session.TableAPI on it for each RPC. One channel per
 // (project, instance, appProfile).
 //
-// project and instance are retained so the per-RPC dispatch path (layered on
-// top of this scaffold) can validate that an incoming V2 resource name targets
-// this daemon's scope before stripping it to the leaf ID session.Client
-// expects.
+// project and instance are retained so the dispatch path can validate that an
+// incoming V2 resource name targets this daemon's scope before stripping it to
+// the leaf ID session.Client expects (see resourcename.go).
 type Channel struct {
 	sc       session.Client
 	project  string
@@ -142,18 +149,104 @@ func NewChannel(
 	}, nil
 }
 
-// Invoke implements grpc.ClientConnInterface for unary V2 RPCs. The per-method
-// dispatch is layered on top of this scaffold; until then every method reports
-// Unimplemented.
-func (c *Channel) Invoke(ctx context.Context, method string, args, reply interface{}, _ ...grpc.CallOption) error {
-	return status.Errorf(codes.Unimplemented, "accelerator: method %s not implemented", method)
+// openSession routes an extracted resource to a session.TableAPI based on its
+// kind. The adapter already determined the kind from the populated V2 name
+// field; here the full name is validated against this daemon's scope and
+// reduced to the leaf ID(s) session.Client expects, which re-prefixes them with
+// its own project/instance. A name targeting a different project/instance is
+// rejected rather than silently served from this daemon's scope.
+//
+// The underlying read/write session pools are deduped inside session.Client,
+// so opening a handle per call is cheap and nothing is cached here.
+func (c *Channel) openSession(res adapters.Resource) (session.TableAPI, error) {
+	switch res.Kind {
+	case adapters.ResourceAuthorizedView:
+		tableID, viewID, err := parseAuthorizedViewName(res.Name, c.project, c.instance)
+		if err != nil {
+			return nil, err
+		}
+		return c.sc.OpenAuthorizedView(tableID, viewID), nil
+	case adapters.ResourceMaterializedView:
+		viewID, err := parseMaterializedViewName(res.Name, c.project, c.instance)
+		if err != nil {
+			return nil, err
+		}
+		return c.sc.OpenMaterializedView(viewID), nil
+	default:
+		tableID, err := parseTableName(res.Name, c.project, c.instance)
+		if err != nil {
+			return nil, err
+		}
+		return c.sc.OpenTable(tableID), nil
+	}
 }
 
-// NewStream implements grpc.ClientConnInterface for streaming V2 RPCs. The
-// per-method dispatch is layered on top of this scaffold; until then every
-// streaming method reports Unimplemented.
+// Invoke implements grpc.ClientConnInterface for unary V2 RPCs.
+func (c *Channel) Invoke(ctx context.Context, method string, args, reply interface{}, _ ...grpc.CallOption) error {
+	switch method {
+	case v2pb.Bigtable_MutateRow_FullMethodName:
+		return c.mutateRowImpl(ctx, args, reply)
+	default:
+		return status.Errorf(codes.Unimplemented, "accelerator: method %s not implemented", method)
+	}
+}
+
+func (c *Channel) mutateRowImpl(ctx context.Context, args, reply interface{}) error {
+	reqV2, ok := args.(*v2pb.MutateRowRequest)
+	if !ok {
+		return status.Errorf(codes.Internal, "accelerator: unexpected request type %T for MutateRow", args)
+	}
+	respV2, ok := reply.(*v2pb.MutateRowResponse)
+	if !ok {
+		return status.Errorf(codes.Internal, "accelerator: unexpected reply type %T for MutateRow", reply)
+	}
+
+	reqAdapter := adapters.DefaultMutateRowRequestAdapter
+	resource, err := reqAdapter.ExtractResource(reqV2)
+	if err != nil {
+		return err
+	}
+	sessionReq, err := reqAdapter.Adapt(reqV2)
+	if err != nil {
+		return err
+	}
+
+	// Open a fresh handle per call, routed to a table or authorized view by the
+	// resource kind; the underlying read/write session pools are deduped inside
+	// session.Client, so this is cheap.
+	tbl, err := c.openSession(resource)
+	if err != nil {
+		return err
+	}
+
+	sessionResp, err := tbl.MutateRow(ctx, sessionReq)
+	if err != nil {
+		return err
+	}
+
+	respAdapter := adapters.DefaultMutateRowResponseAdapter
+	adapted, err := respAdapter.Adapt(sessionResp)
+	if err != nil {
+		return err
+	}
+	proto.Reset(respV2)
+	if adapted != nil {
+		proto.Merge(respV2, adapted)
+	}
+	return nil
+}
+
+// NewStream implements grpc.ClientConnInterface for streaming V2 RPCs.
+// ReadRows is dispatched through session.TableAPI.ReadRow lazily: the
+// session call is deferred until the first RecvMsg so the consumer's pull
+// rate controls when work happens.
 func (c *Channel) NewStream(ctx context.Context, _ *grpc.StreamDesc, method string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
-	return nil, status.Errorf(codes.Unimplemented, "accelerator: streaming method %s not implemented", method)
+	switch method {
+	case v2pb.Bigtable_ReadRows_FullMethodName:
+		return &readRowsClientStream{ctx: ctx, c: c}, nil
+	default:
+		return nil, status.Errorf(codes.Unimplemented, "accelerator: streaming method %s not implemented", method)
+	}
 }
 
 // Close releases resources held by the channel by closing the underlying
@@ -163,4 +256,153 @@ func (c *Channel) Close() error {
 		return nil
 	}
 	return c.sc.Close()
+}
+
+// readRowsClientStream implements grpc.ClientStream for the V2 ReadRows RPC,
+// dispatching to a single SessionTableApi.ReadRow call lazily on the first
+// RecvMsg. Backpressure flows naturally: no session work happens until the
+// consumer pulls.
+//
+// Concurrency contract (matches google.golang.org/grpc.ClientStream): it is
+// safe to have one goroutine calling SendMsg and another calling RecvMsg on
+// the same stream at the same time, but it is NOT safe to call SendMsg from
+// multiple goroutines, nor to call RecvMsg from multiple goroutines, nor to
+// call CloseSend concurrently with SendMsg. Callers that violate this
+// contract race on the internal state below. The daemon's stream
+// interceptor (interceptors.go) is the only production caller and always
+// drives one stream sequentially from a single per-RPC goroutine, so the
+// contract is satisfied trivially there.
+//
+// State machine:
+//   - awaitingSend: SendMsg has not been called.
+//   - awaitingRecv: request captured; session call has not run.
+//   - done: session call has completed (or errored) and the single response
+//     has been delivered (or never will be). Subsequent RecvMsg returns EOF.
+type readRowsClientStream struct {
+	ctx context.Context
+	c   *Channel
+
+	req  *v2pb.ReadRowsRequest
+	sent bool
+	done bool
+}
+
+func (s *readRowsClientStream) Header() (gmetadata.MD, error) { return nil, nil }
+func (s *readRowsClientStream) Trailer() gmetadata.MD         { return nil }
+func (s *readRowsClientStream) CloseSend() error              { return nil }
+func (s *readRowsClientStream) Context() context.Context      { return s.ctx }
+
+func (s *readRowsClientStream) SendMsg(m any) error {
+	if s.sent {
+		return status.Error(codes.Internal, "accelerator: ReadRows SendMsg called more than once")
+	}
+	req, ok := m.(*v2pb.ReadRowsRequest)
+	if !ok {
+		return status.Errorf(codes.Internal, "accelerator: unexpected request type %T for ReadRows", m)
+	}
+	if err := validateSingleRowReadRequest(req); err != nil {
+		return err
+	}
+	s.req = req
+	s.sent = true
+	return nil
+}
+
+func (s *readRowsClientStream) RecvMsg(m any) error {
+	if s.done {
+		return io.EOF
+	}
+	if !s.sent {
+		return status.Error(codes.Internal, "accelerator: ReadRows RecvMsg called before SendMsg")
+	}
+	resp, ok := m.(*v2pb.ReadRowsResponse)
+	if !ok {
+		return status.Errorf(codes.Internal, "accelerator: unexpected reply type %T for ReadRows", m)
+	}
+
+	reqAdapter := adapters.DefaultReadRowRequestAdapter
+	resource, err := reqAdapter.ExtractResource(s.req)
+	if err != nil {
+		s.done = true
+		return err
+	}
+	sessionReq, err := reqAdapter.Adapt(s.req)
+	if err != nil {
+		s.done = true
+		return err
+	}
+
+	// Routed to a table, authorized view, or materialized view by the
+	// resource kind the adapter extracted.
+	tbl, err := s.c.openSession(resource)
+	if err != nil {
+		s.done = true
+		return err
+	}
+
+	sessionResp, err := tbl.ReadRow(s.ctx, sessionReq)
+	if err != nil {
+		s.done = true
+		return err
+	}
+
+	adapted, err := adapters.DefaultReadRowResponseAdapter.Adapt(sessionResp)
+	if err != nil {
+		s.done = true
+		return err
+	}
+	proto.Reset(resp)
+	if adapted != nil {
+		proto.Merge(resp, adapted)
+	}
+	s.done = true
+	return nil
+}
+
+// validateSingleRowReadRequest rejects request shapes the session transport
+// cannot express. SessionReadRow targets exactly one row by key; the only
+// accepted shapes are (a) exactly one RowKey and no RowRanges, or (b) no
+// RowKeys and one closed-closed RowRange whose start and end are equal
+// (which pins the range to a single row). Anything broader must fail fast
+// rather than silently drop rows.
+func validateSingleRowReadRequest(req *v2pb.ReadRowsRequest) error {
+	if req == nil {
+		return status.Error(codes.InvalidArgument, "accelerator: nil ReadRowsRequest")
+	}
+	if req.Reversed {
+		return status.Error(codes.Unimplemented, "accelerator: reversed ReadRows not supported")
+	}
+	if req.Rows == nil {
+		return status.Error(codes.Unimplemented, "accelerator: ReadRows without a single row key not supported")
+	}
+	nKeys, nRanges := len(req.Rows.RowKeys), len(req.Rows.RowRanges)
+	switch {
+	case nKeys == 1 && nRanges == 0:
+		return nil
+	case nKeys == 0 && nRanges == 1:
+		return validateSingleRowRange(req.Rows.RowRanges[0])
+	default:
+		return status.Errorf(codes.Unimplemented, "accelerator: ReadRows must specify exactly one row (got %d row keys, %d row ranges)", nKeys, nRanges)
+	}
+}
+
+// validateSingleRowRange accepts only a closed-closed range whose start and
+// end bounds are byte-equal — the only range shape that pins to exactly one
+// row.
+func validateSingleRowRange(r *v2pb.RowRange) error {
+	if r == nil {
+		return status.Error(codes.Unimplemented, "accelerator: nil RowRange")
+	}
+	start, ok := r.StartKey.(*v2pb.RowRange_StartKeyClosed)
+	if !ok {
+		return status.Error(codes.Unimplemented, "accelerator: ReadRows RowRange must use start_key_closed")
+	}
+	end, ok := r.EndKey.(*v2pb.RowRange_EndKeyClosed)
+	if !ok {
+		return status.Error(codes.Unimplemented, "accelerator: ReadRows RowRange must use end_key_closed")
+	}
+	if !bytes.Equal(start.StartKeyClosed, end.EndKeyClosed) {
+		return status.Error(codes.Unimplemented, "accelerator: ReadRows RowRange must have equal start and end bounds")
+	}
+	return nil
 }

--- a/bigtable/internal/accelerator/accelerator_core.go
+++ b/bigtable/internal/accelerator/accelerator_core.go
@@ -109,13 +109,14 @@ var newSessionClient = func(
 // session.TableAPI on it for each RPC. One channel per
 // (project, instance, appProfile).
 //
-// project and instance are retained so the dispatch path can validate that an
-// incoming V2 resource name targets this daemon's scope before stripping it to
-// the leaf ID session.Client expects (see resourcename.go).
+// scopePrefix is "projects/<project>/instances/<instance>/", precomputed once
+// at construction. The dispatch path validates that an incoming V2 resource
+// name targets this daemon's scope against it, then strips it to the leaf ID
+// session.Client expects (see resourcename.go). It is the only retained form of
+// the (project, instance) the channel is scoped to.
 type Channel struct {
-	sc       session.Client
-	project  string
-	instance string
+	sc          session.Client
+	scopePrefix string
 }
 
 // NewChannel constructs an Channel scoped to
@@ -143,13 +144,12 @@ func NewChannel(
 		return nil, err
 	}
 	return &Channel{
-		sc:       sc,
-		project:  project,
-		instance: instance,
+		sc:          sc,
+		scopePrefix: scopePrefixFor(project, instance),
 	}, nil
 }
 
-// openSession routes an extracted resource to a session.TableAPI based on its
+// openHandle routes an extracted resource to a session.TableAPI based on its
 // kind. The adapter already determined the kind from the populated V2 name
 // field; here the full name is validated against this daemon's scope and
 // reduced to the leaf ID(s) session.Client expects, which re-prefixes them with
@@ -158,26 +158,30 @@ func NewChannel(
 //
 // The underlying read/write session pools are deduped inside session.Client,
 // so opening a handle per call is cheap and nothing is cached here.
-func (c *Channel) openSession(res adapters.Resource) (session.TableAPI, error) {
+func (c *Channel) openHandle(res adapters.Resource) (session.TableAPI, error) {
 	switch res.Kind {
+	case adapters.ResourceTable:
+		tableID, err := c.parseTableName(res.Name)
+		if err != nil {
+			return nil, err
+		}
+		return c.sc.OpenTable(tableID), nil
 	case adapters.ResourceAuthorizedView:
-		tableID, viewID, err := parseAuthorizedViewName(res.Name, c.project, c.instance)
+		tableID, viewID, err := c.parseAuthorizedViewName(res.Name)
 		if err != nil {
 			return nil, err
 		}
 		return c.sc.OpenAuthorizedView(tableID, viewID), nil
 	case adapters.ResourceMaterializedView:
-		viewID, err := parseMaterializedViewName(res.Name, c.project, c.instance)
+		viewID, err := c.parseMaterializedViewName(res.Name)
 		if err != nil {
 			return nil, err
 		}
 		return c.sc.OpenMaterializedView(viewID), nil
 	default:
-		tableID, err := parseTableName(res.Name, c.project, c.instance)
-		if err != nil {
-			return nil, err
-		}
-		return c.sc.OpenTable(tableID), nil
+		// Kind is set by the adapter from the populated V2 name field, so an
+		// unrecognized kind is an internal invariant violation, not bad input.
+		return nil, status.Errorf(codes.Internal, "accelerator: unknown resource kind %v", res.Kind)
 	}
 }
 
@@ -214,7 +218,7 @@ func (c *Channel) mutateRowImpl(ctx context.Context, args, reply interface{}) er
 	// Open a fresh handle per call, routed to a table or authorized view by the
 	// resource kind; the underlying read/write session pools are deduped inside
 	// session.Client, so this is cheap.
-	tbl, err := c.openSession(resource)
+	tbl, err := c.openHandle(resource)
 	if err != nil {
 		return err
 	}
@@ -263,21 +267,24 @@ func (c *Channel) Close() error {
 // RecvMsg. Backpressure flows naturally: no session work happens until the
 // consumer pulls.
 //
-// Concurrency contract (matches google.golang.org/grpc.ClientStream): it is
-// safe to have one goroutine calling SendMsg and another calling RecvMsg on
-// the same stream at the same time, but it is NOT safe to call SendMsg from
-// multiple goroutines, nor to call RecvMsg from multiple goroutines, nor to
-// call CloseSend concurrently with SendMsg. Callers that violate this
-// contract race on the internal state below. The daemon's stream
-// interceptor (interceptors.go) is the only production caller and always
-// drives one stream sequentially from a single per-RPC goroutine, so the
-// contract is satisfied trivially there.
+// Concurrency contract: unlike a general google.golang.org/grpc.ClientStream,
+// this stream must be driven sequentially by a single goroutine. It does NOT
+// support concurrent SendMsg/RecvMsg (nor SendMsg concurrent with CloseSend):
+// the send and receive paths share unsynchronized state (req, sent, done,
+// terminalErr) with no locking, so concurrent access races. This narrower
+// contract is deliberate — the stream is effectively unary (one SendMsg, then
+// RecvMsg until EOF), and the daemon's stream interceptor (interceptors.go),
+// the only production caller, always drives one stream sequentially from a
+// single per-RPC goroutine, so no synchronization is warranted.
 //
 // State machine:
 //   - awaitingSend: SendMsg has not been called.
 //   - awaitingRecv: request captured; session call has not run.
 //   - done: session call has completed (or errored) and the single response
-//     has been delivered (or never will be). Subsequent RecvMsg returns EOF.
+//     has been delivered (or never will be). Subsequent RecvMsg returns the
+//     terminal status recorded in terminalErr — io.EOF after a successful read,
+//     or the error that aborted the stream — matching grpc.ClientStream, which
+//     keeps reporting the terminal status on repeated RecvMsg calls.
 type readRowsClientStream struct {
 	ctx context.Context
 	c   *Channel
@@ -285,6 +292,10 @@ type readRowsClientStream struct {
 	req  *v2pb.ReadRowsRequest
 	sent bool
 	done bool
+	// terminalErr is the status a post-completion RecvMsg replays: io.EOF once
+	// the single response was delivered, or the error that aborted the stream.
+	// Set together with done.
+	terminalErr error
 }
 
 func (s *readRowsClientStream) Header() (gmetadata.MD, error) { return nil, nil }
@@ -310,7 +321,10 @@ func (s *readRowsClientStream) SendMsg(m any) error {
 
 func (s *readRowsClientStream) RecvMsg(m any) error {
 	if s.done {
-		return io.EOF
+		// Replay the terminal status: io.EOF after a successful read, or the
+		// error that aborted the stream. Returning io.EOF here after an error
+		// would falsely signal clean completion to a caller that keeps pulling.
+		return s.terminalErr
 	}
 	if !s.sent {
 		return status.Error(codes.Internal, "accelerator: ReadRows RecvMsg called before SendMsg")
@@ -323,40 +337,45 @@ func (s *readRowsClientStream) RecvMsg(m any) error {
 	reqAdapter := adapters.DefaultReadRowRequestAdapter
 	resource, err := reqAdapter.ExtractResource(s.req)
 	if err != nil {
-		s.done = true
-		return err
+		return s.terminate(err)
 	}
 	sessionReq, err := reqAdapter.Adapt(s.req)
 	if err != nil {
-		s.done = true
-		return err
+		return s.terminate(err)
 	}
 
 	// Routed to a table, authorized view, or materialized view by the
 	// resource kind the adapter extracted.
-	tbl, err := s.c.openSession(resource)
+	tbl, err := s.c.openHandle(resource)
 	if err != nil {
-		s.done = true
-		return err
+		return s.terminate(err)
 	}
 
 	sessionResp, err := tbl.ReadRow(s.ctx, sessionReq)
 	if err != nil {
-		s.done = true
-		return err
+		return s.terminate(err)
 	}
 
 	adapted, err := adapters.DefaultReadRowResponseAdapter.Adapt(sessionResp)
 	if err != nil {
-		s.done = true
-		return err
+		return s.terminate(err)
 	}
 	proto.Reset(resp)
 	if adapted != nil {
 		proto.Merge(resp, adapted)
 	}
+	// The single response was delivered; the next RecvMsg reports EOF.
 	s.done = true
+	s.terminalErr = io.EOF
 	return nil
+}
+
+// terminate marks the stream done, records err as the terminal status so
+// subsequent RecvMsg calls replay it, and returns err for this call.
+func (s *readRowsClientStream) terminate(err error) error {
+	s.done = true
+	s.terminalErr = err
+	return err
 }
 
 // validateSingleRowReadRequest rejects request shapes the session transport

--- a/bigtable/internal/accelerator/accelerator_core_test.go
+++ b/bigtable/internal/accelerator/accelerator_core_test.go
@@ -655,8 +655,11 @@ func TestNewStream_ReadRows_PropagatesSessionError(t *testing.T) {
 	if err := stream.RecvMsg(&v2pb.ReadRowsResponse{}); !errors.Is(err, sentinel) {
 		t.Errorf("RecvMsg err = %v; want %v", err, sentinel)
 	}
-	if err := stream.RecvMsg(&v2pb.ReadRowsResponse{}); err != io.EOF {
-		t.Errorf("RecvMsg after error = %v; want io.EOF", err)
+	// After an aborting error the stream replays that terminal error, not
+	// io.EOF: returning io.EOF would falsely signal clean completion to a
+	// caller that keeps pulling (matches grpc.ClientStream).
+	if err := stream.RecvMsg(&v2pb.ReadRowsResponse{}); !errors.Is(err, sentinel) {
+		t.Errorf("RecvMsg after error = %v; want %v", err, sentinel)
 	}
 }
 

--- a/bigtable/internal/accelerator/accelerator_core_test.go
+++ b/bigtable/internal/accelerator/accelerator_core_test.go
@@ -121,6 +121,9 @@ func newTestChannel(t *testing.T, sc *mockSessionClient) *Channel {
 	if err != nil {
 		t.Fatalf("NewChannel error: %v", err)
 	}
+	// Close on cleanup so the TableCache sweeper goroutine doesn't outlive
+	// the test.
+	t.Cleanup(func() { _ = channel.Close() })
 	return channel
 }
 
@@ -222,26 +225,33 @@ func TestInvoke_MutateRow_RejectsOutOfScope(t *testing.T) {
 	}
 }
 
-func TestInvoke_MutateRow_OpensTablePerCall(t *testing.T) {
+func TestInvoke_MutateRow_CachesTableHandle(t *testing.T) {
 	sc := &mockSessionClient{table: &mockSessionTableAPI{}}
 	channel := newTestChannel(t, sc)
 
-	reqV2 := &v2pb.MutateRowRequest{
-		TableName: "projects/p/instances/i/tables/t",
-		RowKey:    []byte("k"),
-	}
-	for i := 0; i < 3; i++ {
+	mutate := func(table string) {
+		t.Helper()
 		if err := channel.Invoke(context.Background(),
 			v2pb.Bigtable_MutateRow_FullMethodName,
-			reqV2, &v2pb.MutateRowResponse{}); err != nil {
-			t.Fatalf("Invoke iter %d: %v", i, err)
+			&v2pb.MutateRowRequest{TableName: table, RowKey: []byte("k")},
+			&v2pb.MutateRowResponse{}); err != nil {
+			t.Fatalf("Invoke(MutateRow, %s): %v", table, err)
 		}
 	}
-	// No handle cache at this layer: each RPC opens a fresh table handle.
-	// The underlying session pools are deduped inside session.Client, so
-	// this stays cheap.
-	if sc.newTableCalled != 3 {
-		t.Errorf("Expected OpenTable called once per MutateRow (3 invokes); got %d", sc.newTableCalled)
+
+	// Repeated RPCs to the same table share one cached handle: OpenTable runs
+	// once, on the first (cache-miss) call.
+	for i := 0; i < 3; i++ {
+		mutate("projects/p/instances/i/tables/t")
+	}
+	if sc.newTableCalled != 1 {
+		t.Errorf("OpenTable called %d times for one table across 3 MutateRows; want 1 (cached)", sc.newTableCalled)
+	}
+
+	// A distinct resource misses the cache and opens its own handle.
+	mutate("projects/p/instances/i/tables/other")
+	if sc.newTableCalled != 2 {
+		t.Errorf("OpenTable called %d times after a second distinct table; want 2", sc.newTableCalled)
 	}
 }
 
@@ -663,7 +673,7 @@ func TestNewStream_ReadRows_PropagatesSessionError(t *testing.T) {
 	}
 }
 
-func TestNewStream_ReadRows_OpensTablePerCall(t *testing.T) {
+func TestNewStream_ReadRows_CachesTableHandle(t *testing.T) {
 	tbl := &mockSessionTableAPI{
 		readRowFn: func(_ context.Context, _ *v2pb.SessionReadRowRequest) (*v2pb.SessionReadRowResponse, error) {
 			return &v2pb.SessionReadRowResponse{}, nil
@@ -672,26 +682,37 @@ func TestNewStream_ReadRows_OpensTablePerCall(t *testing.T) {
 	sc := &mockSessionClient{table: tbl}
 	channel := newTestChannel(t, sc)
 
-	for i := 0; i < 3; i++ {
+	readRows := func(table string) {
+		t.Helper()
 		stream, err := channel.NewStream(context.Background(), nil, v2pb.Bigtable_ReadRows_FullMethodName)
 		if err != nil {
-			t.Fatalf("NewStream iter %d: %v", i, err)
+			t.Fatalf("NewStream(%s): %v", table, err)
 		}
-		if err := stream.SendMsg(singleKeyReadRowsRequest("projects/p/instances/i/tables/t", "k")); err != nil {
-			t.Fatalf("SendMsg iter %d: %v", i, err)
+		if err := stream.SendMsg(singleKeyReadRowsRequest(table, "k")); err != nil {
+			t.Fatalf("SendMsg(%s): %v", table, err)
 		}
 		if err := stream.RecvMsg(&v2pb.ReadRowsResponse{}); err != nil {
-			t.Fatalf("RecvMsg iter %d: %v", i, err)
+			t.Fatalf("RecvMsg(%s): %v", table, err)
 		}
 	}
-	// No handle cache at this layer: each ReadRows opens a fresh table
-	// handle; session pools are deduped downstream in session.Client.
-	if sc.newTableCalled != 3 {
-		t.Errorf("OpenTable called %d times across 3 ReadRows; want 3 (one per call)", sc.newTableCalled)
+
+	// Repeated ReadRows to the same table share one cached handle: OpenTable
+	// runs once, on the first (cache-miss) call.
+	for i := 0; i < 3; i++ {
+		readRows("projects/p/instances/i/tables/t")
+	}
+	if sc.newTableCalled != 1 {
+		t.Errorf("OpenTable called %d times across 3 ReadRows; want 1 (cached)", sc.newTableCalled)
+	}
+
+	// A distinct resource misses the cache and opens its own handle.
+	readRows("projects/p/instances/i/tables/other")
+	if sc.newTableCalled != 2 {
+		t.Errorf("OpenTable called %d times after a second distinct table; want 2", sc.newTableCalled)
 	}
 }
 
-func TestNewStream_ReadRows_OpensTableIndependentlyFromMutateRow(t *testing.T) {
+func TestNewStream_ReadRows_SharesCachedHandleWithMutateRow(t *testing.T) {
 	tbl := &mockSessionTableAPI{
 		readRowFn: func(_ context.Context, _ *v2pb.SessionReadRowRequest) (*v2pb.SessionReadRowResponse, error) {
 			return &v2pb.SessionReadRowResponse{}, nil
@@ -720,9 +741,10 @@ func TestNewStream_ReadRows_OpensTableIndependentlyFromMutateRow(t *testing.T) {
 		t.Fatalf("Invoke(MutateRow): %v", err)
 	}
 
-	// One OpenTable per RPC: one for the ReadRows, one for the MutateRow.
-	if sc.newTableCalled != 2 {
-		t.Errorf("OpenTable called %d times; want 2 (one per RPC)", sc.newTableCalled)
+	// Read and write on the same table key into the same cache entry, so the
+	// handle opened by the ReadRows is reused by the MutateRow.
+	if sc.newTableCalled != 1 {
+		t.Errorf("OpenTable called %d times for read+write on one table; want 1 (shared handle)", sc.newTableCalled)
 	}
 }
 

--- a/bigtable/internal/accelerator/accelerator_core_test.go
+++ b/bigtable/internal/accelerator/accelerator_core_test.go
@@ -15,7 +15,10 @@
 package accelerator
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"io"
 	"testing"
 
 	v2pb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
@@ -128,12 +131,595 @@ func TestNewChannel_Constructs(t *testing.T) {
 	}
 }
 
+func TestInvoke_MutateRow_DispatchesThroughSession(t *testing.T) {
+	called := false
+	tbl := &mockSessionTableAPI{
+		mutateRowFn: func(ctx context.Context, req *v2pb.SessionMutateRowRequest) (*v2pb.SessionMutateRowResponse, error) {
+			called = true
+			if got := string(req.Key); got != "k" {
+				t.Errorf("MutateRow req.Key = %q; want %q", got, "k")
+			}
+			return &v2pb.SessionMutateRowResponse{}, nil
+		},
+	}
+	sc := &mockSessionClient{table: tbl}
+	channel := newTestChannel(t, sc)
+
+	reqV2 := &v2pb.MutateRowRequest{
+		TableName: "projects/p/instances/i/tables/t",
+		RowKey:    []byte("k"),
+	}
+	if err := channel.Invoke(context.Background(),
+		v2pb.Bigtable_MutateRow_FullMethodName,
+		reqV2, &v2pb.MutateRowResponse{}); err != nil {
+		t.Fatalf("Invoke(MutateRow) error: %v", err)
+	}
+	if !called {
+		t.Error("Expected SessionTableApi.MutateRow to be called")
+	}
+	if sc.lastTableName != "t" {
+		t.Errorf("Expected NewSessionTable called with leaf %q; got %q", "t", sc.lastTableName)
+	}
+}
+
+func TestInvoke_MutateRow_RoutesToAuthorizedView(t *testing.T) {
+	sc := &mockSessionClient{table: &mockSessionTableAPI{}}
+	channel := newTestChannel(t, sc)
+
+	reqV2 := &v2pb.MutateRowRequest{
+		AuthorizedViewName: "projects/p/instances/i/tables/t/authorizedViews/v",
+		RowKey:             []byte("k"),
+	}
+	if err := channel.Invoke(context.Background(),
+		v2pb.Bigtable_MutateRow_FullMethodName,
+		reqV2, &v2pb.MutateRowResponse{}); err != nil {
+		t.Fatalf("Invoke(MutateRow) error: %v", err)
+	}
+	if sc.newAVCalled != 1 {
+		t.Errorf("OpenAuthorizedView called %d times; want 1", sc.newAVCalled)
+	}
+	if sc.lastAVTable != "t" || sc.lastAVView != "v" {
+		t.Errorf("OpenAuthorizedView(table, view) = (%q, %q); want (t, v)", sc.lastAVTable, sc.lastAVView)
+	}
+	if sc.newTableCalled != 0 {
+		t.Errorf("OpenTable called %d times; want 0 (authorized view request)", sc.newTableCalled)
+	}
+}
+
+func TestInvoke_MutateRow_RejectsOutOfScope(t *testing.T) {
+	cases := []struct {
+		name  string
+		table string
+		av    string
+	}{
+		{"wrong-project-table", "projects/other/instances/i/tables/t", ""},
+		{"wrong-instance-table", "projects/p/instances/other/tables/t", ""},
+		{"wrong-project-av", "", "projects/other/instances/i/tables/t/authorizedViews/v"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := &mockSessionClient{table: &mockSessionTableAPI{}}
+			channel := newTestChannel(t, sc)
+
+			reqV2 := &v2pb.MutateRowRequest{
+				TableName:          tc.table,
+				AuthorizedViewName: tc.av,
+				RowKey:             []byte("k"),
+			}
+			err := channel.Invoke(context.Background(),
+				v2pb.Bigtable_MutateRow_FullMethodName,
+				reqV2, &v2pb.MutateRowResponse{})
+			if got := status.Code(err); got != codes.InvalidArgument {
+				t.Fatalf("Invoke(MutateRow) code = %v; want InvalidArgument", got)
+			}
+			// A rejected out-of-scope name must never open a session handle:
+			// that is exactly the cross-tenant rebind the scope check prevents.
+			if sc.newTableCalled != 0 || sc.newAVCalled != 0 || sc.newMVCalled != 0 {
+				t.Errorf("opened a session handle for out-of-scope name (table=%d av=%d mv=%d); want none",
+					sc.newTableCalled, sc.newAVCalled, sc.newMVCalled)
+			}
+		})
+	}
+}
+
+func TestInvoke_MutateRow_OpensTablePerCall(t *testing.T) {
+	sc := &mockSessionClient{table: &mockSessionTableAPI{}}
+	channel := newTestChannel(t, sc)
+
+	reqV2 := &v2pb.MutateRowRequest{
+		TableName: "projects/p/instances/i/tables/t",
+		RowKey:    []byte("k"),
+	}
+	for i := 0; i < 3; i++ {
+		if err := channel.Invoke(context.Background(),
+			v2pb.Bigtable_MutateRow_FullMethodName,
+			reqV2, &v2pb.MutateRowResponse{}); err != nil {
+			t.Fatalf("Invoke iter %d: %v", i, err)
+		}
+	}
+	// No handle cache at this layer: each RPC opens a fresh table handle.
+	// The underlying session pools are deduped inside session.Client, so
+	// this stays cheap.
+	if sc.newTableCalled != 3 {
+		t.Errorf("Expected OpenTable called once per MutateRow (3 invokes); got %d", sc.newTableCalled)
+	}
+}
+
+func TestInvoke_MutateRow_PropagatesSessionError(t *testing.T) {
+	sentinel := errors.New("session boom")
+	tbl := &mockSessionTableAPI{
+		mutateRowFn: func(ctx context.Context, req *v2pb.SessionMutateRowRequest) (*v2pb.SessionMutateRowResponse, error) {
+			return nil, sentinel
+		},
+	}
+	channel := newTestChannel(t, &mockSessionClient{table: tbl})
+
+	reqV2 := &v2pb.MutateRowRequest{
+		TableName: "projects/p/instances/i/tables/t",
+		RowKey:    []byte("k"),
+	}
+	err := channel.Invoke(context.Background(),
+		v2pb.Bigtable_MutateRow_FullMethodName,
+		reqV2, &v2pb.MutateRowResponse{})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("Invoke(MutateRow) err = %v; want %v", err, sentinel)
+	}
+}
+
 func TestInvoke_UnknownMethod_ReturnsUnimplemented(t *testing.T) {
 	channel := newTestChannel(t, &mockSessionClient{table: &mockSessionTableAPI{}})
 
 	err := channel.Invoke(context.Background(), "/google.bigtable.v2.Bigtable/SampleRowKeys", nil, nil)
 	if status.Code(err) != codes.Unimplemented {
 		t.Errorf("Invoke(unknown) code = %v; want Unimplemented", status.Code(err))
+	}
+}
+
+func singleKeyReadRowsRequest(table, key string) *v2pb.ReadRowsRequest {
+	return &v2pb.ReadRowsRequest{
+		TableName: table,
+		Rows: &v2pb.RowSet{
+			RowKeys: [][]byte{[]byte(key)},
+		},
+	}
+}
+
+func TestNewStream_ReadRows_DispatchesThroughSessionAndAdaptsResponse(t *testing.T) {
+	gotKey := ""
+	tbl := &mockSessionTableAPI{
+		readRowFn: func(_ context.Context, req *v2pb.SessionReadRowRequest) (*v2pb.SessionReadRowResponse, error) {
+			gotKey = string(req.Key)
+			return &v2pb.SessionReadRowResponse{
+				Row: &v2pb.Row{
+					Key: []byte("k"),
+					Families: []*v2pb.Family{{
+						Name: "fam",
+						Columns: []*v2pb.Column{{
+							Qualifier: []byte("q"),
+							Cells: []*v2pb.Cell{{
+								TimestampMicros: 42,
+								Value:           []byte("v"),
+							}},
+						}},
+					}},
+				},
+			}, nil
+		},
+	}
+	sc := &mockSessionClient{table: tbl}
+	channel := newTestChannel(t, sc)
+
+	stream, err := channel.NewStream(context.Background(), nil, v2pb.Bigtable_ReadRows_FullMethodName)
+	if err != nil {
+		t.Fatalf("NewStream: %v", err)
+	}
+	if err := stream.SendMsg(singleKeyReadRowsRequest("projects/p/instances/i/tables/t", "k")); err != nil {
+		t.Fatalf("SendMsg: %v", err)
+	}
+	if err := stream.CloseSend(); err != nil {
+		t.Fatalf("CloseSend: %v", err)
+	}
+
+	resp := &v2pb.ReadRowsResponse{}
+	if err := stream.RecvMsg(resp); err != nil {
+		t.Fatalf("RecvMsg #1: %v", err)
+	}
+	if gotKey != "k" {
+		t.Errorf("session.ReadRow Key = %q; want %q", gotKey, "k")
+	}
+	if sc.lastTableName != "t" {
+		t.Errorf("NewSessionTable called with %q; want %q", sc.lastTableName, "t")
+	}
+	if len(resp.Chunks) != 1 {
+		t.Fatalf("Chunks len = %d; want 1", len(resp.Chunks))
+	}
+	cc := resp.Chunks[0]
+	if !bytes.Equal(cc.RowKey, []byte("k")) {
+		t.Errorf("Chunk.RowKey = %q; want k", cc.RowKey)
+	}
+	if cc.FamilyName == nil || cc.FamilyName.Value != "fam" {
+		t.Errorf("Chunk.FamilyName = %v; want fam", cc.FamilyName)
+	}
+	if cc.GetCommitRow() != true {
+		t.Errorf("Chunk.CommitRow = %v; want true", cc.GetCommitRow())
+	}
+
+	if err := stream.RecvMsg(&v2pb.ReadRowsResponse{}); err != io.EOF {
+		t.Errorf("RecvMsg #2 = %v; want io.EOF", err)
+	}
+}
+
+func TestNewStream_ReadRows_RoutesToAuthorizedView(t *testing.T) {
+	sc := &mockSessionClient{table: &mockSessionTableAPI{}}
+	channel := newTestChannel(t, sc)
+
+	stream, err := channel.NewStream(context.Background(), nil, v2pb.Bigtable_ReadRows_FullMethodName)
+	if err != nil {
+		t.Fatalf("NewStream: %v", err)
+	}
+	req := &v2pb.ReadRowsRequest{
+		AuthorizedViewName: "projects/p/instances/i/tables/t/authorizedViews/v",
+		Rows:               &v2pb.RowSet{RowKeys: [][]byte{[]byte("k")}},
+	}
+	if err := stream.SendMsg(req); err != nil {
+		t.Fatalf("SendMsg: %v", err)
+	}
+	if err := stream.RecvMsg(&v2pb.ReadRowsResponse{}); err != nil {
+		t.Fatalf("RecvMsg: %v", err)
+	}
+	if sc.newAVCalled != 1 {
+		t.Errorf("OpenAuthorizedView called %d times; want 1", sc.newAVCalled)
+	}
+	if sc.lastAVTable != "t" || sc.lastAVView != "v" {
+		t.Errorf("OpenAuthorizedView(table, view) = (%q, %q); want (t, v)", sc.lastAVTable, sc.lastAVView)
+	}
+	if sc.newTableCalled != 0 {
+		t.Errorf("OpenTable called %d times; want 0 (authorized view request)", sc.newTableCalled)
+	}
+}
+
+func TestNewStream_ReadRows_RoutesToMaterializedView(t *testing.T) {
+	sc := &mockSessionClient{table: &mockSessionTableAPI{}}
+	channel := newTestChannel(t, sc)
+
+	stream, err := channel.NewStream(context.Background(), nil, v2pb.Bigtable_ReadRows_FullMethodName)
+	if err != nil {
+		t.Fatalf("NewStream: %v", err)
+	}
+	req := &v2pb.ReadRowsRequest{
+		MaterializedViewName: "projects/p/instances/i/materializedViews/mv",
+		Rows:                 &v2pb.RowSet{RowKeys: [][]byte{[]byte("k")}},
+	}
+	if err := stream.SendMsg(req); err != nil {
+		t.Fatalf("SendMsg: %v", err)
+	}
+	if err := stream.RecvMsg(&v2pb.ReadRowsResponse{}); err != nil {
+		t.Fatalf("RecvMsg: %v", err)
+	}
+	if sc.newMVCalled != 1 {
+		t.Errorf("OpenMaterializedView called %d times; want 1", sc.newMVCalled)
+	}
+	if sc.lastMVView != "mv" {
+		t.Errorf("OpenMaterializedView view = %q; want %q", sc.lastMVView, "mv")
+	}
+	if sc.newTableCalled != 0 {
+		t.Errorf("OpenTable called %d times; want 0 (materialized view request)", sc.newTableCalled)
+	}
+}
+
+func TestNewStream_ReadRows_RejectsOutOfScope(t *testing.T) {
+	cases := []struct {
+		name string
+		req  *v2pb.ReadRowsRequest
+	}{
+		{"wrong-project-table", &v2pb.ReadRowsRequest{
+			TableName: "projects/other/instances/i/tables/t",
+			Rows:      &v2pb.RowSet{RowKeys: [][]byte{[]byte("k")}},
+		}},
+		{"wrong-instance-av", &v2pb.ReadRowsRequest{
+			AuthorizedViewName: "projects/p/instances/other/tables/t/authorizedViews/v",
+			Rows:               &v2pb.RowSet{RowKeys: [][]byte{[]byte("k")}},
+		}},
+		{"wrong-project-mv", &v2pb.ReadRowsRequest{
+			MaterializedViewName: "projects/other/instances/i/materializedViews/mv",
+			Rows:                 &v2pb.RowSet{RowKeys: [][]byte{[]byte("k")}},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := &mockSessionClient{table: &mockSessionTableAPI{}}
+			channel := newTestChannel(t, sc)
+
+			stream, err := channel.NewStream(context.Background(), nil, v2pb.Bigtable_ReadRows_FullMethodName)
+			if err != nil {
+				t.Fatalf("NewStream: %v", err)
+			}
+			if err := stream.SendMsg(tc.req); err != nil {
+				t.Fatalf("SendMsg: %v", err)
+			}
+			// Dispatch is lazy: the scope check fires on the first RecvMsg.
+			err = stream.RecvMsg(&v2pb.ReadRowsResponse{})
+			if got := status.Code(err); got != codes.InvalidArgument {
+				t.Fatalf("RecvMsg code = %v; want InvalidArgument", got)
+			}
+			if sc.newTableCalled != 0 || sc.newAVCalled != 0 || sc.newMVCalled != 0 {
+				t.Errorf("opened a session handle for out-of-scope name (table=%d av=%d mv=%d); want none",
+					sc.newTableCalled, sc.newAVCalled, sc.newMVCalled)
+			}
+		})
+	}
+}
+
+func TestNewStream_ReadRows_LazyDispatch(t *testing.T) {
+	called := false
+	tbl := &mockSessionTableAPI{
+		readRowFn: func(_ context.Context, _ *v2pb.SessionReadRowRequest) (*v2pb.SessionReadRowResponse, error) {
+			called = true
+			return &v2pb.SessionReadRowResponse{}, nil
+		},
+	}
+	channel := newTestChannel(t, &mockSessionClient{table: tbl})
+
+	stream, err := channel.NewStream(context.Background(), nil, v2pb.Bigtable_ReadRows_FullMethodName)
+	if err != nil {
+		t.Fatalf("NewStream: %v", err)
+	}
+	if err := stream.SendMsg(singleKeyReadRowsRequest("projects/p/instances/i/tables/t", "k")); err != nil {
+		t.Fatalf("SendMsg: %v", err)
+	}
+	if called {
+		t.Fatal("session ReadRow invoked before RecvMsg — backpressure violated")
+	}
+	if err := stream.RecvMsg(&v2pb.ReadRowsResponse{}); err != nil {
+		t.Fatalf("RecvMsg: %v", err)
+	}
+	if !called {
+		t.Fatal("session ReadRow not invoked on first RecvMsg")
+	}
+}
+
+func TestNewStream_ReadRows_MissingRowEmitsEmptyResponseThenEOF(t *testing.T) {
+	tbl := &mockSessionTableAPI{
+		readRowFn: func(_ context.Context, _ *v2pb.SessionReadRowRequest) (*v2pb.SessionReadRowResponse, error) {
+			return &v2pb.SessionReadRowResponse{}, nil // Row == nil
+		},
+	}
+	channel := newTestChannel(t, &mockSessionClient{table: tbl})
+
+	stream, err := channel.NewStream(context.Background(), nil, v2pb.Bigtable_ReadRows_FullMethodName)
+	if err != nil {
+		t.Fatalf("NewStream: %v", err)
+	}
+	if err := stream.SendMsg(singleKeyReadRowsRequest("projects/p/instances/i/tables/t", "k")); err != nil {
+		t.Fatalf("SendMsg: %v", err)
+	}
+	resp := &v2pb.ReadRowsResponse{}
+	if err := stream.RecvMsg(resp); err != nil {
+		t.Fatalf("RecvMsg: %v", err)
+	}
+	if len(resp.Chunks) != 0 {
+		t.Errorf("Chunks len = %d; want 0", len(resp.Chunks))
+	}
+	if err := stream.RecvMsg(&v2pb.ReadRowsResponse{}); err != io.EOF {
+		t.Errorf("RecvMsg #2 = %v; want io.EOF", err)
+	}
+}
+
+func TestNewStream_ReadRows_MultiKey_ReturnsUnimplemented(t *testing.T) {
+	channel := newTestChannel(t, &mockSessionClient{table: &mockSessionTableAPI{}})
+	stream, err := channel.NewStream(context.Background(), nil, v2pb.Bigtable_ReadRows_FullMethodName)
+	if err != nil {
+		t.Fatalf("NewStream: %v", err)
+	}
+	req := &v2pb.ReadRowsRequest{
+		TableName: "projects/p/instances/i/tables/t",
+		Rows: &v2pb.RowSet{
+			RowKeys: [][]byte{[]byte("k1"), []byte("k2")},
+		},
+	}
+	err = stream.SendMsg(req)
+	if got := status.Code(err); got != codes.Unimplemented {
+		t.Errorf("SendMsg(multi-key) code = %v; want Unimplemented", got)
+	}
+}
+
+func TestNewStream_ReadRows_MixedKeysAndRanges_ReturnsUnimplemented(t *testing.T) {
+	channel := newTestChannel(t, &mockSessionClient{table: &mockSessionTableAPI{}})
+	stream, err := channel.NewStream(context.Background(), nil, v2pb.Bigtable_ReadRows_FullMethodName)
+	if err != nil {
+		t.Fatalf("NewStream: %v", err)
+	}
+	req := &v2pb.ReadRowsRequest{
+		TableName: "projects/p/instances/i/tables/t",
+		Rows: &v2pb.RowSet{
+			RowKeys:   [][]byte{[]byte("k")},
+			RowRanges: []*v2pb.RowRange{{}},
+		},
+	}
+	err = stream.SendMsg(req)
+	if got := status.Code(err); got != codes.Unimplemented {
+		t.Errorf("SendMsg(mixed keys+ranges) code = %v; want Unimplemented", got)
+	}
+}
+
+// closedClosedRange builds a RowRange with equal closed bounds — the only
+// shape SessionReadRow can serve.
+func closedClosedRange(key string) *v2pb.RowRange {
+	return &v2pb.RowRange{
+		StartKey: &v2pb.RowRange_StartKeyClosed{StartKeyClosed: []byte(key)},
+		EndKey:   &v2pb.RowRange_EndKeyClosed{EndKeyClosed: []byte(key)},
+	}
+}
+
+func TestNewStream_ReadRows_SingleClosedClosedRange_DispatchesSingleRow(t *testing.T) {
+	gotKey := ""
+	tbl := &mockSessionTableAPI{
+		readRowFn: func(_ context.Context, req *v2pb.SessionReadRowRequest) (*v2pb.SessionReadRowResponse, error) {
+			gotKey = string(req.Key)
+			return &v2pb.SessionReadRowResponse{}, nil
+		},
+	}
+	channel := newTestChannel(t, &mockSessionClient{table: tbl})
+
+	stream, err := channel.NewStream(context.Background(), nil, v2pb.Bigtable_ReadRows_FullMethodName)
+	if err != nil {
+		t.Fatalf("NewStream: %v", err)
+	}
+	req := &v2pb.ReadRowsRequest{
+		TableName: "projects/p/instances/i/tables/t",
+		Rows:      &v2pb.RowSet{RowRanges: []*v2pb.RowRange{closedClosedRange("k")}},
+	}
+	if err := stream.SendMsg(req); err != nil {
+		t.Fatalf("SendMsg: %v", err)
+	}
+	if err := stream.RecvMsg(&v2pb.ReadRowsResponse{}); err != nil {
+		t.Fatalf("RecvMsg: %v", err)
+	}
+	if gotKey != "k" {
+		t.Errorf("session.ReadRow Key = %q; want %q", gotKey, "k")
+	}
+}
+
+func TestNewStream_ReadRows_RangeRejects(t *testing.T) {
+	cases := []struct {
+		name     string
+		rowRange *v2pb.RowRange
+	}{
+		{"unequal-closed-closed", &v2pb.RowRange{
+			StartKey: &v2pb.RowRange_StartKeyClosed{StartKeyClosed: []byte("a")},
+			EndKey:   &v2pb.RowRange_EndKeyClosed{EndKeyClosed: []byte("b")},
+		}},
+		{"closed-open", &v2pb.RowRange{
+			StartKey: &v2pb.RowRange_StartKeyClosed{StartKeyClosed: []byte("a")},
+			EndKey:   &v2pb.RowRange_EndKeyOpen{EndKeyOpen: []byte("a")},
+		}},
+		{"open-closed", &v2pb.RowRange{
+			StartKey: &v2pb.RowRange_StartKeyOpen{StartKeyOpen: []byte("a")},
+			EndKey:   &v2pb.RowRange_EndKeyClosed{EndKeyClosed: []byte("a")},
+		}},
+		{"unbounded", &v2pb.RowRange{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			channel := newTestChannel(t, &mockSessionClient{table: &mockSessionTableAPI{}})
+			stream, err := channel.NewStream(context.Background(), nil, v2pb.Bigtable_ReadRows_FullMethodName)
+			if err != nil {
+				t.Fatalf("NewStream: %v", err)
+			}
+			req := &v2pb.ReadRowsRequest{
+				TableName: "projects/p/instances/i/tables/t",
+				Rows:      &v2pb.RowSet{RowRanges: []*v2pb.RowRange{tc.rowRange}},
+			}
+			err = stream.SendMsg(req)
+			if got := status.Code(err); got != codes.Unimplemented {
+				t.Errorf("SendMsg code = %v; want Unimplemented", got)
+			}
+		})
+	}
+}
+
+func TestNewStream_ReadRows_MultipleRanges_ReturnsUnimplemented(t *testing.T) {
+	channel := newTestChannel(t, &mockSessionClient{table: &mockSessionTableAPI{}})
+	stream, err := channel.NewStream(context.Background(), nil, v2pb.Bigtable_ReadRows_FullMethodName)
+	if err != nil {
+		t.Fatalf("NewStream: %v", err)
+	}
+	req := &v2pb.ReadRowsRequest{
+		TableName: "projects/p/instances/i/tables/t",
+		Rows: &v2pb.RowSet{
+			RowRanges: []*v2pb.RowRange{closedClosedRange("a"), closedClosedRange("b")},
+		},
+	}
+	err = stream.SendMsg(req)
+	if got := status.Code(err); got != codes.Unimplemented {
+		t.Errorf("SendMsg(multi-range) code = %v; want Unimplemented", got)
+	}
+}
+
+func TestNewStream_ReadRows_PropagatesSessionError(t *testing.T) {
+	sentinel := errors.New("session boom")
+	tbl := &mockSessionTableAPI{
+		readRowFn: func(_ context.Context, _ *v2pb.SessionReadRowRequest) (*v2pb.SessionReadRowResponse, error) {
+			return nil, sentinel
+		},
+	}
+	channel := newTestChannel(t, &mockSessionClient{table: tbl})
+
+	stream, err := channel.NewStream(context.Background(), nil, v2pb.Bigtable_ReadRows_FullMethodName)
+	if err != nil {
+		t.Fatalf("NewStream: %v", err)
+	}
+	if err := stream.SendMsg(singleKeyReadRowsRequest("projects/p/instances/i/tables/t", "k")); err != nil {
+		t.Fatalf("SendMsg: %v", err)
+	}
+	if err := stream.RecvMsg(&v2pb.ReadRowsResponse{}); !errors.Is(err, sentinel) {
+		t.Errorf("RecvMsg err = %v; want %v", err, sentinel)
+	}
+	if err := stream.RecvMsg(&v2pb.ReadRowsResponse{}); err != io.EOF {
+		t.Errorf("RecvMsg after error = %v; want io.EOF", err)
+	}
+}
+
+func TestNewStream_ReadRows_OpensTablePerCall(t *testing.T) {
+	tbl := &mockSessionTableAPI{
+		readRowFn: func(_ context.Context, _ *v2pb.SessionReadRowRequest) (*v2pb.SessionReadRowResponse, error) {
+			return &v2pb.SessionReadRowResponse{}, nil
+		},
+	}
+	sc := &mockSessionClient{table: tbl}
+	channel := newTestChannel(t, sc)
+
+	for i := 0; i < 3; i++ {
+		stream, err := channel.NewStream(context.Background(), nil, v2pb.Bigtable_ReadRows_FullMethodName)
+		if err != nil {
+			t.Fatalf("NewStream iter %d: %v", i, err)
+		}
+		if err := stream.SendMsg(singleKeyReadRowsRequest("projects/p/instances/i/tables/t", "k")); err != nil {
+			t.Fatalf("SendMsg iter %d: %v", i, err)
+		}
+		if err := stream.RecvMsg(&v2pb.ReadRowsResponse{}); err != nil {
+			t.Fatalf("RecvMsg iter %d: %v", i, err)
+		}
+	}
+	// No handle cache at this layer: each ReadRows opens a fresh table
+	// handle; session pools are deduped downstream in session.Client.
+	if sc.newTableCalled != 3 {
+		t.Errorf("OpenTable called %d times across 3 ReadRows; want 3 (one per call)", sc.newTableCalled)
+	}
+}
+
+func TestNewStream_ReadRows_OpensTableIndependentlyFromMutateRow(t *testing.T) {
+	tbl := &mockSessionTableAPI{
+		readRowFn: func(_ context.Context, _ *v2pb.SessionReadRowRequest) (*v2pb.SessionReadRowResponse, error) {
+			return &v2pb.SessionReadRowResponse{}, nil
+		},
+	}
+	sc := &mockSessionClient{table: tbl}
+	channel := newTestChannel(t, sc)
+
+	stream, err := channel.NewStream(context.Background(), nil, v2pb.Bigtable_ReadRows_FullMethodName)
+	if err != nil {
+		t.Fatalf("NewStream: %v", err)
+	}
+	if err := stream.SendMsg(singleKeyReadRowsRequest("projects/p/instances/i/tables/t", "k")); err != nil {
+		t.Fatalf("SendMsg: %v", err)
+	}
+	if err := stream.RecvMsg(&v2pb.ReadRowsResponse{}); err != nil {
+		t.Fatalf("RecvMsg: %v", err)
+	}
+
+	if err := channel.Invoke(context.Background(),
+		v2pb.Bigtable_MutateRow_FullMethodName,
+		&v2pb.MutateRowRequest{
+			TableName: "projects/p/instances/i/tables/t",
+			RowKey:    []byte("k"),
+		}, &v2pb.MutateRowResponse{}); err != nil {
+		t.Fatalf("Invoke(MutateRow): %v", err)
+	}
+
+	// One OpenTable per RPC: one for the ReadRows, one for the MutateRow.
+	if sc.newTableCalled != 2 {
+		t.Errorf("OpenTable called %d times; want 2 (one per RPC)", sc.newTableCalled)
 	}
 }
 

--- a/bigtable/internal/accelerator/resourcename.go
+++ b/bigtable/internal/accelerator/resourcename.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package accelerator
+
+import (
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Resource-name parsing for the channel's dispatch path.
+//
+// A Channel serves exactly one (project, instance). The session layer
+// re-derives the full resource name from that scope given only a leaf ID, so
+// it never sees — and cannot check — the project/instance a caller named. If
+// the channel simply stripped a full V2 name down to its leaf, a request
+// naming a different project/instance would be silently rebound onto this
+// daemon's scope (a cross-tenant confused-deputy). These parsers therefore
+// validate the project/instance segments against the channel's scope and
+// reject a mismatch, returning the leaf ID(s) only for an in-scope name.
+
+// stripScope verifies name begins with this daemon's
+// "projects/<project>/instances/<instance>/" prefix and returns the remainder
+// after it. A name targeting any other project/instance is rejected with
+// InvalidArgument rather than silently rebound onto this daemon's scope.
+func stripScope(name, project, instance string) (string, error) {
+	prefix := "projects/" + project + "/instances/" + instance + "/"
+	rest, ok := strings.CutPrefix(name, prefix)
+	if !ok {
+		return "", status.Errorf(codes.InvalidArgument,
+			"accelerator: resource %q is not in this daemon's scope (projects/%s/instances/%s)",
+			name, project, instance)
+	}
+	return rest, nil
+}
+
+// leafAfter returns the single path segment following seg at the front of
+// rest, requiring exactly one non-empty segment with no further "/". For
+// example leafAfter("tables/t", "tables/") returns "t".
+func leafAfter(name, rest, seg string) (string, error) {
+	v, ok := strings.CutPrefix(rest, seg)
+	if !ok || v == "" || strings.Contains(v, "/") {
+		return "", malformedResource(name)
+	}
+	return v, nil
+}
+
+func malformedResource(name string) error {
+	return status.Errorf(codes.InvalidArgument, "accelerator: malformed resource name %q", name)
+}
+
+// parseTableName validates that name is a table resource in this daemon's
+// (project, instance) and returns the table leaf ID.
+func parseTableName(name, project, instance string) (tableID string, err error) {
+	rest, err := stripScope(name, project, instance)
+	if err != nil {
+		return "", err
+	}
+	return leafAfter(name, rest, "tables/")
+}
+
+// parseAuthorizedViewName validates that name is an authorized-view resource in
+// this daemon's (project, instance) and returns the table and view leaf IDs.
+func parseAuthorizedViewName(name, project, instance string) (tableID, viewID string, err error) {
+	rest, err := stripScope(name, project, instance)
+	if err != nil {
+		return "", "", err
+	}
+	afterTables, ok := strings.CutPrefix(rest, "tables/")
+	if !ok {
+		return "", "", malformedResource(name)
+	}
+	tableID, viewID, ok = strings.Cut(afterTables, "/authorizedViews/")
+	if !ok || tableID == "" || viewID == "" ||
+		strings.Contains(tableID, "/") || strings.Contains(viewID, "/") {
+		return "", "", malformedResource(name)
+	}
+	return tableID, viewID, nil
+}
+
+// parseMaterializedViewName validates that name is a materialized-view resource
+// in this daemon's (project, instance) and returns the view leaf ID.
+func parseMaterializedViewName(name, project, instance string) (viewID string, err error) {
+	rest, err := stripScope(name, project, instance)
+	if err != nil {
+		return "", err
+	}
+	return leafAfter(name, rest, "materializedViews/")
+}

--- a/bigtable/internal/accelerator/resourcename.go
+++ b/bigtable/internal/accelerator/resourcename.go
@@ -32,17 +32,23 @@ import (
 // validate the project/instance segments against the channel's scope and
 // reject a mismatch, returning the leaf ID(s) only for an in-scope name.
 
-// stripScope verifies name begins with this daemon's
+// scopePrefixFor builds the "projects/<project>/instances/<instance>/" prefix a
+// Channel validates and strips resource names against. Precomputed once at
+// construction and stored on Channel.scopePrefix.
+func scopePrefixFor(project, instance string) string {
+	return "projects/" + project + "/instances/" + instance + "/"
+}
+
+// stripScope verifies name begins with this daemon's precomputed
 // "projects/<project>/instances/<instance>/" prefix and returns the remainder
 // after it. A name targeting any other project/instance is rejected with
 // InvalidArgument rather than silently rebound onto this daemon's scope.
-func stripScope(name, project, instance string) (string, error) {
-	prefix := "projects/" + project + "/instances/" + instance + "/"
-	rest, ok := strings.CutPrefix(name, prefix)
+func (c *Channel) stripScope(name string) (string, error) {
+	rest, ok := strings.CutPrefix(name, c.scopePrefix)
 	if !ok {
 		return "", status.Errorf(codes.InvalidArgument,
-			"accelerator: resource %q is not in this daemon's scope (projects/%s/instances/%s)",
-			name, project, instance)
+			"accelerator: resource %q is not in this daemon's scope (%s)",
+			name, strings.TrimSuffix(c.scopePrefix, "/"))
 	}
 	return rest, nil
 }
@@ -64,8 +70,8 @@ func malformedResource(name string) error {
 
 // parseTableName validates that name is a table resource in this daemon's
 // (project, instance) and returns the table leaf ID.
-func parseTableName(name, project, instance string) (tableID string, err error) {
-	rest, err := stripScope(name, project, instance)
+func (c *Channel) parseTableName(name string) (tableID string, err error) {
+	rest, err := c.stripScope(name)
 	if err != nil {
 		return "", err
 	}
@@ -74,8 +80,8 @@ func parseTableName(name, project, instance string) (tableID string, err error) 
 
 // parseAuthorizedViewName validates that name is an authorized-view resource in
 // this daemon's (project, instance) and returns the table and view leaf IDs.
-func parseAuthorizedViewName(name, project, instance string) (tableID, viewID string, err error) {
-	rest, err := stripScope(name, project, instance)
+func (c *Channel) parseAuthorizedViewName(name string) (tableID, viewID string, err error) {
+	rest, err := c.stripScope(name)
 	if err != nil {
 		return "", "", err
 	}
@@ -93,8 +99,8 @@ func parseAuthorizedViewName(name, project, instance string) (tableID, viewID st
 
 // parseMaterializedViewName validates that name is a materialized-view resource
 // in this daemon's (project, instance) and returns the view leaf ID.
-func parseMaterializedViewName(name, project, instance string) (viewID string, err error) {
-	rest, err := stripScope(name, project, instance)
+func (c *Channel) parseMaterializedViewName(name string) (viewID string, err error) {
+	rest, err := c.stripScope(name)
 	if err != nil {
 		return "", err
 	}

--- a/bigtable/internal/accelerator/resourcename_test.go
+++ b/bigtable/internal/accelerator/resourcename_test.go
@@ -26,6 +26,12 @@ const (
 	testInstance = "i"
 )
 
+// scopedTestChannel returns a Channel with only the scope the resource-name
+// parsers depend on (no session.Client dialed).
+func scopedTestChannel() *Channel {
+	return &Channel{scopePrefix: scopePrefixFor(testProject, testInstance)}
+}
+
 func TestParseTableName(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -43,7 +49,7 @@ func TestParseTableName(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := parseTableName(tc.in, testProject, testInstance)
+			got, err := scopedTestChannel().parseTableName(tc.in)
 			if status.Code(err) != tc.wantCode {
 				t.Fatalf("parseTableName(%q) code = %v; want %v (err=%v)", tc.in, status.Code(err), tc.wantCode, err)
 			}
@@ -70,7 +76,7 @@ func TestParseAuthorizedViewName(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotT, gotV, err := parseAuthorizedViewName(tc.in, testProject, testInstance)
+			gotT, gotV, err := scopedTestChannel().parseAuthorizedViewName(tc.in)
 			if status.Code(err) != tc.wantCode {
 				t.Fatalf("parseAuthorizedViewName(%q) code = %v; want %v (err=%v)", tc.in, status.Code(err), tc.wantCode, err)
 			}
@@ -95,7 +101,7 @@ func TestParseMaterializedViewName(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := parseMaterializedViewName(tc.in, testProject, testInstance)
+			got, err := scopedTestChannel().parseMaterializedViewName(tc.in)
 			if status.Code(err) != tc.wantCode {
 				t.Fatalf("parseMaterializedViewName(%q) code = %v; want %v (err=%v)", tc.in, status.Code(err), tc.wantCode, err)
 			}

--- a/bigtable/internal/accelerator/resourcename_test.go
+++ b/bigtable/internal/accelerator/resourcename_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package accelerator
+
+import (
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	testProject  = "p"
+	testInstance = "i"
+)
+
+func TestParseTableName(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       string
+		wantLeaf string
+		wantCode codes.Code
+	}{
+		{"in-scope", "projects/p/instances/i/tables/t", "t", codes.OK},
+		{"wrong-project", "projects/other/instances/i/tables/t", "", codes.InvalidArgument},
+		{"wrong-instance", "projects/p/instances/other/tables/t", "", codes.InvalidArgument},
+		{"not-a-table", "projects/p/instances/i/materializedViews/mv", "", codes.InvalidArgument},
+		{"empty-leaf", "projects/p/instances/i/tables/", "", codes.InvalidArgument},
+		{"extra-segment", "projects/p/instances/i/tables/t/authorizedViews/v", "", codes.InvalidArgument},
+		{"bare-leaf", "t", "", codes.InvalidArgument},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseTableName(tc.in, testProject, testInstance)
+			if status.Code(err) != tc.wantCode {
+				t.Fatalf("parseTableName(%q) code = %v; want %v (err=%v)", tc.in, status.Code(err), tc.wantCode, err)
+			}
+			if got != tc.wantLeaf {
+				t.Errorf("parseTableName(%q) = %q; want %q", tc.in, got, tc.wantLeaf)
+			}
+		})
+	}
+}
+
+func TestParseAuthorizedViewName(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        string
+		wantTable string
+		wantView  string
+		wantCode  codes.Code
+	}{
+		{"in-scope", "projects/p/instances/i/tables/t/authorizedViews/v", "t", "v", codes.OK},
+		{"wrong-project", "projects/other/instances/i/tables/t/authorizedViews/v", "", "", codes.InvalidArgument},
+		{"missing-view", "projects/p/instances/i/tables/t", "", "", codes.InvalidArgument},
+		{"empty-view", "projects/p/instances/i/tables/t/authorizedViews/", "", "", codes.InvalidArgument},
+		{"empty-table", "projects/p/instances/i/tables//authorizedViews/v", "", "", codes.InvalidArgument},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotT, gotV, err := parseAuthorizedViewName(tc.in, testProject, testInstance)
+			if status.Code(err) != tc.wantCode {
+				t.Fatalf("parseAuthorizedViewName(%q) code = %v; want %v (err=%v)", tc.in, status.Code(err), tc.wantCode, err)
+			}
+			if gotT != tc.wantTable || gotV != tc.wantView {
+				t.Errorf("parseAuthorizedViewName(%q) = (%q, %q); want (%q, %q)", tc.in, gotT, gotV, tc.wantTable, tc.wantView)
+			}
+		})
+	}
+}
+
+func TestParseMaterializedViewName(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       string
+		wantLeaf string
+		wantCode codes.Code
+	}{
+		{"in-scope", "projects/p/instances/i/materializedViews/mv", "mv", codes.OK},
+		{"wrong-instance", "projects/p/instances/other/materializedViews/mv", "", codes.InvalidArgument},
+		{"not-a-mat-view", "projects/p/instances/i/tables/t", "", codes.InvalidArgument},
+		{"empty-leaf", "projects/p/instances/i/materializedViews/", "", codes.InvalidArgument},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseMaterializedViewName(tc.in, testProject, testInstance)
+			if status.Code(err) != tc.wantCode {
+				t.Fatalf("parseMaterializedViewName(%q) code = %v; want %v (err=%v)", tc.in, status.Code(err), tc.wantCode, err)
+			}
+			if got != tc.wantLeaf {
+				t.Errorf("parseMaterializedViewName(%q) = %q; want %q", tc.in, got, tc.wantLeaf)
+			}
+		})
+	}
+}


### PR DESCRIPTION
…s through sessions

Wires the V2 data path onto the channel scaffold: Invoke routes MutateRow and NewStream routes single-row ReadRows to a per-resource session.TableAPI opened on the channel's session.Client, translating via internal/accelerator/adapters. ReadRows dispatch is lazy — deferred to the first RecvMsg — so consumer pull rate drives when session work happens. resourcename.go validates each V2 resource name against the daemon's (project, instance) scope, rejecting cross-tenant names rather than silently rebinding them onto this daemon, and reduces the name to the leaf ID(s) session.Client expects.

Change-Id: I3e81bd14ed5b675f82d7cff720f86a36e4124cd1