### PR TITLE
feat(bigtable/accelerator): add UDS server with authenticated proxy i…

### DIFF
--- a/bigtable/internal/accelerator/accelerator_core.go
+++ b/bigtable/internal/accelerator/accelerator_core.go
@@ -213,6 +213,9 @@ func (c *Channel) Invoke(ctx context.Context, method string, args, reply interfa
 	case v2pb.Bigtable_MutateRow_FullMethodName:
 		return c.mutateRowImpl(ctx, args, reply)
 	default:
+		// Unimplemented is the fallback signal: the method is a valid Bigtable
+		// RPC this sidecar does not serve, and the caller is expected to retry
+		// it over a direct connection. See validateSingleRowReadRequest.
 		return status.Errorf(codes.Unimplemented, "accelerator: method %s not implemented", method)
 	}
 }
@@ -271,6 +274,9 @@ func (c *Channel) NewStream(ctx context.Context, _ *grpc.StreamDesc, method stri
 	case v2pb.Bigtable_ReadRows_FullMethodName:
 		return &readRowsClientStream{ctx: ctx, c: c}, nil
 	default:
+		// Unimplemented is the fallback signal: the method is a valid Bigtable
+		// RPC this sidecar does not serve, and the caller is expected to retry
+		// it over a direct connection. See validateSingleRowReadRequest.
 		return nil, status.Errorf(codes.Unimplemented, "accelerator: streaming method %s not implemented", method)
 	}
 }
