### PR TITLE
feat(bigtable/accelerator): authenticate UDS callers with a stdin tok…

### DIFF
--- a/bigtable/internal/accelerator/interceptors.go
+++ b/bigtable/internal/accelerator/interceptors.go
@@ -16,9 +16,10 @@ package accelerator
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/subtle"
 	"io"
-	"log/slog"
+	"log"
 	"strings"
 	"sync"
 
@@ -47,11 +48,10 @@ func newBigtableServerStub() *bigtableServerStub {
 }
 
 // authUnaryInterceptor validates the x-accelerator-token metadata header on
-// every unary RPC. An empty secret disables the check — a state reachable only
-// by tests that pass WithStdinReader(nil) (so readSecret never runs). The shipped
-// daemon always reads stdin and readSecret rejects an empty secret, so the
-// serving binary can never reach this branch. Mismatches are rejected with
-// codes.Internal (see checkAuthToken for why not Unauthenticated).
+// every unary RPC. It is only chained into the server when a non-empty secret
+// was read from stdin (see Server.Start); the shipped daemon always reads one,
+// so auth is disabled only in test mode (WithStdinReader(nil)). Mismatches are
+// rejected with codes.Internal (see checkAuthToken for why not Unauthenticated).
 func authUnaryInterceptor(secret string) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		if err := checkAuthToken(ctx, secret); err != nil {
@@ -72,9 +72,15 @@ func authStreamInterceptor(secret string) grpc.StreamServerInterceptor {
 }
 
 // checkAuthToken pulls the x-accelerator-token from incoming metadata and
-// constant-time-compares it against secret. Returns nil when the token matches,
-// or when secret is empty — the latter only in the test-only WithStdinReader(nil)
-// path (readSecret guarantees a non-empty secret for the shipped daemon).
+// constant-time-compares its SHA-256 digest against the secret's. Hashing first
+// makes both ConstantTimeCompare inputs a fixed 32 bytes, so a mismatched-length
+// token cannot leak the secret's length through the early-return timing side
+// channel (ConstantTimeCompare returns immediately when its inputs differ in
+// length).
+//
+// It returns nil when the token matches. The secret == "" guard is defense in
+// depth: Server.Start only chains this interceptor for a non-empty secret, so
+// the shipped daemon never hits it.
 //
 // On failure it returns codes.Internal with a generic message, NOT
 // codes.Unauthenticated: the accelerator is a transparent proxy, so the only
@@ -97,23 +103,25 @@ func checkAuthToken(ctx context.Context, secret string) error {
 	if len(vals) == 0 {
 		return authFailure("missing x-accelerator-token")
 	}
-	if subtle.ConstantTimeCompare([]byte(vals[0]), []byte(secret)) != 1 {
+	secretHash := sha256.Sum256([]byte(secret))
+	tokenHash := sha256.Sum256([]byte(vals[0]))
+	if subtle.ConstantTimeCompare(tokenHash[:], secretHash[:]) != 1 {
 		return authFailure("invalid x-accelerator-token")
 	}
 	return nil
 }
 
-// authRejectMsg is the single message used both for the server-side warning log
-// and for the codes.Internal error returned to the caller, so the two never drift
-// apart. The specific reason (which check failed) is attached to the log as a
-// structured attribute and is never returned, so a same-UID probe gets no oracle.
+// authRejectMsg is the single message used both for the server-side log line and
+// for the codes.Internal error returned to the caller, so the two never drift
+// apart. The specific reason (which check failed) is appended only to the log and
+// is never returned, so a same-UID probe gets no oracle.
 const authRejectMsg = "accelerator: rejecting RPC from mismatched token"
 
-// authFailure logs the handshake rejection server-side at warning level (the
-// specific reason kept as a structured attribute, never returned) and returns a
-// codes.Internal error carrying the same authRejectMsg to the caller.
+// authFailure logs the handshake rejection server-side (with the specific reason,
+// which is never returned) and returns a codes.Internal error carrying the
+// generic authRejectMsg to the caller.
 func authFailure(reason string) error {
-	slog.Warn(authRejectMsg, "reason", reason)
+	log.Printf("%s (reason: %s)", authRejectMsg, reason)
 	return status.Error(codes.Internal, authRejectMsg)
 }
 

--- a/bigtable/internal/accelerator/interceptors.go
+++ b/bigtable/internal/accelerator/interceptors.go
@@ -16,13 +16,16 @@ package accelerator
 
 import (
 	"context"
+	"crypto/subtle"
 	"io"
+	"log/slog"
 	"strings"
 	"sync"
 
 	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -41,6 +44,77 @@ type bigtableServerStub struct {
 // newBigtableServerStub creates a new stub instance.
 func newBigtableServerStub() *bigtableServerStub {
 	return &bigtableServerStub{}
+}
+
+// authUnaryInterceptor validates the x-accelerator-token metadata header on
+// every unary RPC. An empty secret disables the check — a state reachable only
+// by tests that pass WithStdinReader(nil) (so readSecret never runs). The shipped
+// daemon always reads stdin and readSecret rejects an empty secret, so the
+// serving binary can never reach this branch. Mismatches are rejected with
+// codes.Internal (see checkAuthToken for why not Unauthenticated).
+func authUnaryInterceptor(secret string) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if err := checkAuthToken(ctx, secret); err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+}
+
+// authStreamInterceptor is the streaming counterpart to authUnaryInterceptor.
+func authStreamInterceptor(secret string) grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if err := checkAuthToken(ss.Context(), secret); err != nil {
+			return err
+		}
+		return handler(srv, ss)
+	}
+}
+
+// checkAuthToken pulls the x-accelerator-token from incoming metadata and
+// constant-time-compares it against secret. Returns nil when the token matches,
+// or when secret is empty — the latter only in the test-only WithStdinReader(nil)
+// path (readSecret guarantees a non-empty secret for the shipped daemon).
+//
+// On failure it returns codes.Internal with a generic message, NOT
+// codes.Unauthenticated: the accelerator is a transparent proxy, so the only
+// Unauthenticated a caller should ever see is a genuine Bigtable credential
+// failure forwarded from the backend. A handshake-token mismatch is instead an
+// accelerator-internal condition — in practice always a client/daemon wiring
+// bug, since the spawning client attaches the correct token to every RPC.
+// Surfacing it as Unauthenticated would send the user to debug their GCP
+// credentials; Internal correctly says "not your fault." The specific reason is
+// logged server-side (and never returned) so a same-UID probe gets no oracle.
+func checkAuthToken(ctx context.Context, secret string) error {
+	if secret == "" {
+		return nil
+	}
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return authFailure("missing metadata")
+	}
+	vals := md.Get("x-accelerator-token")
+	if len(vals) == 0 {
+		return authFailure("missing x-accelerator-token")
+	}
+	if subtle.ConstantTimeCompare([]byte(vals[0]), []byte(secret)) != 1 {
+		return authFailure("invalid x-accelerator-token")
+	}
+	return nil
+}
+
+// authRejectMsg is the single message used both for the server-side warning log
+// and for the codes.Internal error returned to the caller, so the two never drift
+// apart. The specific reason (which check failed) is attached to the log as a
+// structured attribute and is never returned, so a same-UID probe gets no oracle.
+const authRejectMsg = "accelerator: rejecting RPC from mismatched token"
+
+// authFailure logs the handshake rejection server-side at warning level (the
+// specific reason kept as a structured attribute, never returned) and returns a
+// codes.Internal error carrying the same authRejectMsg to the caller.
+func authFailure(reason string) error {
+	slog.Warn(authRejectMsg, "reason", reason)
+	return status.Error(codes.Internal, authRejectMsg)
 }
 
 // proxyUnaryInterceptor intercepts every incoming unary RPC, allocates the

