### PR TITLE
refactor(bigtable): move session table cache to internal/session

### DIFF
--- a/bigtable/client.go
+++ b/bigtable/client.go
@@ -75,8 +75,9 @@ type Client struct {
 	// same underlying session pools). session.Client does not cache;
 	// this Client is responsible. Entries evict on TTL-idle (default
 	// 1 h) via a background sweeper, or immediately when the caller
-	// calls Close() on the returned handle. See session_table_cache.go.
-	sessionTables *sessionTableCache
+	// calls Close() on the returned handle. See
+	// internal/session/table_cache.go.
+	sessionTables *session.TableCache
 }
 
 // ClientConfig has configurations for the client.
@@ -333,7 +334,7 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 		// qualified resource name as the cache key. Only constructed
 		// when the session backend is actually wired — a sweeper
 		// goroutine over an always-empty map would be dead weight.
-		c.sessionTables = newSessionTableCache(sessionTableCacheTTL, sessionTableCacheSweepInt, nil /* time.Now */)
+		c.sessionTables = session.NewTableCache(session.DefaultTableCacheTTL, session.DefaultTableCacheSweepInterval, nil /* time.Now */)
 	}
 
 	return c, nil
@@ -348,8 +349,8 @@ func (c *Client) Close() error {
 	// stops and every cached handle sees Close() before we tear down
 	// the session client that owns their pools. sessionTables is nil
 	// on hand-built Clients that skipped session-backend wiring; the
-	// cache's own close() nil-checks for that.
-	c.sessionTables.close()
+	// cache's own Close() nil-checks for that.
+	c.sessionTables.Close()
 	// Then the session backend — its bookkeeping (session pools,
 	// ConfigurationManager poller) winds down before we drop the
 	// shared gRPC channels. Any error is aggregated with the classic

--- a/bigtable/internal/session/api.go
+++ b/bigtable/internal/session/api.go
@@ -48,7 +48,7 @@ type TableAPI interface {
 	// does not close the shared channel pool.
 	//
 	// Per-handle pool teardown is safe because callers reach this method
-	// through bigtable.Client's sessionTableCache, which guarantees
+	// through bigtable.Client's session.TableCache, which guarantees
 	// at-most-one TableAPI per resource per Client. A future caller that
 	// bypasses that cache must add a refcount before calling Close.
 	Close() error

--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -599,7 +599,7 @@ func (sc *sessionClient) buildLazyReleaser(key poolKey) func() error {
 //     tearing down.
 //   - the entry is absent (already released — makes second calls safe).
 //
-// Assumes the caller (currently bigtable.Client via sessionTableCache)
+// Assumes the caller (currently bigtable.Client via session.TableCache)
 // guarantees at-most-one sessionTable per resource at any moment. That
 // invariant means no co-owner can be relying on the pool we're closing.
 // If session.Client is ever exposed to callers that bypass that cache,

--- a/bigtable/internal/session/table.go
+++ b/bigtable/internal/session/table.go
@@ -295,7 +295,7 @@ func dispatch[Args any, R any, Resp interface {
 // post-insert would leak a fresh pool.
 //
 // Safety of per-handle pool teardown also rests on a caller-side
-// invariant: bigtable.Client's sessionTableCache guarantees at-most-one
+// invariant: bigtable.Client's session.TableCache guarantees at-most-one
 // sessionTable per resource at any moment, so no co-owner sharing a
 // pool with us can be mid-flight when we tear it down. If session.Client
 // ever gains a caller that bypasses that cache, this method must gain

--- a/bigtable/internal/session/table_cache.go
+++ b/bigtable/internal/session/table_cache.go
@@ -164,18 +164,20 @@ func (h *TableHandle) dispatch() *TableHandle {
 	return cur
 }
 
-// ReadRow: atomic-Load fast path, self-heal on eviction. Happy path
-// adds one atomic Load vs a bare api.ReadRow; the cache-map lookup
-// only fires on the recovery branch inside dispatch().
+// ReadRow proxies to the underlying TableAPI on the atomic-Load fast
+// path, self-healing via dispatch() on eviction. Happy path adds one
+// atomic Load vs a bare api.ReadRow; the cache-map lookup only fires
+// on the recovery branch inside dispatch().
 func (h *TableHandle) ReadRow(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
 	d := h.dispatch()
 	d.touch()
 	return d.api.ReadRow(ctx, req)
 }
 
-// MutateRow: same shape as ReadRow. Kept minimal so any future proxied
-// method (BulkMutate, SampleRowKeys, etc.) drops in as a 3-line pass-
-// through without duplicating the self-heal conditional.
+// MutateRow proxies to the underlying TableAPI, same shape as ReadRow.
+// Kept minimal so any future proxied method (BulkMutate, SampleRowKeys,
+// etc.) drops in as a 3-line pass-through without duplicating the
+// self-heal conditional.
 func (h *TableHandle) MutateRow(ctx context.Context, req *btpb.SessionMutateRowRequest) (*btpb.SessionMutateRowResponse, error) {
 	d := h.dispatch()
 	d.touch()

--- a/bigtable/internal/session/table_cache.go
+++ b/bigtable/internal/session/table_cache.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bigtable
+package session
 
 import (
 	"context"
@@ -21,22 +21,21 @@ import (
 	"time"
 
 	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
-	"cloud.google.com/go/bigtable/internal/session"
 )
 
-// Default eviction parameters for sessionTableCache. Vars (not consts)
-// so tests can tighten the sweep interval and TTL to milliseconds
+// Default eviction parameters for TableCache. Vars (not consts) so
+// tests can tighten the sweep interval and TTL to milliseconds
 // without touching the code under test.
 var (
-	sessionTableCacheTTL      = 1 * time.Hour
-	sessionTableCacheSweepInt = 10 * time.Minute
+	DefaultTableCacheTTL           = 1 * time.Hour
+	DefaultTableCacheSweepInterval = 10 * time.Minute
 )
 
-// sessionTableHandle wraps a session.TableAPI with a back-reference
-// to its cache and an atomically-updated last-access timestamp. It IS
-// the cache entry — one type does both jobs, so ReadRow / MutateRow
-// implicitly touch the entry without requiring the caller (TableShim)
-// to know about the cache.
+// TableHandle wraps a TableAPI with a back-reference to its cache and
+// an atomically-updated last-access timestamp. It IS the cache entry —
+// one type does both jobs, so ReadRow / MutateRow implicitly touch
+// the entry without requiring the caller (TableShim) to know about
+// the cache.
 //
 // Close() runs the eviction: removes the handle from the cache map
 // AND calls the underlying api.Close(), both guarded by closeOnce so
@@ -45,35 +44,35 @@ var (
 // every subsequent Close() call — that keeps the observable behavior
 // stable for callers that treat Close as a query.
 //
-// Underlying Close: session.TableAPI.Close (sessionTable.Close in
-// internal/session/table.go) releases the per-resource read + write
-// pool entries from sessionClient.sessionPools. Cache eviction — TTL
-// sweep, explicit handle Close, or cache-wide shutdown — therefore
-// actually reclaims the session pools for the resource. Safety of
-// per-handle teardown depends on this cache's at-most-one-handle-per-
-// key invariant, which acts as an implicit refcount of size 1; see
-// sessionTable.Close's doc.
-type sessionTableHandle struct {
-	api session.TableAPI
+// Underlying Close: TableAPI.Close (sessionTable.Close in table.go)
+// releases the per-resource read + write pool entries from
+// sessionClient.sessionPools. Cache eviction — TTL sweep, explicit
+// handle Close, or cache-wide shutdown — therefore actually reclaims
+// the session pools for the resource. Safety of per-handle teardown
+// depends on this cache's at-most-one-handle-per-key invariant, which
+// acts as an implicit refcount of size 1; see sessionTable.Close's
+// doc.
+type TableHandle struct {
+	api TableAPI
 	// openFn is the factory captured at cache-miss insertion time
-	// (session_table_cache.go's getOrOpen, driven from open.go via
+	// (table_cache.go's GetOrOpen, driven from bigtable/open.go via
 	// c.sessionImpl.OpenTable / OpenAuthorizedView / OpenMaterializedView).
-	// Invoked ONLY through cache.getOrOpen, which nil-guards on the
+	// Invoked ONLY through cache.GetOrOpen, which nil-guards on the
 	// closed cache; do not call this field directly or the post-close
 	// eviction guard is lost. Safe to hold for the process lifetime:
-	// *Client.sessionImpl is set-once at NewClient and never
+	// *bigtable.Client.sessionImpl is set-once at NewClient and never
 	// reassigned, so the closure never goes stale. If that ever
 	// becomes reconfigurable, self-heal will stale — revisit here.
 	//
 	// Invariant: openFn is the one captured at first insertion for the
 	// key. resolveSuccessor threads it through unchanged into any
-	// successor getOrOpen call, so all handles that ever share the key
+	// successor GetOrOpen call, so all handles that ever share the key
 	// share the same closure. Threading a per-call override into
-	// getOrOpen without also updating this invariant would silently
+	// GetOrOpen without also updating this invariant would silently
 	// leave successors using the original openFn.
-	openFn         func() session.TableAPI
+	openFn         func() TableAPI
 	key            string
-	cache          *sessionTableCache
+	cache          *TableCache
 	lastAccessNano atomic.Int64
 	// evicted flips to true inside Close() BEFORE api.Close runs. The
 	// happy-path cost is one atomic Load per RPC — the cache-map lookup
@@ -97,14 +96,14 @@ type sessionTableHandle struct {
 	// directly — no cache-map lookup, no cache.mu acquisition. Under
 	// TableShim's process-lifetime pointer-caching pattern this matters:
 	// without it, EVERY RPC on a stale handle would pay 2× cache.mu
-	// (removeEntry + getOrOpen) forever until process restart. With it,
+	// (removeEntry + GetOrOpen) forever until process restart. With it,
 	// only the FIRST post-eviction RPC pays that cost; all subsequent
 	// ones are one extra atomic.Load. dispatch() also applies path
 	// compression on the return so a chain of evicted handles collapses
 	// on the next observation.
 	//
 	// Store races are safe: two concurrent dispatches that both call
-	// resolveSuccessor race into getOrOpen, which is at-most-one-per-key
+	// resolveSuccessor race into GetOrOpen, which is at-most-one-per-key
 	// (loser closes its local api and returns the winner's handle), so
 	// both racers see the same `next` — the Store is idempotent. A
 	// divergent-`next` race (successor itself gets evicted between one
@@ -112,12 +111,17 @@ type sessionTableHandle struct {
 	// successor pointer; the next dispatch's outer for loop walks one
 	// extra hop through it and updates. No correctness bug, just a
 	// lagging compression.
-	successor atomic.Pointer[sessionTableHandle]
+	successor atomic.Pointer[TableHandle]
 	closeOnce sync.Once
 	closeErr  error
 }
 
-func (h *sessionTableHandle) touch() {
+// Unwrap returns the underlying TableAPI. Intended for test
+// inspection — production callers should use ReadRow / MutateRow so
+// dispatch()'s self-heal path stays in effect.
+func (h *TableHandle) Unwrap() TableAPI { return h.api }
+
+func (h *TableHandle) touch() {
 	h.lastAccessNano.Store(h.cache.now().UnixNano())
 }
 
@@ -141,7 +145,7 @@ func (h *sessionTableHandle) touch() {
 //
 // Callers dispatch onto the returned handle and pay the touch() there,
 // so ReadRow / MutateRow avoid the wasted touch on the doomed original.
-func (h *sessionTableHandle) dispatch() *sessionTableHandle {
+func (h *TableHandle) dispatch() *TableHandle {
 	cur := h
 	for cur.evicted.Load() {
 		next := cur.successor.Load()
@@ -163,7 +167,7 @@ func (h *sessionTableHandle) dispatch() *sessionTableHandle {
 // ReadRow: atomic-Load fast path, self-heal on eviction. Happy path
 // adds one atomic Load vs a bare api.ReadRow; the cache-map lookup
 // only fires on the recovery branch inside dispatch().
-func (h *sessionTableHandle) ReadRow(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
+func (h *TableHandle) ReadRow(ctx context.Context, req *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
 	d := h.dispatch()
 	d.touch()
 	return d.api.ReadRow(ctx, req)
@@ -172,7 +176,7 @@ func (h *sessionTableHandle) ReadRow(ctx context.Context, req *btpb.SessionReadR
 // MutateRow: same shape as ReadRow. Kept minimal so any future proxied
 // method (BulkMutate, SampleRowKeys, etc.) drops in as a 3-line pass-
 // through without duplicating the self-heal conditional.
-func (h *sessionTableHandle) MutateRow(ctx context.Context, req *btpb.SessionMutateRowRequest) (*btpb.SessionMutateRowResponse, error) {
+func (h *TableHandle) MutateRow(ctx context.Context, req *btpb.SessionMutateRowRequest) (*btpb.SessionMutateRowResponse, error) {
 	d := h.dispatch()
 	d.touch()
 	return d.api.MutateRow(ctx, req)
@@ -185,32 +189,32 @@ func (h *sessionTableHandle) MutateRow(ctx context.Context, req *btpb.SessionMut
 //
 // The removeEntry call covers the interleaving where Close.Do fired
 // evicted.Store(true) but has not yet reached its own removeEntry (h is
-// still installed in the map). Without it, our subsequent getOrOpen
+// still installed in the map). Without it, our subsequent GetOrOpen
 // fast-path would return h itself and dispatch would loop forever. On
 // the sweeper path (where sweepOnce already removed h before firing
 // Close), this is a harmless no-op — removeEntry is identity-scoped, so
 // it won't clobber a peer's fresh install either.
-func (h *sessionTableHandle) resolveSuccessor() *sessionTableHandle {
+func (h *TableHandle) resolveSuccessor() *TableHandle {
 	h.cache.removeEntry(h.key, h)
-	api := h.cache.getOrOpen(h.key, h.openFn)
+	api := h.cache.GetOrOpen(h.key, h.openFn)
 	if api == nil {
 		return nil
 	}
 	// Type assertion narrows the interface back to the concrete cache
-	// entry. Guaranteed non-nil-and-not-h by getOrOpen's insertion path
-	// (the only construction site is inside getOrOpen's slow path,
-	// which mints a fresh *sessionTableHandle) — the assertion is a
-	// defensive check against a future getOrOpen contributor changing
-	// what the cache stores. If that ever fires, dispatch() falls
-	// through to h.api, which will surface the closed-api error.
-	fresh, _ := api.(*sessionTableHandle)
+	// entry. Guaranteed non-nil-and-not-h by GetOrOpen's insertion path
+	// (the only construction site is inside GetOrOpen's slow path,
+	// which mints a fresh *TableHandle) — the assertion is a defensive
+	// check against a future GetOrOpen contributor changing what the
+	// cache stores. If that ever fires, dispatch() falls through to
+	// h.api, which will surface the closed-api error.
+	fresh, _ := api.(*TableHandle)
 	return fresh
 }
 
 // Close evicts the handle from its cache and Close()s the underlying
-// session.TableAPI. Fully idempotent: subsequent calls return the
-// error captured on the first call without invoking api.Close again.
-// Safe to call from multiple paths (explicit caller Close, TTL sweep,
+// TableAPI. Fully idempotent: subsequent calls return the error
+// captured on the first call without invoking api.Close again. Safe
+// to call from multiple paths (explicit caller Close, TTL sweep,
 // cache-wide shutdown) concurrently.
 //
 // The three steps run in strict order inside closeOnce.Do:
@@ -218,15 +222,15 @@ func (h *sessionTableHandle) resolveSuccessor() *sessionTableHandle {
 //  1. evicted.Store(true) — readers observing true after this point
 //     route through dispatch() → resolveSuccessor instead of taking
 //     the fast path onto the doomed api.
-//  2. cache.removeEntry — future getOrOpen callers stop finding this
+//  2. cache.removeEntry — future GetOrOpen callers stop finding this
 //     handle in the map, so cache misses fall through to openFn and
 //     mint a fresh live successor.
 //  3. api.Close — actually tears down the underlying pool.
 //
 // The (1) → (3) ordering is the load-bearing invariant for self-heal.
-// (2) between them just tightens the window in which a getOrOpen
+// (2) between them just tightens the window in which a GetOrOpen
 // fast-path could still return this now-evicted handle.
-func (h *sessionTableHandle) Close() error {
+func (h *TableHandle) Close() error {
 	h.closeOnce.Do(func() {
 		h.evicted.Store(true)
 		h.cache.removeEntry(h.key, h)
@@ -235,26 +239,26 @@ func (h *sessionTableHandle) Close() error {
 	return h.closeErr
 }
 
-// sessionTableCache holds per-resource sessionTableHandles with
-// TTL-on-idle eviction. Zero size cap — cardinality is naturally
-// bounded by the caller's Open* pattern.
+// TableCache holds per-resource TableHandles with TTL-on-idle
+// eviction. Zero size cap — cardinality is naturally bounded by the
+// caller's Open* pattern.
 //
-// The cache is opener-agnostic: getOrOpen takes an openFn per call
+// The cache is opener-agnostic: GetOrOpen takes an openFn per call
 // so a single cache can back tables, authorized views, and
 // materialized views without needing to encode the resource kind
 // in the key or dispatch on a prefix. Keys are opaque strings; the
 // consumer (bigtable.Client) uses the fully-qualified resource name
 // (projects/P/instances/I/tables/T, etc.) so the cache key is the
 // same identity Cloud Bigtable uses over the wire.
-type sessionTableCache struct {
+type TableCache struct {
 	ttl           time.Duration
 	sweepInterval time.Duration
 
 	mu      sync.Mutex
-	entries map[string]*sessionTableHandle
-	// closed is flipped by close() under mu. getOrOpen's slow path
+	entries map[string]*TableHandle
+	// closed is flipped by Close() under mu. GetOrOpen's slow path
 	// re-checks it before inserting the freshly-opened handle so a
-	// slow-path insert straddling close() can't orphan a live
+	// slow-path insert straddling Close() can't orphan a live
 	// underlying api (which would leak its per-resource session pool
 	// once sessionTable.Close does real teardown).
 	closed bool
@@ -264,21 +268,21 @@ type sessionTableCache struct {
 	sweeperG sync.WaitGroup
 
 	// now is a func for tests to inject synthetic time. Defaults to
-	// time.Now when nil is passed to newSessionTableCache.
+	// time.Now when nil is passed to NewTableCache.
 	now func() time.Time
 }
 
-// newSessionTableCache constructs a cache and starts its background
-// sweeper. Production callers pass nil for now (→ time.Now); tests
-// inject a controllable clock.
-func newSessionTableCache(ttl, sweepInterval time.Duration, now func() time.Time) *sessionTableCache {
+// NewTableCache constructs a cache and starts its background sweeper.
+// Production callers pass nil for now (→ time.Now); tests inject a
+// controllable clock.
+func NewTableCache(ttl, sweepInterval time.Duration, now func() time.Time) *TableCache {
 	if now == nil {
 		now = time.Now
 	}
-	c := &sessionTableCache{
+	c := &TableCache{
 		ttl:           ttl,
 		sweepInterval: sweepInterval,
-		entries:       make(map[string]*sessionTableHandle),
+		entries:       make(map[string]*TableHandle),
 		stop:          make(chan struct{}),
 		now:           now,
 	}
@@ -287,7 +291,7 @@ func newSessionTableCache(ttl, sweepInterval time.Duration, now func() time.Time
 	return c
 }
 
-// getOrOpen returns the cached handle for key, opening a fresh one
+// GetOrOpen returns the cached handle for key, opening a fresh one
 // via openFn on cache miss. Returns nil when openFn returns nil.
 //
 // openFn is invoked OUTSIDE the cache mutex — safe for callers whose
@@ -295,7 +299,7 @@ func newSessionTableCache(ttl, sweepInterval time.Duration, now func() time.Time
 // callers race to open the same key concurrently, both may invoke
 // their openFn; the loser's api gets Close()d and the winner's is
 // returned to both callers.
-func (c *sessionTableCache) getOrOpen(key string, openFn func() session.TableAPI) session.TableAPI {
+func (c *TableCache) GetOrOpen(key string, openFn func() TableAPI) TableAPI {
 	if c == nil {
 		return nil
 	}
@@ -319,9 +323,9 @@ func (c *sessionTableCache) getOrOpen(key string, openFn func() session.TableAPI
 
 	c.mu.Lock()
 	if c.closed {
-		// close() ran between the slow-path openFn and our re-lock.
+		// Close() ran between the slow-path openFn and our re-lock.
 		// If we inserted this handle now, nothing would ever call
-		// its Close (sweeper stopped, close() already snapshotted an
+		// its Close (sweeper stopped, Close() already snapshotted an
 		// empty map, cache-Close is stopOnce-guarded). Release the
 		// freshly-opened api ourselves and return nil so the caller
 		// falls back to classic (TableShim treats nil session-side
@@ -336,7 +340,7 @@ func (c *sessionTableCache) getOrOpen(key string, openFn func() session.TableAPI
 		h.touch()
 		return h
 	}
-	h := &sessionTableHandle{api: api, openFn: openFn, key: key, cache: c}
+	h := &TableHandle{api: api, openFn: openFn, key: key, cache: c}
 	h.lastAccessNano.Store(c.now().UnixNano())
 	c.entries[key] = h
 	c.mu.Unlock()
@@ -347,7 +351,7 @@ func (c *sessionTableCache) getOrOpen(key string, openFn func() session.TableAPI
 // exactly h. Guards against the race where Close and a concurrent
 // Open both raced: Close should not evict the freshly-inserted
 // handle installed by the new Open.
-func (c *sessionTableCache) removeEntry(key string, h *sessionTableHandle) {
+func (c *TableCache) removeEntry(key string, h *TableHandle) {
 	c.mu.Lock()
 	if c.entries[key] == h {
 		delete(c.entries, key)
@@ -356,8 +360,8 @@ func (c *sessionTableCache) removeEntry(key string, h *sessionTableHandle) {
 }
 
 // sweeperLoop walks the cache every sweepInterval and evicts entries
-// idle for > ttl. Exits when close() signals stop.
-func (c *sessionTableCache) sweeperLoop() {
+// idle for > ttl. Exits when Close() signals stop.
+func (c *TableCache) sweeperLoop() {
 	defer c.sweeperG.Done()
 	t := time.NewTicker(c.sweepInterval)
 	defer t.Stop()
@@ -385,11 +389,11 @@ func (c *sessionTableCache) sweeperLoop() {
 // isn't on the RPC hot path. If cardinality ever grows to matter, a
 // time-ordered heap keyed by lastAccess would trim this to O(k) per
 // sweep where k = evicted count.
-func (c *sessionTableCache) sweepOnce() {
+func (c *TableCache) sweepOnce() {
 	cutoff := c.now().Add(-c.ttl).UnixNano()
 
 	c.mu.Lock()
-	var evicted []*sessionTableHandle
+	var evicted []*TableHandle
 	for k, h := range c.entries {
 		if h.lastAccessNano.Load() < cutoff {
 			evicted = append(evicted, h)
@@ -403,9 +407,9 @@ func (c *sessionTableCache) sweepOnce() {
 	}
 }
 
-// close stops the sweeper, waits for it to exit, then Close()s every
+// Close stops the sweeper, waits for it to exit, then Close()s every
 // remaining handle. Safe to call multiple times.
-func (c *sessionTableCache) close() {
+func (c *TableCache) Close() {
 	if c == nil {
 		return
 	}
@@ -416,7 +420,7 @@ func (c *sessionTableCache) close() {
 
 	c.mu.Lock()
 	c.closed = true
-	remaining := make([]*sessionTableHandle, 0, len(c.entries))
+	remaining := make([]*TableHandle, 0, len(c.entries))
 	for k, h := range c.entries {
 		remaining = append(remaining, h)
 		delete(c.entries, k)

--- a/bigtable/internal/session/table_cache_test.go
+++ b/bigtable/internal/session/table_cache_test.go
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// sessionTableCache + sessionTableHandle unit tests. Split out from
-// open_test.go after it crossed the 1000-line guideline. Cache-level
-// fakes (noopSessionTable, unwrapSession) live in open_test.go because
-// the open-path tests also consume them; cache-only helpers
-// (fakeClock, newTestSessionTableCache, openNoop, openClosing,
-// closeCountingTable) live here alongside their only callers.
+// TableCache + TableHandle unit tests. Cache-only helpers (fakeClock,
+// newTestTableCache, openNoop, openClosing, closeCountingTable, plus
+// the local noopTable fake TableAPI) live here alongside their only
+// callers.
 
-package bigtable
+package session
 
 import (
 	"context"
@@ -29,37 +27,47 @@ import (
 	"time"
 
 	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
-	"cloud.google.com/go/bigtable/internal/session"
 )
 
-// ─── sessionTableCache tests ──────────────────────────────────────────
+// noopTable is a TableAPI implementation whose RPC methods are no-ops.
+// Tests only inspect identity (pointer equality) so cache-hit vs.
+// cache-miss can be distinguished.
+type noopTable struct{ key string }
 
-// newTestSessionTableCache builds a cache with an injectable clock.
-// Sweep interval is intentionally long — tests drive sweepOnce
-// directly instead of waiting on the background ticker, which is
-// wall-clock and flaky under CI scheduler pressure (#20266). TTL is
-// set per test.
-func newTestSessionTableCache(t *testing.T, ttl time.Duration, clock *fakeClock) *sessionTableCache {
+func (n *noopTable) ReadRow(context.Context, *btpb.SessionReadRowRequest) (*btpb.SessionReadRowResponse, error) {
+	return &btpb.SessionReadRowResponse{}, nil
+}
+func (n *noopTable) MutateRow(context.Context, *btpb.SessionMutateRowRequest) (*btpb.SessionMutateRowResponse, error) {
+	return &btpb.SessionMutateRowResponse{}, nil
+}
+func (n *noopTable) Close() error { return nil }
+
+// newTestTableCache builds a cache with an injectable clock. Sweep
+// interval is intentionally long — tests drive sweepOnce directly
+// instead of waiting on the background ticker, which is wall-clock
+// and flaky under CI scheduler pressure (#20266). TTL is set per
+// test.
+func newTestTableCache(t *testing.T, ttl time.Duration, clock *fakeClock) *TableCache {
 	t.Helper()
-	c := newSessionTableCache(ttl, 1*time.Hour, clock.now)
-	t.Cleanup(c.close)
+	c := NewTableCache(ttl, 1*time.Hour, clock.now)
+	t.Cleanup(c.Close)
 	return c
 }
 
-// openNoop returns an openFn that constructs a *noopSessionTable
-// stamped with the given key. Used by cache-internal tests that
-// want to inspect which key the cache asked to open.
-func openNoop(key string) func() session.TableAPI {
-	return func() session.TableAPI { return &noopSessionTable{key: key} }
+// openNoop returns an openFn that constructs a *noopTable stamped with
+// the given key. Used by cache-internal tests that want to inspect
+// which key the cache asked to open.
+func openNoop(key string) func() TableAPI {
+	return func() TableAPI { return &noopTable{key: key} }
 }
 
-// openClosing returns an openFn that constructs a
-// *closeCountingTable stamped with the given key, atomically
-// incrementing counter on every Close call. Counter is atomic so
-// sweeper-goroutine writes don't race the test's Load.
-func openClosing(key string, counter *atomic.Int32) func() session.TableAPI {
-	return func() session.TableAPI {
-		return &closeCountingTable{noopSessionTable{key: key}, counter}
+// openClosing returns an openFn that constructs a *closeCountingTable
+// stamped with the given key, atomically incrementing counter on every
+// Close call. Counter is atomic so sweeper-goroutine writes don't race
+// the test's Load.
+func openClosing(key string, counter *atomic.Int32) func() TableAPI {
+	return func() TableAPI {
+		return &closeCountingTable{noopTable{key: key}, counter}
 	}
 }
 
@@ -76,31 +84,31 @@ func newFakeClock(start time.Time) *fakeClock {
 func (c *fakeClock) now() time.Time          { return time.Unix(0, c.nano.Load()) }
 func (c *fakeClock) advance(d time.Duration) { c.nano.Add(int64(d)) }
 
-// TestSessionTableCache_HandleIsCacheEntry pins that the returned
-// handle satisfies session.TableAPI, wraps the underlying api, and
-// is the same value the cache holds (identity check on repeat Open).
-func TestSessionTableCache_HandleIsCacheEntry(t *testing.T) {
+// TestTableCache_HandleIsCacheEntry pins that the returned handle
+// satisfies TableAPI, wraps the underlying api, and is the same value
+// the cache holds (identity check on repeat Open).
+func TestTableCache_HandleIsCacheEntry(t *testing.T) {
 	clock := newFakeClock(time.Unix(1_700_000_000, 0))
-	c := newTestSessionTableCache(t, 1*time.Hour, clock)
+	c := newTestTableCache(t, 1*time.Hour, clock)
 
-	h1 := c.getOrOpen("tbl:t", openNoop("tbl:t")).(*sessionTableHandle)
-	h2 := c.getOrOpen("tbl:t", openNoop("tbl:t")).(*sessionTableHandle)
+	h1 := c.GetOrOpen("tbl:t", openNoop("tbl:t")).(*TableHandle)
+	h2 := c.GetOrOpen("tbl:t", openNoop("tbl:t")).(*TableHandle)
 	if h1 != h2 {
-		t.Errorf("repeat getOrOpen on same key = distinct handles: h1=%p h2=%p", h1, h2)
+		t.Errorf("repeat GetOrOpen on same key = distinct handles: h1=%p h2=%p", h1, h2)
 	}
-	if _, ok := h1.api.(*noopSessionTable); !ok {
-		t.Errorf("handle.api = %T, want *noopSessionTable", h1.api)
+	if _, ok := h1.api.(*noopTable); !ok {
+		t.Errorf("handle.api = %T, want *noopTable", h1.api)
 	}
 }
 
-// TestSessionTableCache_ReadRowTouchesLastAccess pins that the
-// wrapper's ReadRow updates lastAccess so a caller polling every
-// ReadRow keeps the entry alive.
-func TestSessionTableCache_ReadRowTouchesLastAccess(t *testing.T) {
+// TestTableCache_ReadRowTouchesLastAccess pins that the wrapper's
+// ReadRow updates lastAccess so a caller polling every ReadRow keeps
+// the entry alive.
+func TestTableCache_ReadRowTouchesLastAccess(t *testing.T) {
 	clock := newFakeClock(time.Unix(1_700_000_000, 0))
-	c := newTestSessionTableCache(t, 1*time.Hour, clock)
+	c := newTestTableCache(t, 1*time.Hour, clock)
 
-	h := c.getOrOpen("tbl:t", openNoop("tbl:t")).(*sessionTableHandle)
+	h := c.GetOrOpen("tbl:t", openNoop("tbl:t")).(*TableHandle)
 	before := h.lastAccessNano.Load()
 
 	clock.advance(30 * time.Minute)
@@ -112,17 +120,17 @@ func TestSessionTableCache_ReadRowTouchesLastAccess(t *testing.T) {
 	}
 }
 
-// TestSessionTableCache_CloseEvictsAndFires pins that handle.Close
-// removes the entry from the cache map AND calls the underlying
-// api.Close, and that a subsequent getOrOpen mints a fresh handle
-// (the closed one is not resurrected).
-func TestSessionTableCache_CloseEvictsAndFires(t *testing.T) {
+// TestTableCache_CloseEvictsAndFires pins that handle.Close removes
+// the entry from the cache map AND calls the underlying api.Close,
+// and that a subsequent GetOrOpen mints a fresh handle (the closed
+// one is not resurrected).
+func TestTableCache_CloseEvictsAndFires(t *testing.T) {
 	clock := newFakeClock(time.Unix(1_700_000_000, 0))
 	var closeCount atomic.Int32
-	c := newSessionTableCache(1*time.Hour, 1*time.Second, clock.now)
-	t.Cleanup(c.close)
+	c := NewTableCache(1*time.Hour, 1*time.Second, clock.now)
+	t.Cleanup(c.Close)
 
-	h1 := c.getOrOpen("tbl:t", openClosing("tbl:t", &closeCount)).(*sessionTableHandle)
+	h1 := c.GetOrOpen("tbl:t", openClosing("tbl:t", &closeCount)).(*TableHandle)
 	if err := h1.Close(); err != nil {
 		t.Fatalf("h1.Close: %v", err)
 	}
@@ -137,9 +145,9 @@ func TestSessionTableCache_CloseEvictsAndFires(t *testing.T) {
 		t.Error("entry still present after handle.Close()")
 	}
 	// Second Open mints a fresh handle.
-	h2 := c.getOrOpen("tbl:t", openClosing("tbl:t", &closeCount)).(*sessionTableHandle)
+	h2 := c.GetOrOpen("tbl:t", openClosing("tbl:t", &closeCount)).(*TableHandle)
 	if h2 == h1 {
-		t.Error("getOrOpen after Close returned the evicted handle")
+		t.Error("GetOrOpen after Close returned the evicted handle")
 	}
 	// Double-Close on h1 is fully idempotent — closeOnce guards both
 	// the map removal AND the underlying api.Close call, so the
@@ -152,9 +160,9 @@ func TestSessionTableCache_CloseEvictsAndFires(t *testing.T) {
 	}
 }
 
-// TestSessionTableCache_TTLSweepEvictsIdle pins that a sweep evicts
-// entries whose lastAccess is older than TTL, and calls the
-// underlying Close on eviction.
+// TestTableCache_TTLSweepEvictsIdle pins that a sweep evicts entries
+// whose lastAccess is older than TTL, and calls the underlying Close
+// on eviction.
 //
 // Drives sweepOnce directly instead of polling on the background
 // ticker: the ticker fires at a real-wall-clock cadence and, under CI
@@ -162,18 +170,18 @@ func TestSessionTableCache_CloseEvictsAndFires(t *testing.T) {
 // window even at a 1ms interval — see #20266 for the flake pattern.
 // Same-package access to sweepOnce lets us exercise the sweep logic
 // deterministically without any wall-clock dependency.
-func TestSessionTableCache_TTLSweepEvictsIdle(t *testing.T) {
+func TestTableCache_TTLSweepEvictsIdle(t *testing.T) {
 	clock := newFakeClock(time.Unix(1_700_000_000, 0))
 	var closeCount atomic.Int32
 	// Use a long sweepInterval so the background ticker never races the
 	// direct sweepOnce call below — the test asserts sweep behavior,
 	// not scheduler timing.
-	c := newSessionTableCache(1*time.Hour, 1*time.Hour, clock.now)
-	t.Cleanup(c.close)
+	c := NewTableCache(1*time.Hour, 1*time.Hour, clock.now)
+	t.Cleanup(c.Close)
 
 	// Open two handles, touch neither.
-	_ = c.getOrOpen("tbl:a", openClosing("tbl:a", &closeCount))
-	_ = c.getOrOpen("tbl:b", openClosing("tbl:b", &closeCount))
+	_ = c.GetOrOpen("tbl:a", openClosing("tbl:a", &closeCount))
+	_ = c.GetOrOpen("tbl:b", openClosing("tbl:b", &closeCount))
 
 	// Advance past TTL and drive a sweep synchronously.
 	clock.advance(2 * time.Hour)
@@ -190,14 +198,14 @@ func TestSessionTableCache_TTLSweepEvictsIdle(t *testing.T) {
 	}
 }
 
-// TestSessionTableCache_TouchDefersEviction pins that a ReadRow
-// touch resets the idle timer — an entry touched every half-TTL
-// stays alive indefinitely.
-func TestSessionTableCache_TouchDefersEviction(t *testing.T) {
+// TestTableCache_TouchDefersEviction pins that a ReadRow touch resets
+// the idle timer — an entry touched every half-TTL stays alive
+// indefinitely.
+func TestTableCache_TouchDefersEviction(t *testing.T) {
 	clock := newFakeClock(time.Unix(1_700_000_000, 0))
-	c := newTestSessionTableCache(t, 1*time.Hour, clock)
+	c := newTestTableCache(t, 1*time.Hour, clock)
 
-	h := c.getOrOpen("tbl:t", openNoop("tbl:t")).(*sessionTableHandle)
+	h := c.GetOrOpen("tbl:t", openNoop("tbl:t")).(*TableHandle)
 	// Every half-TTL, touch and step past a full TTL from the LAST
 	// touch. Each touch resets the clock reference so eviction never
 	// triggers.
@@ -216,68 +224,68 @@ func TestSessionTableCache_TouchDefersEviction(t *testing.T) {
 	}
 }
 
-// TestSessionTableCache_CloseEvictsAll pins that closing the cache
-// itself stops the sweeper and closes every remaining entry.
-func TestSessionTableCache_CloseEvictsAll(t *testing.T) {
+// TestTableCache_CloseEvictsAll pins that closing the cache itself
+// stops the sweeper and closes every remaining entry.
+func TestTableCache_CloseEvictsAll(t *testing.T) {
 	clock := newFakeClock(time.Unix(1_700_000_000, 0))
 	var closeCount atomic.Int32
-	c := newSessionTableCache(1*time.Hour, 1*time.Hour, clock.now)
+	c := NewTableCache(1*time.Hour, 1*time.Hour, clock.now)
 
-	_ = c.getOrOpen("tbl:a", openClosing("tbl:a", &closeCount))
-	_ = c.getOrOpen("tbl:b", openClosing("tbl:b", &closeCount))
-	_ = c.getOrOpen("mv:v", openClosing("mv:v", &closeCount))
+	_ = c.GetOrOpen("tbl:a", openClosing("tbl:a", &closeCount))
+	_ = c.GetOrOpen("tbl:b", openClosing("tbl:b", &closeCount))
+	_ = c.GetOrOpen("mv:v", openClosing("mv:v", &closeCount))
 
-	c.close()
+	c.Close()
 
 	if got := closeCount.Load(); got != 3 {
-		t.Errorf("close(): underlying Close called %d times, want 3", got)
+		t.Errorf("Close(): underlying Close called %d times, want 3", got)
 	}
-	// close() is idempotent.
-	c.close()
+	// Close() is idempotent.
+	c.Close()
 }
 
-// TestSessionTableCache_ClosedGate_SlowPathInsertNoLeak reproduces
-// audit finding #5: without the closed-gate in getOrOpen's slow path,
-// a caller whose openFn straddles cache.close() would leak the
-// freshly-opened api (installed into a cache the sweeper has already
-// stopped clearing). This test forces that interleaving via a
-// synchronization channel on the openFn.
+// TestTableCache_ClosedGate_SlowPathInsertNoLeak reproduces audit
+// finding #5: without the closed-gate in GetOrOpen's slow path, a
+// caller whose openFn straddles cache.Close() would leak the freshly-
+// opened api (installed into a cache the sweeper has already stopped
+// clearing). This test forces that interleaving via a synchronization
+// channel on the openFn.
 //
-// Shape: caller A begins getOrOpen("k") on an empty cache. Fast-path
+// Shape: caller A begins GetOrOpen("k") on an empty cache. Fast-path
 // misses. Slow-path calls openFn. openFn blocks until we signal it to
-// return. Meanwhile close() runs on the cache (flips closed, walks the
-// empty map). Then openFn returns. getOrOpen re-locks, sees closed,
+// return. Meanwhile Close() runs on the cache (flips closed, walks the
+// empty map). Then openFn returns. GetOrOpen re-locks, sees closed,
 // releases the fresh api itself, and returns nil. Underlying api's
 // Close counter must reach 1.
-func TestSessionTableCache_ClosedGate_SlowPathInsertNoLeak(t *testing.T) {
+func TestTableCache_ClosedGate_SlowPathInsertNoLeak(t *testing.T) {
 	clock := newFakeClock(time.Unix(1_700_000_000, 0))
 	var closeCount atomic.Int32
-	c := newSessionTableCache(1*time.Hour, 1*time.Hour, clock.now)
+	c := NewTableCache(1*time.Hour, 1*time.Hour, clock.now)
 
 	release := make(chan struct{})
 	opened := make(chan struct{})
-	openFn := func() session.TableAPI {
+	openFn := func() TableAPI {
 		close(opened)
 		<-release
-		return &closeCountingTable{noopSessionTable{key: "k"}, &closeCount}
+		return &closeCountingTable{noopTable{key: "k"}, &closeCount}
 	}
 
-	var result session.TableAPI
+	var result TableAPI
 	done := make(chan struct{})
 	go func() {
-		result = c.getOrOpen("k", openFn)
+		result = c.GetOrOpen("k", openFn)
 		close(done)
 	}()
 
 	// Wait until openFn is in-flight, THEN close the cache. This is the
-	// race window: openFn returns AFTER close() completed.
+	// race window: openFn returns AFTER Close() completed.
 	<-opened
-	c.close()
+	c.Close()
 	close(release)
 	<-done
 
 	if result != nil {
-		t.Errorf("getOrOpen returned non-nil after cache close: %v (want nil so TableShim falls back to classic)", result)
+		t.Errorf("GetOrOpen returned non-nil after cache Close: %v (want nil so TableShim falls back to classic)", result)
 	}
 	if got := closeCount.Load(); got != 1 {
 		t.Errorf("underlying api Close called %d times, want 1 (slow-path insert must release its api when cache is closed)", got)
@@ -292,11 +300,11 @@ func TestSessionTableCache_ClosedGate_SlowPathInsertNoLeak(t *testing.T) {
 	}
 }
 
-// closeCountingTable is a noopSessionTable that atomically
-// increments a counter on Close so tests can assert eviction actually
-// called Close from any goroutine (including the cache sweeper).
+// closeCountingTable is a noopTable that atomically increments a
+// counter on Close so tests can assert eviction actually called Close
+// from any goroutine (including the cache sweeper).
 type closeCountingTable struct {
-	noopSessionTable
+	noopTable
 	counter *atomic.Int32
 }
 
@@ -305,34 +313,33 @@ func (c *closeCountingTable) Close() error {
 	return nil
 }
 
-// TestSessionTableHandle_EvictedSelfHeals pins the Design C invariant
-// that makes bug #6 fixable without TableShim changes: a
-// *sessionTableHandle whose Close() has run (sweeper eviction, or
-// direct handle.Close from any owner) transparently re-opens via the
-// cache on the next RPC. The caller — TableShim or any other holder —
-// keeps its *sessionTableHandle pointer forever; the wrapper does the
-// self-heal.
+// TestTableHandle_EvictedSelfHeals pins the Design C invariant that
+// makes bug #6 fixable without TableShim changes: a *TableHandle whose
+// Close() has run (sweeper eviction, or direct handle.Close from any
+// owner) transparently re-opens via the cache on the next RPC. The
+// caller — TableShim or any other holder — keeps its *TableHandle
+// pointer forever; the wrapper does the self-heal.
 //
 // Verifies:
 //   - After handle.Close(), evicted is true.
 //   - Subsequent ReadRow / MutateRow succeed by delegating to a
 //     freshly-minted successor handle.
 //   - openFn IS invoked a second time (fresh sessionTable is minted).
-//   - Handle identity is stable — the same *sessionTableHandle
-//     transparently dispatches to whichever underlying api is live.
-func TestSessionTableHandle_EvictedSelfHeals(t *testing.T) {
+//   - Handle identity is stable — the same *TableHandle transparently
+//     dispatches to whichever underlying api is live.
+func TestTableHandle_EvictedSelfHeals(t *testing.T) {
 	clock := newFakeClock(time.Unix(1_700_000_000, 0))
-	c := newSessionTableCache(1*time.Hour, 1*time.Hour, clock.now)
-	t.Cleanup(c.close)
+	c := NewTableCache(1*time.Hour, 1*time.Hour, clock.now)
+	t.Cleanup(c.Close)
 
 	var opens atomic.Int32
-	openFn := func() session.TableAPI {
+	openFn := func() TableAPI {
 		opens.Add(1)
-		return &noopSessionTable{key: "tbl:t"}
+		return &noopTable{key: "tbl:t"}
 	}
 
-	// Install h1 via first getOrOpen.
-	h1 := c.getOrOpen("tbl:t", openFn).(*sessionTableHandle)
+	// Install h1 via first GetOrOpen.
+	h1 := c.GetOrOpen("tbl:t", openFn).(*TableHandle)
 	if opens.Load() != 1 {
 		t.Fatalf("openFn calls after first install = %d, want 1", opens.Load())
 	}
@@ -358,7 +365,7 @@ func TestSessionTableHandle_EvictedSelfHeals(t *testing.T) {
 	installed, ok := c.entries["tbl:t"]
 	c.mu.Unlock()
 	if !ok {
-		t.Fatal("cache.entries missing 'tbl:t' after self-heal; getOrOpen must have installed the successor")
+		t.Fatal("cache.entries missing 'tbl:t' after self-heal; GetOrOpen must have installed the successor")
 	}
 	if installed == h1 {
 		t.Error("cache.entries['tbl:t'] == h1 (evicted); self-heal must have installed a distinct successor")
@@ -375,10 +382,10 @@ func TestSessionTableHandle_EvictedSelfHeals(t *testing.T) {
 	}
 }
 
-// TestSessionTableHandle_EvictedReopenFailsGracefully pins the
-// terminal branch: when the cache is closed, dispatch() must NOT
-// loop — it falls through to the doomed handle so h.api.ReadRow can
-// surface the honest terminal error.
+// TestTableHandle_EvictedReopenFailsGracefully pins the terminal
+// branch: when the cache is closed, dispatch() must NOT loop — it
+// falls through to the doomed handle so h.api.ReadRow can surface the
+// honest terminal error.
 //
 // Asserts two invariants:
 //   - ReadRow returns within a bounded time. If dispatch()'s loop
@@ -386,21 +393,21 @@ func TestSessionTableHandle_EvictedSelfHeals(t *testing.T) {
 //     before the default go-test deadline (which reads as an
 //     unrelated CI hang).
 //   - The cache stays empty after the call. openFn may have fired
-//     one extra time (getOrOpen's slow path invokes openFn OUTSIDE
+//     one extra time (GetOrOpen's slow path invokes openFn OUTSIDE
 //     the mutex — the closed-cache guard fires AFTER, releasing the
 //     wasted api) but the freshly-opened api MUST NOT install into
 //     the closed cache.
-func TestSessionTableHandle_EvictedReopenFailsGracefully(t *testing.T) {
+func TestTableHandle_EvictedReopenFailsGracefully(t *testing.T) {
 	clock := newFakeClock(time.Unix(1_700_000_000, 0))
-	c := newSessionTableCache(1*time.Hour, 1*time.Hour, clock.now)
+	c := NewTableCache(1*time.Hour, 1*time.Hour, clock.now)
 
-	openFn := func() session.TableAPI { return &noopSessionTable{key: "tbl:t"} }
-	h := c.getOrOpen("tbl:t", openFn).(*sessionTableHandle)
+	openFn := func() TableAPI { return &noopTable{key: "tbl:t"} }
+	h := c.GetOrOpen("tbl:t", openFn).(*TableHandle)
 
-	// Close the cache itself so getOrOpen refuses to install new entries.
-	c.close()
+	// Close the cache itself so GetOrOpen refuses to install new entries.
+	c.Close()
 	if !h.evicted.Load() {
-		t.Fatal("cache.close() did not propagate to h.evicted; expected true")
+		t.Fatal("cache.Close() did not propagate to h.evicted; expected true")
 	}
 
 	// Bounded wait — hang detection.
@@ -418,9 +425,9 @@ func TestSessionTableHandle_EvictedReopenFailsGracefully(t *testing.T) {
 	}
 
 	// Cache must remain empty — the closed-cache guard inside
-	// getOrOpen must have refused to install the freshly-opened api,
+	// GetOrOpen must have refused to install the freshly-opened api,
 	// releasing it via api.Close instead. If a successor slipped in,
-	// it would leak (sweeper has stopped, cache.close is stopOnce-
+	// it would leak (sweeper has stopped, cache.Close is stopOnce-
 	// guarded, nothing would ever tear it down).
 	c.mu.Lock()
 	n := len(c.entries)
@@ -430,21 +437,21 @@ func TestSessionTableHandle_EvictedReopenFailsGracefully(t *testing.T) {
 	}
 }
 
-// TestSessionTableHandle_SweeperEvictionSelfHeals pins the actual bug
-// #6 production trigger: the TTL sweeper (not an explicit Close) evicts
+// TestTableHandle_SweeperEvictionSelfHeals pins the actual bug #6
+// production trigger: the TTL sweeper (not an explicit Close) evicts
 // the handle while TableShim still holds it. Direct-Close tests above
 // don't exercise the sweeper path; this one does.
-func TestSessionTableHandle_SweeperEvictionSelfHeals(t *testing.T) {
+func TestTableHandle_SweeperEvictionSelfHeals(t *testing.T) {
 	clock := newFakeClock(time.Unix(1_700_000_000, 0))
-	c := newSessionTableCache(1*time.Hour, 1*time.Hour, clock.now)
-	t.Cleanup(c.close)
+	c := NewTableCache(1*time.Hour, 1*time.Hour, clock.now)
+	t.Cleanup(c.Close)
 
 	var opens atomic.Int32
-	openFn := func() session.TableAPI {
+	openFn := func() TableAPI {
 		opens.Add(1)
-		return &noopSessionTable{key: "tbl:t"}
+		return &noopTable{key: "tbl:t"}
 	}
-	h := c.getOrOpen("tbl:t", openFn).(*sessionTableHandle)
+	h := c.GetOrOpen("tbl:t", openFn).(*TableHandle)
 
 	// Advance past TTL and run one sweep — this is the exact production
 	// path that poisoned TableShim's held pointer before Design C.
@@ -456,8 +463,8 @@ func TestSessionTableHandle_SweeperEvictionSelfHeals(t *testing.T) {
 	}
 
 	// The critical assertion: TableShim (represented here by our held h
-	// pointer) can keep using the same *sessionTableHandle after the
-	// sweeper evicted its underlying pool.
+	// pointer) can keep using the same *TableHandle after the sweeper
+	// evicted its underlying pool.
 	if _, err := h.ReadRow(context.Background(), &btpb.SessionReadRowRequest{Key: []byte("r")}); err != nil {
 		t.Fatalf("post-sweep h.ReadRow: %v (self-heal from sweeper path failed)", err)
 	}
@@ -466,22 +473,22 @@ func TestSessionTableHandle_SweeperEvictionSelfHeals(t *testing.T) {
 	}
 }
 
-// TestSessionTableHandle_ConcurrentEvictAndReadRace runs under -race:
-// one goroutine spins Close/getOrOpen cycles while another spins
-// ReadRow through the same held handle. dispatch() must not race, and
-// the returned errors (or successes) must be well-defined — no panic,
-// no data race, no infinite loop.
-func TestSessionTableHandle_ConcurrentEvictAndReadRace(t *testing.T) {
+// TestTableHandle_ConcurrentEvictAndReadRace runs under -race: one
+// goroutine spins Close/GetOrOpen cycles while another spins ReadRow
+// through the same held handle. dispatch() must not race, and the
+// returned errors (or successes) must be well-defined — no panic, no
+// data race, no infinite loop.
+func TestTableHandle_ConcurrentEvictAndReadRace(t *testing.T) {
 	clock := newFakeClock(time.Unix(1_700_000_000, 0))
-	c := newSessionTableCache(1*time.Hour, 1*time.Hour, clock.now)
-	t.Cleanup(c.close)
+	c := NewTableCache(1*time.Hour, 1*time.Hour, clock.now)
+	t.Cleanup(c.Close)
 
 	var opens atomic.Int32
-	openFn := func() session.TableAPI {
+	openFn := func() TableAPI {
 		opens.Add(1)
-		return &noopSessionTable{key: "tbl:t"}
+		return &noopTable{key: "tbl:t"}
 	}
-	h := c.getOrOpen("tbl:t", openFn).(*sessionTableHandle)
+	h := c.GetOrOpen("tbl:t", openFn).(*TableHandle)
 
 	stop := make(chan struct{})
 	var wg sync.WaitGroup
@@ -498,7 +505,7 @@ func TestSessionTableHandle_ConcurrentEvictAndReadRace(t *testing.T) {
 				return
 			default:
 			}
-			if cur, ok := c.getOrOpen("tbl:t", openFn).(*sessionTableHandle); ok {
+			if cur, ok := c.GetOrOpen("tbl:t", openFn).(*TableHandle); ok {
 				_ = cur.Close()
 			}
 		}
@@ -517,8 +524,8 @@ func TestSessionTableHandle_ConcurrentEvictAndReadRace(t *testing.T) {
 			default:
 			}
 			if _, err := h.ReadRow(context.Background(), &btpb.SessionReadRowRequest{Key: []byte("r")}); err != nil {
-				// noopSessionTable never returns an error, so any err
-				// here is a bug (nil deref, closed pool leaking through).
+				// noopTable never returns an error, so any err here is
+				// a bug (nil deref, closed pool leaking through).
 				t.Errorf("racing ReadRow returned err = %v", err)
 				return
 			}
@@ -531,31 +538,31 @@ func TestSessionTableHandle_ConcurrentEvictAndReadRace(t *testing.T) {
 	wg.Wait()
 }
 
-// TestSessionTableHandle_EvictionStormConvergesOnSingleInstalled pins
-// the invariant getOrOpen actually guarantees: N concurrent post-
-// eviction RPCs may each invoke openFn (getOrOpen is NOT single-flight
-// on openFn per line 205-207's doc), but the cache converges on
-// EXACTLY ONE installed successor, and every loser api gets Close()d.
-// This is the leak-avoidance invariant — without it, a storm would
-// leak N-1 session pools under a single key.
+// TestTableHandle_EvictionStormConvergesOnSingleInstalled pins the
+// invariant GetOrOpen actually guarantees: N concurrent post-eviction
+// RPCs may each invoke openFn (GetOrOpen is NOT single-flight on
+// openFn per line 205-207's doc), but the cache converges on EXACTLY
+// ONE installed successor, and every loser api gets Close()d. This is
+// the leak-avoidance invariant — without it, a storm would leak N-1
+// session pools under a single key.
 //
 // (Making openFn genuinely single-flight would be a real perf win but
 // is a separate feature — this test would need to tighten if that
 // ever lands.)
-func TestSessionTableHandle_EvictionStormConvergesOnSingleInstalled(t *testing.T) {
+func TestTableHandle_EvictionStormConvergesOnSingleInstalled(t *testing.T) {
 	clock := newFakeClock(time.Unix(1_700_000_000, 0))
-	c := newSessionTableCache(1*time.Hour, 1*time.Hour, clock.now)
-	t.Cleanup(c.close)
+	c := NewTableCache(1*time.Hour, 1*time.Hour, clock.now)
+	t.Cleanup(c.Close)
 
 	var opens, closes atomic.Int32
 	// Slow openFn so concurrent callers actually pile up in the slow
 	// path and produce a real storm.
-	openFn := func() session.TableAPI {
+	openFn := func() TableAPI {
 		opens.Add(1)
 		time.Sleep(5 * time.Millisecond)
-		return &closeCountingTable{noopSessionTable{key: "tbl:t"}, &closes}
+		return &closeCountingTable{noopTable{key: "tbl:t"}, &closes}
 	}
-	h := c.getOrOpen("tbl:t", openFn).(*sessionTableHandle)
+	h := c.GetOrOpen("tbl:t", openFn).(*TableHandle)
 	if err := h.Close(); err != nil {
 		t.Fatalf("h.Close: %v", err)
 	}
@@ -582,7 +589,7 @@ func TestSessionTableHandle_EvictionStormConvergesOnSingleInstalled(t *testing.T
 	}
 
 	// Every openFn call except the winner must have had its api closed
-	// by getOrOpen's loser-close path. The initial h was also closed
+	// by GetOrOpen's loser-close path. The initial h was also closed
 	// (the h.Close() above), so total closes == opens - 1 (one live
 	// installed successor).
 	opensLoaded := opens.Load()

--- a/bigtable/open.go
+++ b/bigtable/open.go
@@ -120,13 +120,13 @@ func (c *Client) OpenMaterializedView(materializedView string) TableAPI {
 // ("projects/P/instances/I/tables/T") — same identity Cloud Bigtable
 // uses over the wire, so table + AV + MV keys never collide even
 // though they share one cache. Handles evict after
-// sessionTableCacheTTL of idle (default 1 h) or when the caller
-// Close()s them explicitly. See session_table_cache.go.
+// session.DefaultTableCacheTTL of idle (default 1 h) or when the
+// caller Close()s them explicitly. See internal/session/table_cache.go.
 func (c *Client) getOrCreateSessionTable(table string) session.TableAPI {
 	if c.sessionImpl == nil {
 		return nil
 	}
-	return c.sessionTables.getOrOpen(c.fullTableName(table), func() session.TableAPI {
+	return c.sessionTables.GetOrOpen(c.fullTableName(table), func() session.TableAPI {
 		return c.sessionImpl.OpenTable(table)
 	})
 }
@@ -141,7 +141,7 @@ func (c *Client) getOrCreateSessionAuthorizedView(table, view string) session.Ta
 	if c.sessionImpl == nil {
 		return nil
 	}
-	return c.sessionTables.getOrOpen(c.fullAuthorizedViewName(table, view), func() session.TableAPI {
+	return c.sessionTables.GetOrOpen(c.fullAuthorizedViewName(table, view), func() session.TableAPI {
 		return c.sessionImpl.OpenAuthorizedView(table, view)
 	})
 }
@@ -153,7 +153,7 @@ func (c *Client) getOrCreateSessionMaterializedView(view string) session.TableAP
 	if c.sessionImpl == nil {
 		return nil
 	}
-	return c.sessionTables.getOrOpen(c.fullMaterializedViewName(view), func() session.TableAPI {
+	return c.sessionTables.GetOrOpen(c.fullMaterializedViewName(view), func() session.TableAPI {
 		return c.sessionImpl.OpenMaterializedView(view)
 	})
 }

--- a/bigtable/open_test.go
+++ b/bigtable/open_test.go
@@ -503,23 +503,23 @@ func newSessionWiredClient(t *testing.T, fsc *fakeSessionClient) *Client {
 	// Cache with a huge TTL and huge sweep interval so eviction never
 	// fires during these tests. Cache-behavior tests build their own
 	// cache with tight timings.
-	c.sessionTables = newSessionTableCache(24*time.Hour, 24*time.Hour, nil)
-	t.Cleanup(c.sessionTables.close)
+	c.sessionTables = session.NewTableCache(24*time.Hour, 24*time.Hour, nil)
+	t.Cleanup(c.sessionTables.Close)
 	return c
 }
 
-// unwrap peels the sessionTableHandle wrapper off a shim's session so
+// unwrap peels the session.TableHandle wrapper off a shim's session so
 // tests can inspect the underlying fakeSessionClient-vended
 // noopSessionTable directly.
 func unwrapSession(t *testing.T, api session.TableAPI) *noopSessionTable {
 	t.Helper()
-	h, ok := api.(*sessionTableHandle)
+	h, ok := api.(*session.TableHandle)
 	if !ok {
-		t.Fatalf("session = %T, want *sessionTableHandle (cache wrapper)", api)
+		t.Fatalf("session = %T, want *session.TableHandle (cache wrapper)", api)
 	}
-	nst, ok := h.api.(*noopSessionTable)
+	nst, ok := h.Unwrap().(*noopSessionTable)
 	if !ok {
-		t.Fatalf("handle.api = %T, want *noopSessionTable (from fakeSessionClient)", h.api)
+		t.Fatalf("handle.Unwrap() = %T, want *noopSessionTable (from fakeSessionClient)", h.Unwrap())
 	}
 	return nst
 }


### PR DESCRIPTION
## Summary

Moves `sessionTableCache` + `sessionTableHandle` out of `package bigtable` into `bigtable/internal/session` as exported `TableCache` + `TableHandle`. The cache is a session-layer primitive — `bigtable.Client` is its only consumer, and the top-level package no longer needs to see its internals.

Pure rename + relocation. No logic change.

### Rename table

| Old (`package bigtable`) | New (`package session`) |
|---|---|
| `sessionTableCache` | `TableCache` |
| `sessionTableHandle` | `TableHandle` |
| `newSessionTableCache` | `NewTableCache` |
| `sessionTableCacheTTL` | `DefaultTableCacheTTL` |
| `sessionTableCacheSweepInt` | `DefaultTableCacheSweepInterval` |
| `cache.getOrOpen` | `cache.GetOrOpen` |
| `cache.close` | `cache.Close` |

Handle fields stay unexported; `TableHandle` grows a small `Unwrap() TableAPI` accessor so `package bigtable`'s `unwrapSession` test helper can reach the underlying api across the package boundary without exposing the field itself.

### Test helpers

`fakeClock`, `openNoop`, `openClosing`, `closeCountingTable` — plus a local `noopTable` TableAPI fake — move alongside the tests into `internal/session/table_cache_test.go`. `package bigtable` keeps its own `noopSessionTable`; both fakes are tiny (4 methods) and staying package-local avoids coupling test packages.

### Consumers updated

- `bigtable/client.go` — field type, constructor call, close call.
- `bigtable/open.go` — three `GetOrOpen` call sites (getOrCreateSessionTable / AuthorizedView / MaterializedView).
- `bigtable/open_test.go` — `newSessionWiredClient` factory + `unwrapSession` helper.
- `bigtable/internal/session/{api,client,table}.go` — doc-comment references to the old name updated.

## Test plan

- [x] `go test ./bigtable/internal/session/ -race -short -count=1` — all cache + handle tests pass, including the concurrent-race and eviction-storm cases.
- [x] `go test ./bigtable/ -run '^TestOpen' -race -short -count=1` — all open-path tests (`TestOpenTable_WithSessionBackend_WiresSessionTableAPI`, `TestOpenTable_SessionTableAPICacheHit`, etc.) pass through the new `session.TableCache` type.
- [x] `go vet ./bigtable/internal/session/ ./bigtable/`, `gofmt -l` — clean.
- [x] `git diff --stat` shows the two moved files as renames (git detected them automatically); no residual references to the old symbol names anywhere under `bigtable/`.