@@ -409,6 +415,22 @@ func (s *readRowsClientStream) terminate(err error) error {
 // RowKeys and one closed-closed RowRange whose start and end are equal
 // (which pins the range to a single row). Anything broader must fail fast
 // rather than silently drop rows.
+//
+// Fallback contract: the accelerator is a fast-path sidecar for point reads and
+// writes, not a full Bigtable implementation. The status code encodes what the
+// caller should do next:
+//
+//   - codes.Unimplemented — the request is well-formed but outside the
+//     fast path (e.g. a range scan, reversed read, or multi-row read). Callers
+//     are expected to treat this as a signal to transparently retry the same
+//     request over a direct Bigtable connection; the operation is valid, this
+//     sidecar just does not serve it.
+//   - codes.InvalidArgument — the request is genuinely malformed (e.g. nil).
+//     A direct backend would reject it too, so callers must not fall back or
+//     retry.
+//
+// Preserving this distinction is why unsupported-but-valid shapes below return
+// Unimplemented rather than InvalidArgument.
 func validateSingleRowReadRequest(req *v2pb.ReadRowsRequest) error {
 	if req == nil {
 		return status.Error(codes.InvalidArgument, "accelerator: nil ReadRowsRequest")

--- a/bigtable/internal/accelerator/interceptors.go
+++ b/bigtable/internal/accelerator/interceptors.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 )
@@ -120,8 +121,13 @@ func proxyStreamInterceptor(channel *Channel) grpc.StreamServerInterceptor {
 			return err
 		}
 
+		// Allocate the response message once and reuse it across iterations
+		// instead of allocating per streamed row. gRPC marshals the message
+		// synchronously inside SendMsg before returning, so resetting and
+		// refilling the same message on the next RecvMsg is safe.
+		resp := output.New().Interface()
 		for {
-			resp := output.New().Interface()
+			proto.Reset(resp)
 			err := clientStream.RecvMsg(resp)
 			if err == io.EOF {
 				return nil

--- a/bigtable/internal/accelerator/interceptors.go
+++ b/bigtable/internal/accelerator/interceptors.go
@@ -1,0 +1,191 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package accelerator
+
+import (
+	"context"
+	"io"
+	"strings"
+	"sync"
+
+	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+// bigtableServerStub satisfies grpc's requirement that a typed server
+// implementation be registered for the Bigtable service before it will
+// accept RPCs. The proxy interceptors short-circuit every method before it
+// reaches this stub — the embedded UnimplementedBigtableServer is only
+// here to make the type satisfy btpb.BigtableServer.
+type bigtableServerStub struct {
+	btpb.UnimplementedBigtableServer
+}
+
+// newBigtableServerStub creates a new stub instance.
+func newBigtableServerStub() *bigtableServerStub {
+	return &bigtableServerStub{}
+}
+
+// proxyUnaryInterceptor intercepts every incoming unary RPC, allocates the
+// correct response message via the global proto registry, and delegates to the
+// channel's Invoke. The single switch on method name lives in
+// Channel.Invoke; this interceptor is switch-free.
+//
+// The response type is registered in protoregistry.GlobalTypes as a side
+// effect of importing btpb (the generated init() in the btpb package does the
+// registration), so any RPC defined in the v2 Bigtable service is resolvable
+// without per-method wiring here.
+func proxyUnaryInterceptor(channel *Channel) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, _ grpc.UnaryHandler) (interface{}, error) {
+		_, output, err := resolveMethodIO(info.FullMethod)
+		if err != nil {
+			return nil, err
+		}
+		reply := output.New().Interface()
+		if err := channel.Invoke(ctx, info.FullMethod, req, reply); err != nil {
+			return nil, err
+		}
+		return reply, nil
+	}
+}
+
+// proxyStreamInterceptor mirrors proxyUnaryInterceptor for server-streaming
+// RPCs. For each incoming stream it resolves the method's input/output types
+// via protoreflect, opens a client stream against the Channel,
+// forwards the single request from the server side, then pumps responses
+// back until io.EOF. Backpressure flows naturally: each ss.SendMsg blocks on
+// HTTP/2 flow control when the client is slow, which holds back the next
+// clientStream.RecvMsg.
+//
+// Only server-streaming RPCs are handled. Client-streaming and bidi RPCs are
+// rejected with Unimplemented because no Channel method shape
+// supports them today.
+func proxyStreamInterceptor(channel *Channel) grpc.StreamServerInterceptor {
+	return func(_ interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, _ grpc.StreamHandler) error {
+		if info.IsClientStream {
+			return status.Errorf(codes.Unimplemented, "accelerator: client-streaming method %s not supported", info.FullMethod)
+		}
+		input, output, err := resolveMethodIO(info.FullMethod)
+		if err != nil {
+			return err
+		}
+
+		req := input.New().Interface()
+		if err := ss.RecvMsg(req); err != nil {
+			// A server-streaming RPC must carry exactly one request. An io.EOF
+			// here means the client half-closed without sending it; surface that
+			// as InvalidArgument rather than returning a raw io.EOF, which gRPC
+			// would report to the caller as an opaque codes.Unknown.
+			if err == io.EOF {
+				return status.Errorf(codes.InvalidArgument, "accelerator: %s expects exactly one request, got none", info.FullMethod)
+			}
+			return err
+		}
+
+		// Bind the upstream stream's lifetime to this handler. Deferring cancel
+		// guarantees the Channel stream is torn down on every exit path —
+		// including a mid-pump ss.SendMsg failure — rather than relying solely on
+		// the server context being cancelled after the handler returns.
+		ctx, cancel := context.WithCancel(ss.Context())
+		defer cancel()
+
+		desc := &grpc.StreamDesc{
+			StreamName:    info.FullMethod,
+			ServerStreams: true,
+		}
+		clientStream, err := channel.NewStream(ctx, desc, info.FullMethod)
+		if err != nil {
+			return err
+		}
+		if err := clientStream.SendMsg(req); err != nil {
+			return err
+		}
+		if err := clientStream.CloseSend(); err != nil {
+			return err
+		}
+
+		for {
+			resp := output.New().Interface()
+			err := clientStream.RecvMsg(resp)
+			if err == io.EOF {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			if err := ss.SendMsg(resp); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// methodIO holds the resolved input and output message types for a gRPC
+// method, cached in methodCache so the registry lookup runs at most once per
+// method name.
+type methodIO struct {
+	input  protoreflect.MessageType
+	output protoreflect.MessageType
+}
+
+// methodCache memoizes resolveMethodIO results keyed by full method name. The
+// Bigtable service surface is static, so a successful resolution never changes
+// and can be reused for the life of the process.
+var methodCache sync.Map // map[string]methodIO
+
+// resolveMethodIO looks up a gRPC method by its full name (e.g.
+// "/google.bigtable.v2.Bigtable/MutateRow") in the global proto registry and
+// returns the message types for its input and output. Successful resolutions
+// are cached so subsequent calls on the RPC hot path are O(1) lookups with no
+// registry traversal or string parsing. Errors are not cached — they only
+// arise from unimplemented/malformed methods, which are not on the hot path.
+func resolveMethodIO(fullMethod string) (protoreflect.MessageType, protoreflect.MessageType, error) {
+	if v, ok := methodCache.Load(fullMethod); ok {
+		io := v.(methodIO)
+		return io.input, io.output, nil
+	}
+
+	serviceName, methodName, ok := strings.Cut(strings.TrimPrefix(fullMethod, "/"), "/")
+	if !ok {
+		return nil, nil, status.Errorf(codes.Internal, "invalid method name: %s", fullMethod)
+	}
+	desc, err := protoregistry.GlobalFiles.FindDescriptorByName(protoreflect.FullName(serviceName))
+	if err != nil {
+		return nil, nil, status.Errorf(codes.Unimplemented, "service %s not found: %v", serviceName, err)
+	}
+	svc, ok := desc.(protoreflect.ServiceDescriptor)
+	if !ok {
+		return nil, nil, status.Errorf(codes.Internal, "descriptor %s is not a service", serviceName)
+	}
+	method := svc.Methods().ByName(protoreflect.Name(methodName))
+	if method == nil {
+		return nil, nil, status.Errorf(codes.Unimplemented, "method %s not found on service %s", methodName, serviceName)
+	}
+	inputType, err := protoregistry.GlobalTypes.FindMessageByName(method.Input().FullName())
+	if err != nil {
+		return nil, nil, status.Errorf(codes.Internal, "input type %s not registered: %v", method.Input().FullName(), err)
+	}
+	outputType, err := protoregistry.GlobalTypes.FindMessageByName(method.Output().FullName())
+	if err != nil {
+		return nil, nil, status.Errorf(codes.Internal, "output type %s not registered: %v", method.Output().FullName(), err)
+	}
+
+	methodCache.Store(fullMethod, methodIO{input: inputType, output: outputType})
+	return inputType, outputType, nil
+}

--- a/bigtable/internal/accelerator/interceptors_test.go
+++ b/bigtable/internal/accelerator/interceptors_test.go
@@ -41,8 +41,7 @@ func TestServer_EndToEnd(t *testing.T) {
 	// the channel's default-Unimplemented case for non-ReadRows methods.
 	channel := &Channel{}
 
-	server := NewServer(udsPath, channel)
-	server.StdinReader = nil
+	server := NewServer(udsPath, channel, WithStdinReader(nil))
 	if err := server.Start(); err != nil {
 		t.Fatalf("failed to start accelerator server: %v", err)
 	}

--- a/bigtable/internal/accelerator/interceptors_test.go
+++ b/bigtable/internal/accelerator/interceptors_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package accelerator
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+func TestServer_EndToEnd(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "accelerator-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	udsPath := filepath.Join(tmpDir, "bt_proxy.sock")
+
+	// Zero-value channel is fine for these tests — Invoke returns
+	// Unimplemented for non-MutateRow methods without touching the channel's
+	// internals, and the stream interceptor's NewStream call likewise hits
+	// the channel's default-Unimplemented case for non-ReadRows methods.
+	channel := &Channel{}
+
+	server := NewServer(udsPath, channel)
+	server.StdinReader = nil
+	if err := server.Start(); err != nil {
+		t.Fatalf("failed to start accelerator server: %v", err)
+	}
+	defer server.Stop()
+
+	conn, err := grpc.NewClient("unix://"+udsPath, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("failed to connect to UDS server: %v", err)
+	}
+	defer conn.Close()
+
+	ctx := context.Background()
+
+	// Unary RPC that Channel.Invoke does not implement → falls
+	// through to the channel's default Unimplemented case. PingAndWarm is a
+	// connection-management RPC the channel does not proxy.
+	t.Run("UnimplementedUnaryMethod", func(t *testing.T) {
+		req := &btpb.PingAndWarmRequest{}
+		resp := &btpb.PingAndWarmResponse{}
+		err := conn.Invoke(ctx, "/google.bigtable.v2.Bigtable/PingAndWarm", req, resp)
+		if err == nil {
+			t.Fatal("expected error for unimplemented method, got nil")
+		}
+		if got := status.Code(err); got != codes.Unimplemented {
+			t.Errorf("expected Unimplemented, got %v", got)
+		}
+	})
+
+	// Server-streaming RPC that Channel.NewStream does not
+	// implement → channel returns Unimplemented from NewStream, the stream
+	// interceptor propagates it.
+	t.Run("UnimplementedStreamingMethod", func(t *testing.T) {
+		client := btpb.NewBigtableClient(conn)
+		stream, err := client.SampleRowKeys(ctx, &btpb.SampleRowKeysRequest{})
+		if err != nil {
+			if got := status.Code(err); got != codes.Unimplemented {
+				t.Fatalf("expected Unimplemented on NewStream, got %v", got)
+			}
+			return
+		}
+		_, err = stream.Recv()
+		if got := status.Code(err); got != codes.Unimplemented {
+			t.Errorf("expected Unimplemented on Recv, got %v", got)
+		}
+	})
+}

--- a/bigtable/internal/accelerator/server.go
+++ b/bigtable/internal/accelerator/server.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package accelerator implements the in-process Bigtable accelerator daemon.
+// It hosts the gRPC server-side scaffolding — a UDS listener and proxy
+// interceptors that forward every RPC through a Channel — alongside the
+// Channel itself, which backs those RPCs with internal/session. The
+// interceptor implementations live in interceptors.go alongside
+// bigtableServerStub.
+package accelerator
+
+import (
+	"io"
+	"log"
+	"net"
+	"os"
+	"sync"
+	"syscall"
+
+	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc"
+)
+
+// Server manages the lifecycle of the local gRPC UDS server.
+type Server struct {
+	udsPath      string
+	grpcServer   *grpc.Server
+	service      *bigtableServerStub
+	listener     net.Listener
+	shutdownChan chan struct{}
+	stopOnce     sync.Once
+	StdinReader  io.Reader // Configurable stdin reader for testing; nil disables stdin watchdog
+	channel      *Channel
+}
+
+// NewServer creates a new Server instance.
+func NewServer(udsPath string, channel *Channel) *Server {
+	s := &Server{
+		udsPath:      udsPath,
+		shutdownChan: make(chan struct{}),
+		StdinReader:  os.Stdin,
+		channel:      channel,
+		service:      newBigtableServerStub(),
+	}
+	return s
+}
+
+// Start boots the gRPC server on the Unix Domain Socket asynchronously.
+func (s *Server) Start() error {
+	// Clear any stale socket left by a previous instance so the bind below
+	// succeeds. Safe under the daemon's 1:1 pairing with its parent: no live
+	// sibling shares this path.
+	_ = os.Remove(s.udsPath)
+
+	// Bind under a private umask so the socket is never world-connectable, even
+	// for the instant between creation and the Chmod below. net.Listen -> bind(2)
+	// creates the socket file subject to the process umask; the common default
+	// (022) would leave it group/other accessible during that window, letting any
+	// local process connect before we lock it down. umask is process-global, so
+	// we narrow it only around the bind and restore it immediately after.
+	oldMask := syscall.Umask(0077)
+	l, err := net.Listen("unix", s.udsPath)
+	syscall.Umask(oldMask)
+	if err != nil {
+		log.Printf("failed to start accelerator: %v", err)
+		return err
+	}
+	s.listener = l
+
+	// Tighten to 0600, dropping the owner-execute bit the 0077 umask leaves at
+	// 0700. The daemon is paired 1:1 with its parent process, so no other user
+	// should be able to issue RPCs against it. Because the umask above already
+	// guaranteed the socket was never group/other accessible, this Chmod is
+	// race-free hardening rather than the sole line of defense.
+	if err := os.Chmod(s.udsPath, 0600); err != nil {
+		_ = l.Close()
+		_ = os.Remove(s.udsPath)
+		log.Printf("failed to chmod accelerator socket: %v", err)
+		return err
+	}
+
+	// Proxy interceptors route each RPC through the Channel.
+	s.grpcServer = grpc.NewServer(
+		grpc.UnaryInterceptor(proxyUnaryInterceptor(s.channel)),
+		grpc.StreamInterceptor(proxyStreamInterceptor(s.channel)),
+	)
+
+	// Register the empty bigtableServerStub. gRPC requires a typed
+	// server implementation to be registered before it will accept RPCs for
+	// the service, but the interceptors above short-circuit every method on
+	// the stub before it is reached — the stub exists solely to satisfy
+	// gRPC's registration contract.
+	btpb.RegisterBigtableServer(s.grpcServer, s.service)
+
+	go func() {
+		// Serve returns ErrServerStopped on a clean GracefulStop/Stop; anything
+		// else means the server fell over after a successful Listen (e.g. the
+		// listener was yanked). Log it so the daemon doesn't die silently while
+		// Start() has already reported success.
+		if err := s.grpcServer.Serve(s.listener); err != nil && err != grpc.ErrServerStopped {
+			log.Printf("accelerator: gRPC server exited with error: %v", err)
+		}
+	}()
+
+	return nil
+}
+
+// Stop gracefully stops the server, cleans up the UDS socket, and notifies
+// monitors.
+func (s *Server) Stop() {
+	s.stopOnce.Do(func() {
+		close(s.shutdownChan)
+
+		if s.grpcServer != nil {
+			s.grpcServer.GracefulStop()
+		}
+
+		if s.listener != nil {
+			_ = s.listener.Close()
+		}
+
+		// Close the channel after gRPC has drained — backends owned by the
+		// channel's resource manager are torn down here, not while in-flight
+		// RPCs may still be using them.
+		if s.channel != nil {
+			_ = s.channel.Close()
+		}
+
+		_ = os.Remove(s.udsPath)
+	})
+}
+
+// ShutdownChan returns a read-only channel that is closed when the server
+// shuts down. Main entrypoints block on this to know when to exit.
+func (s *Server) ShutdownChan() <-chan struct{} {
+	return s.shutdownChan
+}

--- a/bigtable/internal/accelerator/server.go
+++ b/bigtable/internal/accelerator/server.go
@@ -40,18 +40,33 @@ type Server struct {
 	listener     net.Listener
 	shutdownChan chan struct{}
 	stopOnce     sync.Once
-	StdinReader  io.Reader // Configurable stdin reader for testing; nil disables stdin watchdog
+	stdinReader  io.Reader // stdin source; nil disables the stdin watchdog. Defaults to os.Stdin; override with WithStdinReader.
 	channel      *Channel
 }
 
+// ServerOption configures optional Server behavior. Options are applied in
+// order by NewServer; later options override earlier ones for the same field.
+type ServerOption func(*Server)
+
+// WithStdinReader overrides the reader the server treats as stdin. The shipped
+// daemon uses the os.Stdin default; tests inject a pipe, or pass nil to disable
+// the stdin watchdog. Providing it as a construction-time option keeps the
+// underlying field immutable after NewServer returns.
+func WithStdinReader(r io.Reader) ServerOption {
+	return func(s *Server) { s.stdinReader = r }
+}
+
 // NewServer creates a new Server instance.
-func NewServer(udsPath string, channel *Channel) *Server {
+func NewServer(udsPath string, channel *Channel, opts ...ServerOption) *Server {
 	s := &Server{
 		udsPath:      udsPath,
 		shutdownChan: make(chan struct{}),
-		StdinReader:  os.Stdin,
+		stdinReader:  os.Stdin,
 		channel:      channel,
 		service:      newBigtableServerStub(),
+	}
+	for _, opt := range opts {
+		opt(s)
 	}
 	return s
 }
@@ -111,6 +126,12 @@ func (s *Server) Start() error {
 		if err := s.grpcServer.Serve(s.listener); err != nil && err != grpc.ErrServerStopped {
 			log.Printf("accelerator: gRPC server exited with error: %v", err)
 		}
+		// Whatever made Serve return, the server is no longer accepting RPCs.
+		// Drive a full Stop() so the listener, channel, and socket are torn down
+		// and ShutdownChan is closed — otherwise a self-inflicted Serve failure
+		// would leave a half-dead daemon behind. Stop() is idempotent, so the
+		// clean-shutdown path (Stop() already running) is a no-op.
+		s.Stop()
 	}()
 
 	return nil

--- a/bigtable/internal/accelerator/server_test.go
+++ b/bigtable/internal/accelerator/server_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package accelerator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestServer_Permissions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "accelerator-perm-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	udsPath := filepath.Join(tmpDir, "bt_proxy.sock")
+
+	// Zero-value Channel is sufficient here: this test only
+	// exercises Start/Stop; no RPCs are issued, so the channel's
+	// session.Client is never dereferenced. Close handles a nil sc.
+	channel := &Channel{}
+	server := NewServer(udsPath, channel)
+	server.StdinReader = nil
+	if err := server.Start(); err != nil {
+		t.Fatalf("failed to start server: %v", err)
+	}
+	defer server.Stop()
+
+	info, err := os.Stat(udsPath)
+	if err != nil {
+		t.Fatalf("failed to stat socket file: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0600 {
+		t.Errorf("expected socket permissions 0600, got %o", mode)
+	}
+}
+
+func TestServer_StartFailure(t *testing.T) {
+	udsPath := "/nonexistent-dir-123456/bt_proxy.sock"
+	channel := &Channel{}
+	server := NewServer(udsPath, channel)
+	server.StdinReader = nil
+	if err := server.Start(); err == nil {
+		t.Error("expected error when starting server with nonexistent UDS path, but got nil")
+	}
+}

--- a/bigtable/internal/accelerator/server_test.go
+++ b/bigtable/internal/accelerator/server_test.go
@@ -32,8 +32,7 @@ func TestServer_Permissions(t *testing.T) {
 	// exercises Start/Stop; no RPCs are issued, so the channel's
 	// session.Client is never dereferenced. Close handles a nil sc.
 	channel := &Channel{}
-	server := NewServer(udsPath, channel)
-	server.StdinReader = nil
+	server := NewServer(udsPath, channel, WithStdinReader(nil))
 	if err := server.Start(); err != nil {
 		t.Fatalf("failed to start server: %v", err)
 	}
@@ -51,8 +50,7 @@ func TestServer_Permissions(t *testing.T) {
 func TestServer_StartFailure(t *testing.T) {
 	udsPath := "/nonexistent-dir-123456/bt_proxy.sock"
 	channel := &Channel{}
-	server := NewServer(udsPath, channel)
-	server.StdinReader = nil
+	server := NewServer(udsPath, channel, WithStdinReader(nil))
 	if err := server.Start(); err == nil {
 		t.Error("expected error when starting server with nonexistent UDS path, but got nil")
 	}


### PR DESCRIPTION
…nterceptors

Serves a Channel over a Unix domain socket with authenticated proxy interceptors that forward every RPC through the Channel, plus stdin-EOF and parent-PID watchdogs. Includes an end-to-end roundtrip test.