--- a/bigtable/internal/accelerator/interceptors_test.go
+++ b/bigtable/internal/accelerator/interceptors_test.go
@@ -24,8 +24,86 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
+
+// newServerWithSecret starts an Server wired to accept exactly
+// `secret` on every RPC. It returns the server and the write end of the stdin
+// pipe — callers must defer both server.Stop() and stdinW.Close() (in that
+// order). Keeping stdinW open prevents monitorStdin from triggering a premature
+// shutdown while tests are running.
+func newServerWithSecret(t *testing.T, udsPath, secret string) (*Server, *os.File) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	go func() { w.WriteString(secret + "\n") }()
+	channel := &Channel{}
+	server := NewServer(udsPath, channel, WithStdinReader(r))
+	if err := server.Start(); err != nil {
+		r.Close()
+		w.Close()
+		t.Fatalf("failed to start server: %v", err)
+	}
+	return server, w
+}
+
+func TestServer_AuthInterceptor(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "accelerator-auth-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	udsPath := filepath.Join(tmpDir, "bt_proxy.sock")
+
+	const secret = "correct-secret-token"
+	server, stdinW := newServerWithSecret(t, udsPath, secret)
+	defer stdinW.Close()
+	defer server.Stop()
+
+	conn, err := grpc.NewClient("unix://"+udsPath, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	// PingAndWarm is a real Bigtable RPC (so the proxy resolves its proto types)
+	// that the channel does not proxy, so it returns Unimplemented. That makes
+	// Unimplemented a reliable stand-in for "auth passed": the request reached
+	// the channel instead of being rejected by the auth interceptor.
+	req := &btpb.PingAndWarmRequest{}
+	resp := &btpb.PingAndWarmResponse{}
+
+	// A rejected handshake surfaces as Internal (not Unauthenticated), so it is
+	// not mistaken for a Bigtable credential failure by the calling client.
+	t.Run("MissingToken", func(t *testing.T) {
+		err := conn.Invoke(context.Background(), "/google.bigtable.v2.Bigtable/PingAndWarm", req, resp)
+		if got := status.Code(err); got != codes.Internal {
+			t.Errorf("expected Internal, got %v", got)
+		}
+	})
+
+	t.Run("WrongToken", func(t *testing.T) {
+		ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("x-accelerator-token", "wrong-token"))
+		err := conn.Invoke(ctx, "/google.bigtable.v2.Bigtable/PingAndWarm", req, resp)
+		if got := status.Code(err); got != codes.Internal {
+			t.Errorf("expected Internal, got %v", got)
+		}
+	})
+
+	t.Run("CorrectToken", func(t *testing.T) {
+		ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("x-accelerator-token", secret))
+		err := conn.Invoke(ctx, "/google.bigtable.v2.Bigtable/PingAndWarm", req, resp)
+		// Auth passes and falls through to the zero-value channel, which returns
+		// Unimplemented for PingAndWarm — proving the auth layer did not
+		// short-circuit with Internal.
+		if got := status.Code(err); got != codes.Unimplemented {
+			t.Errorf("expected auth to pass (Unimplemented from channel), got %v", got)
+		}
+	})
+}
 
 func TestServer_EndToEnd(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "accelerator-test-*")

