### PR TITLE
feat(bigtable/accelerator): add stdin-EOF and parent-PID lifecycle wa…

### DIFF
--- a/bigtable/internal/accelerator/server.go
+++ b/bigtable/internal/accelerator/server.go
@@ -43,6 +43,14 @@ import (
 // never exiting.
 const defaultHandshakeTimeout = 5 * time.Second
 
+// gracefulStopTimeout bounds the graceful drain in Stop before falling back to a
+// hard grpc.Server.Stop, so a wedged in-flight RPC can't hang shutdown forever.
+const gracefulStopTimeout = 5 * time.Second
+
+// parentPidPollInterval is how often monitorParentPid samples the parent PID to
+// detect reparenting (original parent death).
+const parentPidPollInterval = 500 * time.Millisecond
+
 // Server manages the lifecycle of the local gRPC UDS server.
 type Server struct {
 	udsPath      string
@@ -96,6 +104,16 @@ func NewServer(udsPath string, channel *Channel, opts ...ServerOption) *Server {
 
 // Start boots the gRPC server on the Unix Domain Socket asynchronously.
 func (s *Server) Start() error {
+	// Capture the parent PID before serving so monitorParentPid can detect a
+	// later reparent (the original parent dying). A ppid of 1 is ambiguous — it
+	// means either we were orphaned and reparented to init, OR the parent
+	// legitimately IS pid 1 (e.g. the SDK process running as a container's
+	// entrypoint, `CMD ["python", "app.py"]`). We can't distinguish the two from
+	// ppid alone, so we don't refuse to serve; instead we skip the parent-PID
+	// watchdog below and rely on monitorStdin, whose EOF signal detects parent
+	// death without the ppid ambiguity.
+	initialPpid := os.Getppid()
+
 	// Read the auth secret from stdin BEFORE binding — the parent process writes
 	// the secret before the daemon starts serving, so it is always present on the
 	// pipe.
@@ -180,7 +198,13 @@ func (s *Server) Start() error {
 	}()
 
 	go s.monitorStdin()
-	go s.monitorParentPid()
+	// Skip the parent-PID watchdog when initialPpid is 1: it's ambiguous (orphan
+	// vs. legitimate child of pid 1), and monitorStdin already covers parent
+	// death. When initialPpid is a real parent, any later change to it means the
+	// parent we shadow has died.
+	if initialPpid != 1 {
+		go s.monitorParentPid(initialPpid)
+	}
 
 	return nil
 }
@@ -204,7 +228,7 @@ func (s *Server) Stop() {
 			}()
 			select {
 			case <-stopped:
-			case <-time.After(5 * time.Second):
+			case <-time.After(gracefulStopTimeout):
 				s.grpcServer.Stop()
 			}
 		}
@@ -299,17 +323,13 @@ func (s *Server) monitorStdin() {
 	}
 }
 
-// monitorParentPid stops the daemon if its parent PID changes, which happens
-// when the original parent dies and the process is reparented (to init or a
-// subreaper). If the daemon is already parented to init at startup (e.g. under
-// a process supervisor or in a container), there is no original parent to
-// outlive, so the watchdog is disabled.
-func (s *Server) monitorParentPid() {
-	initialPpid := os.Getppid()
-	if initialPpid == 1 {
-		return
-	}
-	ticker := time.NewTicker(500 * time.Millisecond)
+// monitorParentPid stops the daemon if its parent PID changes from initialPpid,
+// which happens when the original parent dies and the process is reparented (to
+// init or a subreaper). initialPpid is captured and passed in by Start, which
+// only launches this watchdog when initialPpid is a real parent (not 1) — see
+// Start for why a ppid of 1 is ambiguous and handled by monitorStdin instead.
+func (s *Server) monitorParentPid(initialPpid int) {
+	ticker := time.NewTicker(parentPidPollInterval)
 	defer ticker.Stop()
 
 	for {

--- a/bigtable/internal/accelerator/server.go
+++ b/bigtable/internal/accelerator/server.go
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 // Package accelerator implements the in-process Bigtable accelerator daemon.
-// It hosts the gRPC server-side scaffolding — a UDS listener and proxy
-// interceptors that forward every RPC through a Channel — alongside the
-// Channel itself, which backs those RPCs with internal/session. The
-// interceptor implementations live in interceptors.go alongside
-// bigtableServerStub.
+// It hosts the gRPC server-side scaffolding — a UDS listener, lifecycle
+// watchdogs (stdin EOF and parent-PID reparent), and proxy interceptors that
+// forward every RPC through a Channel — alongside the Channel itself, which
+// backs those RPCs with internal/session. The interceptor implementations
+// live in interceptors.go alongside bigtableServerStub.
 package accelerator
 
 import (
@@ -179,6 +179,9 @@ func (s *Server) Start() error {
 		s.Stop()
 	}()
 
+	go s.monitorStdin()
+	go s.monitorParentPid()
+
 	return nil
 }
 
@@ -189,7 +192,21 @@ func (s *Server) Stop() {
 		close(s.shutdownChan)
 
 		if s.grpcServer != nil {
-			s.grpcServer.GracefulStop()
+			// GracefulStop blocks until all in-flight RPCs finish. A wedged or
+			// slow-draining RPC would otherwise hang shutdown forever, which is
+			// especially harmful on the watchdog paths (stdin EOF, parent-PID
+			// reparent) whose whole purpose is to guarantee the daemon exits.
+			// Bound the graceful drain and fall back to a hard Stop().
+			stopped := make(chan struct{})
+			go func() {
+				s.grpcServer.GracefulStop()
+				close(stopped)
+			}()
+			select {
+			case <-stopped:
+			case <-time.After(5 * time.Second):
+				s.grpcServer.Stop()
+			}
 		}
 
 		if s.listener != nil {
@@ -249,6 +266,57 @@ func (s *Server) readSecret(ctx context.Context) error {
 		}
 		s.authSecret = secret
 		return nil
+	}
+}
+
+// monitorStdin monitors standard input for an EOF signal. Tests that don't
+// want this watchdog pass WithStdinReader(nil).
+func (s *Server) monitorStdin() {
+	if s.stdinReader == nil {
+		return
+	}
+	// Use the buffered reader created by readSecret so bytes already consumed
+	// into the buffer are not lost (in practice stdin only carries the secret
+	// line followed by EOF, but using the same reader is correct).
+	var r io.Reader
+	if s.stdinBuf != nil {
+		r = s.stdinBuf
+	} else {
+		r = s.stdinReader
+	}
+	buf := make([]byte, 1)
+	for {
+		select {
+		case <-s.shutdownChan:
+			return
+		default:
+			_, err := r.Read(buf)
+			if err != nil {
+				s.Stop()
+				return
+			}
+		}
+	}
+}
+
+// monitorParentPid stops the daemon if the parent PID becomes 1 (orphaned)
+// or otherwise changes.
+func (s *Server) monitorParentPid() {
+	initialPpid := os.Getppid()
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.shutdownChan:
+			return
+		case <-ticker.C:
+			currentPpid := os.Getppid()
+			if currentPpid == 1 || currentPpid != initialPpid {
+				s.Stop()
+				return
+			}
+		}
 	}
 }
 

--- a/bigtable/internal/accelerator/server.go
+++ b/bigtable/internal/accelerator/server.go
@@ -299,10 +299,16 @@ func (s *Server) monitorStdin() {
 	}
 }
 
-// monitorParentPid stops the daemon if the parent PID becomes 1 (orphaned)
-// or otherwise changes.
+// monitorParentPid stops the daemon if its parent PID changes, which happens
+// when the original parent dies and the process is reparented (to init or a
+// subreaper). If the daemon is already parented to init at startup (e.g. under
+// a process supervisor or in a container), there is no original parent to
+// outlive, so the watchdog is disabled.
 func (s *Server) monitorParentPid() {
 	initialPpid := os.Getppid()
+	if initialPpid == 1 {
+		return
+	}
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 
@@ -311,8 +317,7 @@ func (s *Server) monitorParentPid() {
 		case <-s.shutdownChan:
 			return
 		case <-ticker.C:
-			currentPpid := os.Getppid()
-			if currentPpid == 1 || currentPpid != initialPpid {
+			if os.Getppid() != initialPpid {
 				s.Stop()
 				return
 			}

--- a/bigtable/internal/accelerator/server_test.go
+++ b/bigtable/internal/accelerator/server_test.go
@@ -48,6 +48,44 @@ func TestServer_Permissions(t *testing.T) {
 	}
 }
 
+func TestServer_LifecycleStdinEOF(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "accelerator-lifecycle-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	udsPath := filepath.Join(tmpDir, "bt_proxy.sock")
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	defer r.Close()
+
+	// Write the handshake secret before Start() blocks on ReadString.
+	go func() {
+		w.WriteString("test-handshake-secret\n")
+	}()
+
+	channel := &Channel{}
+	server := NewServer(udsPath, channel, WithStdinReader(r)) // inject the pipe instead of os.Stdin
+	if err := server.Start(); err != nil {
+		t.Fatalf("failed to start server: %v", err)
+	}
+	defer server.Stop()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close write pipe: %v", err)
+	}
+
+	select {
+	case <-server.shutdownChan:
+		// success
+	case <-time.After(3 * time.Second):
+		t.Error("server failed to shut down within timeout after stdin EOF")
+	}
+}
+
 func TestServer_ReadSecret(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "accelerator-secret-*")
 	if err != nil {


### PR DESCRIPTION
…tchdogs

Tie the daemon's lifetime to its parent. monitorStdin shuts the server down when the stdin pipe reaches EOF (parent closed it or exited), and monitorParentPid shuts down when the process is reparented (ppid becomes 1 or otherwise changes). Both are launched from Start and stop cleanly on the shutdown channel. monitorStdin reuses the buffered reader created by readSecret so no bytes after the secret line are lost.

Change-Id: Ifa56c3e594d77a1f831b164cb3611ff2ea68925d