### PR TITLE
test(bigtable): fix cross-test flakes in transport session pool suite

### DIFF
--- a/bigtable/internal/transport/session_pool_test.go
+++ b/bigtable/internal/transport/session_pool_test.go
@@ -128,9 +128,31 @@ func newTestPool(t testing.TB, min, max int) *SessionPoolImpl {
 		nil,
 		SessionTypeTable, true,
 	)
-	p.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
+	// Configure min/max via the sizer directly instead of pool.UpdateConfig.
+	// pool.UpdateConfig fires spawnTickOnce as its last step; under the
+	// full-suite run that async Tick has time to (a) record a scaling
+	// event into p.m.scalingHistory (breaking TestRecordScaling_RingCaps'
+	// assertion that snap[0].Before starts at 3, not 4), and (b) spawn a
+	// createSession whose readLoop parks on fakeStream.Recv forever —
+	// fakeStream.Recv is a channel receive that does NOT observe ctx
+	// cancellation, so p.Close's Phase-5 spawns.Wait deadlocks past the
+	// 30s timeout in TestPoolClose_DrainsParkedWaitersWithSentinel.
+	// Tests that specifically exercise pool.UpdateConfig (e.g.
+	// TestConsecutiveFailures_UpdateConfigHonoredByTrip) still call it
+	// explicitly in-body; their cleanup's closeStreams-before-Close
+	// order unblocks any tick-spawned createSession.
+	p.sizer.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
 		MinSessionCount: int32(min), MaxSessionCount: int32(max),
 	})
+	// Bridge poolCtx cancellation to closeStreams so a test that calls
+	// p.Close() in-body (rather than relying on cleanup ordering) still
+	// unblocks any parked readLoops: Close's Phase-4 cancels poolCtx,
+	// which then wakes this goroutine, which closes every fakeStream and
+	// lets readLoop's Recv return so spawns.Wait can complete.
+	go func() {
+		<-p.poolCtx.Done()
+		closeStreams()
+	}()
 	// Close streams before closing the pool: the pool's Close waits for
 	// per-session teardown, which requires the readLoop goroutines to
 	// exit — and they won't while parked on fakeStream.Recv.
@@ -652,11 +674,12 @@ func TestUpdateConfig_SwapsPickerAndBounds(t *testing.T) {
 	if got := p.picker.Name(); got != "least-latency" {
 		t.Errorf("after PeakEwma swap, picker = %q, want least-latency", got)
 	}
-	// listenerFires counter bumps once per UpdateConfig. Expect 3:
-	// one from newTestPool's bootstrap UpdateConfig plus the two in
-	// this test body.
-	if got := p.m.listenerFires.Load(); got != 3 {
-		t.Errorf("listenerFires = %d, want 3 (one per UpdateConfig)", got)
+	// listenerFires counter bumps once per pool.UpdateConfig call.
+	// newTestPool now configures min/max via sizer.UpdateConfig directly
+	// (to avoid the async spawnTickOnce that produced flakes in the
+	// full-suite run), so only the two in-body UpdateConfig calls count.
+	if got := p.m.listenerFires.Load(); got != 2 {
+		t.Errorf("listenerFires = %d, want 2 (one per UpdateConfig)", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `newTestPool` called `pool.UpdateConfig`, whose trailing `spawnTickOnce` launched an async Tick that (a) recorded a scaling event into `p.m.scalingHistory` and (b) fire-and-forget spawned a `createSession` whose `readLoop` parked on `fakeStream.Recv` — a channel receive that ignores ctx cancellation. Under the full-suite run these races resolved often enough to break two tests intermittently: `TestRecordScaling_RingCaps` (`snap[0].Before = 4, want 3` — the extra ring entry) and `TestPoolClose_DrainsParkedWaitersWithSentinel` (`Close did not return within 30s` — Phase-5 `spawns.Wait` blocked on the orphan `createSession`).
- Test-only fix in `session_pool_test.go`: configure min/max via `p.sizer.UpdateConfig` directly (skipping the pool-level UpdateConfig and its spawnTickOnce side effect), and bridge `poolCtx` cancellation to `closeStreams` so any in-body `p.Close()` still unblocks parked `readLoop`s. Adjusted the `TestUpdateConfig_SwapsPickerAndBounds` listenerFires assertion accordingly (2 in-body calls now instead of 2 + 1 bootstrap).

## Test plan

- [x] `for i in 1 2 3 4 5; do go test ./bigtable/internal/transport/ -short -count=1 -timeout=120s; done` — all five runs green
- [x] `go build ./bigtable/...`
- [x] `go vet ./bigtable/internal/transport/...`