--- a/bigtable/internal/accelerator/server.go
+++ b/bigtable/internal/accelerator/server.go
@@ -21,10 +21,13 @@
 package accelerator
 
 import (
+	"bufio"
+	"fmt"
 	"io"
 	"log"
 	"net"
 	"os"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -40,7 +43,9 @@ type Server struct {
 	listener     net.Listener
 	shutdownChan chan struct{}
 	stopOnce     sync.Once
-	stdinReader  io.Reader // stdin source; nil disables the stdin watchdog. Defaults to os.Stdin; override with WithStdinReader.
+	stdinReader  io.Reader     // stdin source; nil disables the stdin watchdog. Defaults to os.Stdin; override with WithStdinReader.
+	stdinBuf     *bufio.Reader // wraps stdinReader once in Start(); shared by readSecret + monitorStdin
+	authSecret   string
 	channel      *Channel
 }
 
@@ -73,6 +78,15 @@ func NewServer(udsPath string, channel *Channel, opts ...ServerOption) *Server {
 
 // Start boots the gRPC server on the Unix Domain Socket asynchronously.
 func (s *Server) Start() error {
+	// Read the auth secret from stdin BEFORE binding — the parent process writes
+	// the secret before the daemon starts serving, so it is always present on the
+	// pipe.
+	if s.stdinReader != nil {
+		if err := s.readSecret(); err != nil {
+			return err
+		}
+	}
+
 	// Clear any stale socket left by a previous instance so the bind below
 	// succeeds. Safe under the daemon's 1:1 pairing with its parent: no live
 	// sibling shares this path.
@@ -105,10 +119,18 @@ func (s *Server) Start() error {
 		return err
 	}
 
-	// Proxy interceptors route each RPC through the Channel.
+	// Auth interceptors run first; when authSecret is empty (test mode with
+	// WithStdinReader(nil)) they are no-ops. Proxy interceptors follow and route
+	// each RPC through the Channel.
 	s.grpcServer = grpc.NewServer(
-		grpc.UnaryInterceptor(proxyUnaryInterceptor(s.channel)),
-		grpc.StreamInterceptor(proxyStreamInterceptor(s.channel)),
+		grpc.ChainUnaryInterceptor(
+			authUnaryInterceptor(s.authSecret),
+			proxyUnaryInterceptor(s.channel),
+		),
+		grpc.ChainStreamInterceptor(
+			authStreamInterceptor(s.authSecret),
+			proxyStreamInterceptor(s.channel),
+		),
 	)
 
 	// Register the empty bigtableServerStub. gRPC requires a typed
@@ -160,6 +182,30 @@ func (s *Server) Stop() {
 
 		_ = os.Remove(s.udsPath)
 	})
+}
+
+// readSecret reads the auth secret written by the parent process to stdin
+// before the daemon binds. It wraps stdinReader once in a bufio.Reader
+// (stored as s.stdinBuf) so monitorStdin can continue consuming the same
+// buffered stream without losing bytes.
+//
+// An empty or whitespace-only secret is rejected so the daemon fails closed:
+// serving with an empty authSecret would disable the auth interceptor (see
+// checkAuthToken), so we refuse to start rather than accept unauthenticated
+// callers. This guarantees the shipped binary — which always feeds os.Stdin —
+// either has a real secret or never binds the socket.
+func (s *Server) readSecret() error {
+	s.stdinBuf = bufio.NewReader(s.stdinReader)
+	line, err := s.stdinBuf.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("accelerator: failed to read auth secret from stdin: %w", err)
+	}
+	secret := strings.TrimSpace(line)
+	if secret == "" {
+		return fmt.Errorf("accelerator: received empty auth secret from stdin; refusing to serve unauthenticated")
+	}
+	s.authSecret = secret
+	return nil
 }
 
 // ShutdownChan returns a read-only channel that is closed when the server

--- a/bigtable/internal/accelerator/server.go
+++ b/bigtable/internal/accelerator/server.go
@@ -22,6 +22,7 @@ package accelerator
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -30,10 +31,17 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
 	"google.golang.org/grpc"
 )
+
+// defaultHandshakeTimeout bounds how long Start waits for the parent process to
+// write the auth secret to stdin. Without it, a parent that never writes would
+// leave the daemon blocked in readSecret forever — never binding the socket and
+// never exiting.
+const defaultHandshakeTimeout = 5 * time.Second
 
 // Server manages the lifecycle of the local gRPC UDS server.
 type Server struct {
@@ -47,6 +55,8 @@ type Server struct {
 	stdinBuf     *bufio.Reader // wraps stdinReader once in Start(); shared by readSecret + monitorStdin
 	authSecret   string
 	channel      *Channel
+
+	handshakeTimeout time.Duration // bounds readSecret; defaults to defaultHandshakeTimeout, override with WithHandshakeTimeout.
 }
 
 // ServerOption configures optional Server behavior. Options are applied in
@@ -61,14 +71,22 @@ func WithStdinReader(r io.Reader) ServerOption {
 	return func(s *Server) { s.stdinReader = r }
 }
 
+// WithHandshakeTimeout overrides how long Start waits for the parent to write
+// the auth secret to stdin before failing. Primarily for tests that want a short
+// deadline; the shipped daemon uses defaultHandshakeTimeout.
+func WithHandshakeTimeout(d time.Duration) ServerOption {
+	return func(s *Server) { s.handshakeTimeout = d }
+}
+
 // NewServer creates a new Server instance.
 func NewServer(udsPath string, channel *Channel, opts ...ServerOption) *Server {
 	s := &Server{
-		udsPath:      udsPath,
-		shutdownChan: make(chan struct{}),
-		stdinReader:  os.Stdin,
-		channel:      channel,
-		service:      newBigtableServerStub(),
+		udsPath:          udsPath,
+		shutdownChan:     make(chan struct{}),
+		stdinReader:      os.Stdin,
+		channel:          channel,
+		service:          newBigtableServerStub(),
+		handshakeTimeout: defaultHandshakeTimeout,
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -82,7 +100,9 @@ func (s *Server) Start() error {
 	// the secret before the daemon starts serving, so it is always present on the
 	// pipe.
 	if s.stdinReader != nil {
-		if err := s.readSecret(); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), s.handshakeTimeout)
+		defer cancel()
+		if err := s.readSecret(ctx); err != nil {
 			return err
 		}
 	}
@@ -119,18 +139,21 @@ func (s *Server) Start() error {
 		return err
 	}
 
-	// Auth interceptors run first; when authSecret is empty (test mode with
-	// WithStdinReader(nil)) they are no-ops. Proxy interceptors follow and route
-	// each RPC through the Channel.
+	// Chain the proxy interceptors, which route each RPC through the Channel.
+	// The auth interceptors are prepended only when a secret was read from stdin
+	// — the sole secret-less path is test mode (WithStdinReader(nil)), where auth
+	// is intentionally disabled. Gating the wiring here (rather than relying on a
+	// no-op inside the interceptor) keeps "auth is off" explicit and off the RPC
+	// hot path.
+	unaryInterceptors := []grpc.UnaryServerInterceptor{proxyUnaryInterceptor(s.channel)}
+	streamInterceptors := []grpc.StreamServerInterceptor{proxyStreamInterceptor(s.channel)}
+	if s.authSecret != "" {
+		unaryInterceptors = append([]grpc.UnaryServerInterceptor{authUnaryInterceptor(s.authSecret)}, unaryInterceptors...)
+		streamInterceptors = append([]grpc.StreamServerInterceptor{authStreamInterceptor(s.authSecret)}, streamInterceptors...)
+	}
 	s.grpcServer = grpc.NewServer(
-		grpc.ChainUnaryInterceptor(
-			authUnaryInterceptor(s.authSecret),
-			proxyUnaryInterceptor(s.channel),
-		),
-		grpc.ChainStreamInterceptor(
-			authStreamInterceptor(s.authSecret),
-			proxyStreamInterceptor(s.channel),
-		),
+		grpc.ChainUnaryInterceptor(unaryInterceptors...),
+		grpc.ChainStreamInterceptor(streamInterceptors...),
 	)
 
 	// Register the empty bigtableServerStub. gRPC requires a typed
@@ -191,21 +214,42 @@ func (s *Server) Stop() {
 //
 // An empty or whitespace-only secret is rejected so the daemon fails closed:
 // serving with an empty authSecret would disable the auth interceptor (see
-// checkAuthToken), so we refuse to start rather than accept unauthenticated
+// Server.Start), so we refuse to start rather than accept unauthenticated
 // callers. This guarantees the shipped binary — which always feeds os.Stdin —
 // either has a real secret or never binds the socket.
-func (s *Server) readSecret() error {
+//
+// The read is bounded by ctx: ReadString blocks until a newline or EOF, so a
+// parent that opens the pipe but never writes would otherwise wedge Start
+// forever. On timeout we return ctx.Err(); the read goroutine stays parked on
+// stdin until the process exits, which is fine because Start returns an error
+// and the daemon never serves.
+func (s *Server) readSecret(ctx context.Context) error {
 	s.stdinBuf = bufio.NewReader(s.stdinReader)
-	line, err := s.stdinBuf.ReadString('\n')
-	if err != nil {
-		return fmt.Errorf("accelerator: failed to read auth secret from stdin: %w", err)
+
+	type readResult struct {
+		line string
+		err  error
 	}
-	secret := strings.TrimSpace(line)
-	if secret == "" {
-		return fmt.Errorf("accelerator: received empty auth secret from stdin; refusing to serve unauthenticated")
+	ch := make(chan readResult, 1)
+	go func() {
+		line, err := s.stdinBuf.ReadString('\n')
+		ch <- readResult{line, err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("accelerator: timed out reading auth secret from stdin: %w", ctx.Err())
+	case res := <-ch:
+		if res.err != nil {
+			return fmt.Errorf("accelerator: failed to read auth secret from stdin: %w", res.err)
+		}
+		secret := strings.TrimSpace(res.line)
+		if secret == "" {
+			return fmt.Errorf("accelerator: received empty auth secret from stdin; refusing to serve unauthenticated")
+		}
+		s.authSecret = secret
+		return nil
 	}
-	s.authSecret = secret
-	return nil
 }
 
 // ShutdownChan returns a read-only channel that is closed when the server

--- a/bigtable/internal/accelerator/server_test.go
+++ b/bigtable/internal/accelerator/server_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestServer_Permissions(t *testing.T) {
@@ -137,6 +138,40 @@ func TestServer_ReadSecretEmpty(t *testing.T) {
 				t.Error("expected Start() to fail on empty auth secret, but got nil")
 			}
 		})
+	}
+}
+
+func TestServer_ReadSecretTimeout(t *testing.T) {
+	// Parent opens the pipe but never writes the secret. Start must fail on the
+	// handshake deadline rather than blocking forever in readSecret.
+	tmpDir, err := os.MkdirTemp("", "accelerator-secrettimeout-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	udsPath := filepath.Join(tmpDir, "bt_proxy.sock")
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close() // keep the write end open so the read blocks (no EOF).
+
+	channel := &Channel{}
+	server := NewServer(udsPath, channel, WithStdinReader(r), WithHandshakeTimeout(50*time.Millisecond))
+
+	done := make(chan error, 1)
+	go func() { done <- server.Start() }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			server.Stop()
+			t.Fatal("expected Start() to fail on handshake timeout, but got nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start() did not return within 2s; handshake timeout not enforced")
 	}
 }
 

--- a/bigtable/internal/accelerator/server_test.go
+++ b/bigtable/internal/accelerator/server_test.go
@@ -47,6 +47,99 @@ func TestServer_Permissions(t *testing.T) {
 	}
 }
 
+func TestServer_ReadSecret(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "accelerator-secret-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	udsPath := filepath.Join(tmpDir, "bt_proxy.sock")
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	const want = "my-test-secret-token"
+	go func() { w.WriteString(want + "\n") }()
+
+	channel := &Channel{}
+	server := NewServer(udsPath, channel, WithStdinReader(r))
+	if err := server.Start(); err != nil {
+		t.Fatalf("failed to start server: %v", err)
+	}
+	defer server.Stop()
+
+	if got := server.authSecret; got != want {
+		t.Errorf("authSecret = %q, want %q", got, want)
+	}
+}
+
+func TestServer_ReadSecretEOFBeforeNewline(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "accelerator-badsecret-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	udsPath := filepath.Join(tmpDir, "bt_proxy.sock")
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	defer r.Close()
+
+	// Close write end immediately — daemon gets EOF before reading a newline.
+	w.Close()
+
+	channel := &Channel{}
+	server := NewServer(udsPath, channel, WithStdinReader(r))
+	if err := server.Start(); err == nil {
+		server.Stop()
+		t.Error("expected Start() to fail when stdin closes before secret newline, but got nil")
+	}
+}
+
+func TestServer_ReadSecretEmpty(t *testing.T) {
+	// A blank secret line must fail the daemon closed rather than serving with
+	// auth disabled.
+	for _, tc := range []struct {
+		name    string
+		payload string
+	}{
+		{"EmptyLine", "\n"},
+		{"WhitespaceOnly", "   \n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "accelerator-emptysecret-*")
+			if err != nil {
+				t.Fatalf("failed to create temp dir: %v", err)
+			}
+			defer os.RemoveAll(tmpDir)
+			udsPath := filepath.Join(tmpDir, "bt_proxy.sock")
+
+			r, w, err := os.Pipe()
+			if err != nil {
+				t.Fatalf("failed to create pipe: %v", err)
+			}
+			defer r.Close()
+			go func() {
+				w.WriteString(tc.payload)
+				w.Close()
+			}()
+
+			channel := &Channel{}
+			server := NewServer(udsPath, channel, WithStdinReader(r))
+			if err := server.Start(); err == nil {
+				server.Stop()
+				t.Error("expected Start() to fail on empty auth secret, but got nil")
+			}
+		})
+	}
+}
+
 func TestServer_StartFailure(t *testing.T) {
 	udsPath := "/nonexistent-dir-123456/bt_proxy.sock"
 	channel := &Channel{}


### PR DESCRIPTION
…en handshake

Layer a token-based handshake on top of the UDS proxy server. The Python parent mints a secret and writes it to the daemon's stdin before the socket binds; readSecret consumes it (failing closed on an empty or truncated secret) and auth interceptors constant-time-compare the x-accelerator-token metadata header on every RPC. Mismatches are rejected with codes.Internal — never Unauthenticated — so a handshake failure is not mistaken for a forwarded Bigtable credential error.

Change-Id: I908a45c772b6aa87c43ea33da57d2e8c3aeb90e9