### PR TITLE
feat(bigtable/accelerator): add daemon binary with identity verification  

### DIFF
--- a/bigtable/internal/accelerator/accelerator_core.go
+++ b/bigtable/internal/accelerator/accelerator_core.go
@@ -53,8 +53,13 @@ import (
 const (
 	prodAddr     = "bigtable.UNIVERSE_DOMAIN:443"
 	mtlsProdAddr = "bigtable.mtls.googleapis.com:443"
-	dataScope    = "https://www.googleapis.com/auth/bigtable.data"
 )
+
+// DataScope is the default OAuth scope the channel dials with when the caller
+// supplies no scope override. Exported so the daemon binary can resolve ADC
+// once with the same effective scope the channel would, then hand the resolved
+// credentials back via option.WithCredentials (avoiding a second ADC lookup).
+const DataScope = "https://www.googleapis.com/auth/bigtable.data"
 
 var userAgent = "cbt-go-accelerator/v" + internal.Version
 
@@ -139,7 +144,7 @@ func NewChannel(
 	// Bigtable data-plane endpoint, scope, and user agent first, then let the
 	// caller's opts override. Mirrors bigtable.NewClient's use of
 	// btopt.DefaultClientOptions.
-	defaultOpts, err := btopt.DefaultClientOptions(prodAddr, mtlsProdAddr, dataScope, userAgent)
+	defaultOpts, err := btopt.DefaultClientOptions(prodAddr, mtlsProdAddr, DataScope, userAgent)
 	if err != nil {
 		return nil, err
 	}

--- a/bigtable/internal/accelerator/cmd/identity.go
+++ b/bigtable/internal/accelerator/cmd/identity.go
@@ -39,19 +39,14 @@ type identityDoc struct {
 	Scopes    []string `json:"scopes"`
 }
 
-// resolveAndWriteIdentity resolves the daemon's Application Default Credentials
-// locally (no token introspection) and writes the resulting principal + scopes
-// to identity.json in the same directory as udsPath. It must be called before
-// the UDS is bound so the file is present by the time the client can connect.
+// writeIdentity writes the daemon's resolved principal + scopes to
+// identity.json in the same directory as udsPath. It must be called before the
+// UDS is bound so the file is present by the time the client can connect.
 //
 // An empty principal (e.g. plain user ADC, which exposes no local email) is
 // written as-is; the client treats "no principal" as unverifiable and falls
 // back to its native path rather than risking an identity mismatch.
-func resolveAndWriteIdentity(ctx context.Context, udsPath string, scopes []string) error {
-	principal, err := resolvePrincipal(ctx, scopes)
-	if err != nil {
-		return err
-	}
+func writeIdentity(udsPath, principal string, scopes []string) error {
 	doc := identityDoc{Principal: principal, Scopes: scopes}
 	b, err := json.Marshal(doc)
 	if err != nil {
@@ -65,17 +60,18 @@ func resolveAndWriteIdentity(ctx context.Context, udsPath string, scopes []strin
 	return nil
 }
 
-// resolvePrincipal returns the service-account email of the daemon's ADC using
-// only local sources: the credential JSON for keyed creds (SA key, impersonated,
-// Workload Identity Federation) and the link-local metadata server for GCE/GKE
-// creds. Returns "" (no error) when no principal can be resolved locally.
-func resolvePrincipal(ctx context.Context, scopes []string) (string, error) {
-	creds, err := google.FindDefaultCredentials(ctx, scopes...)
-	if err != nil {
-		return "", fmt.Errorf("find default credentials: %w", err)
-	}
-	if email := emailFromCredsJSON(creds.JSON); email != "" {
-		return email, nil
+// principalFromCreds returns the service-account email of already-resolved ADC
+// using only local sources: the credential JSON for keyed creds (SA key,
+// impersonated, Workload Identity Federation) and the link-local metadata
+// server for GCE/GKE creds. It takes pre-resolved credentials so the daemon
+// resolves ADC exactly once (the same creds it dials the channel with) rather
+// than calling FindDefaultCredentials a second time here. Returns "" (no error)
+// when no principal can be resolved locally.
+func principalFromCreds(ctx context.Context, creds *google.Credentials) (string, error) {
+	if creds != nil {
+		if email := emailFromCredsJSON(creds.JSON); email != "" {
+			return email, nil
+		}
 	}
 	if metadata.OnGCE() {
 		// Link-local metadata server; no external egress, no IAM permission.

--- a/bigtable/internal/accelerator/cmd/identity.go
+++ b/bigtable/internal/accelerator/cmd/identity.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"cloud.google.com/go/compute/metadata"
+	"golang.org/x/oauth2/google"
+)
+
+// identityFilename is the name of the identity document written alongside the
+// UDS. The spawning client reads it to verify the daemon resolved the same
+// principal it did, then deletes it.
+const identityFilename = "identity.json"
+
+// identityDoc is the on-disk handshake payload. It holds only identifiers --
+// the resolved principal (a service-account email) and the scopes the daemon
+// dials with -- never access/refresh tokens or private-key bytes.
+type identityDoc struct {
+	Principal string   `json:"principal"`
+	Scopes    []string `json:"scopes"`
+}
+
+// resolveAndWriteIdentity resolves the daemon's Application Default Credentials
+// locally (no token introspection) and writes the resulting principal + scopes
+// to identity.json in the same directory as udsPath. It must be called before
+// the UDS is bound so the file is present by the time the client can connect.
+//
+// An empty principal (e.g. plain user ADC, which exposes no local email) is
+// written as-is; the client treats "no principal" as unverifiable and falls
+// back to its native path rather than risking an identity mismatch.
+func resolveAndWriteIdentity(ctx context.Context, udsPath string, scopes []string) error {
+	principal, err := resolvePrincipal(ctx, scopes)
+	if err != nil {
+		return err
+	}
+	doc := identityDoc{Principal: principal, Scopes: scopes}
+	b, err := json.Marshal(doc)
+	if err != nil {
+		return fmt.Errorf("marshal identity doc: %w", err)
+	}
+	path := filepath.Join(filepath.Dir(udsPath), identityFilename)
+	// 0600: identifier only, but keep it same-uid readable and nothing more.
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// resolvePrincipal returns the service-account email of the daemon's ADC using
+// only local sources: the credential JSON for keyed creds (SA key, impersonated,
+// Workload Identity Federation) and the link-local metadata server for GCE/GKE
+// creds. Returns "" (no error) when no principal can be resolved locally.
+func resolvePrincipal(ctx context.Context, scopes []string) (string, error) {
+	creds, err := google.FindDefaultCredentials(ctx, scopes...)
+	if err != nil {
+		return "", fmt.Errorf("find default credentials: %w", err)
+	}
+	if email := emailFromCredsJSON(creds.JSON); email != "" {
+		return email, nil
+	}
+	if metadata.OnGCE() {
+		// Link-local metadata server; no external egress, no IAM permission.
+		if email, err := metadata.EmailWithContext(ctx, "default"); err == nil {
+			return email, nil
+		}
+	}
+	return "", nil
+}
+
+// emailFromCredsJSON extracts the principal email from ADC credential JSON
+// without any network call. It handles service-account keys (client_email) and
+// impersonated / external-account creds (the target email embedded in the
+// impersonation URL). Returns "" for user creds or unrecognized shapes.
+func emailFromCredsJSON(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	var doc struct {
+		Type                           string `json:"type"`
+		ClientEmail                    string `json:"client_email"`
+		ServiceAccountImpersonationURL string `json:"service_account_impersonation_url"`
+	}
+	if err := json.Unmarshal(b, &doc); err != nil {
+		return ""
+	}
+	if doc.ClientEmail != "" {
+		return doc.ClientEmail
+	}
+	return emailFromImpersonationURL(doc.ServiceAccountImpersonationURL)
+}
+
+// emailFromImpersonationURL pulls "<email>" out of a URL shaped like
+// ".../serviceAccounts/<email>:generateAccessToken". Returns "" if the URL does
+// not match that shape.
+func emailFromImpersonationURL(url string) string {
+	const marker = "/serviceAccounts/"
+	i := strings.Index(url, marker)
+	if i < 0 {
+		return ""
+	}
+	rest := url[i+len(marker):]
+	if j := strings.IndexByte(rest, ':'); j >= 0 {
+		rest = rest[:j]
+	}
+	if k := strings.IndexByte(rest, '/'); k >= 0 {
+		rest = rest[:k]
+	}
+	return rest
+}

--- a/bigtable/internal/accelerator/cmd/identity.go
+++ b/bigtable/internal/accelerator/cmd/identity.go
@@ -65,8 +65,12 @@ func writeIdentity(udsPath, principal string, scopes []string) error {
 // impersonated, Workload Identity Federation) and the link-local metadata
 // server for GCE/GKE creds. It takes pre-resolved credentials so the daemon
 // resolves ADC exactly once (the same creds it dials the channel with) rather
-// than calling FindDefaultCredentials a second time here. Returns "" (no error)
-// when no principal can be resolved locally.
+// than calling FindDefaultCredentials a second time here.
+//
+// Returns "" with a nil error when no local principal source exists (e.g. plain
+// user ADC, which exposes no email). A non-nil error means a resolution source
+// was available but failed -- notably a metadata-server lookup that timed out or
+// errored -- which the caller surfaces as a warning rather than swallowing it.
 func principalFromCreds(ctx context.Context, creds *google.Credentials) (string, error) {
 	if creds != nil {
 		if email := emailFromCredsJSON(creds.JSON); email != "" {
@@ -75,9 +79,11 @@ func principalFromCreds(ctx context.Context, creds *google.Credentials) (string,
 	}
 	if metadata.OnGCE() {
 		// Link-local metadata server; no external egress, no IAM permission.
-		if email, err := metadata.EmailWithContext(ctx, "default"); err == nil {
-			return email, nil
+		email, err := metadata.EmailWithContext(ctx, "default")
+		if err != nil {
+			return "", fmt.Errorf("resolve principal from metadata server: %w", err)
 		}
+		return email, nil
 	}
 	return "", nil
 }

--- a/bigtable/internal/accelerator/cmd/identity_test.go
+++ b/bigtable/internal/accelerator/cmd/identity_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEmailFromCredsJSON(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "service account key",
+			in:   `{"type":"service_account","client_email":"sa@proj.iam.gserviceaccount.com","private_key":"-----BEGIN..."}`,
+			want: "sa@proj.iam.gserviceaccount.com",
+		},
+		{
+			name: "impersonated",
+			in:   `{"type":"impersonated_service_account","service_account_impersonation_url":"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/target@proj.iam.gserviceaccount.com:generateAccessToken"}`,
+			want: "target@proj.iam.gserviceaccount.com",
+		},
+		{
+			name: "workload identity federation",
+			in:   `{"type":"external_account","service_account_impersonation_url":"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/wif@proj.iam.gserviceaccount.com:generateAccessToken"}`,
+			want: "wif@proj.iam.gserviceaccount.com",
+		},
+		{
+			name: "authorized user has no local email",
+			in:   `{"type":"authorized_user","client_id":"abc.apps.googleusercontent.com","refresh_token":"x"}`,
+			want: "",
+		},
+		{
+			name: "empty",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "garbage",
+			in:   "not json",
+			want: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := emailFromCredsJSON([]byte(tc.in)); got != tc.want {
+				t.Errorf("emailFromCredsJSON(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEmailFromImpersonationURL(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want string
+	}{
+		{
+			in:   "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/x@y.iam.gserviceaccount.com:generateAccessToken",
+			want: "x@y.iam.gserviceaccount.com",
+		},
+		{in: "https://example.com/no/marker", want: ""},
+		{in: "", want: ""},
+	} {
+		if got := emailFromImpersonationURL(tc.in); got != tc.want {
+			t.Errorf("emailFromImpersonationURL(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestResolveAndWriteIdentity_WritesDocNextToSocket(t *testing.T) {
+	dir := t.TempDir()
+	udsPath := filepath.Join(dir, "sock")
+
+	// Point ADC at a service-account key so resolution is local and
+	// deterministic (no metadata server, no network).
+	keyPath := filepath.Join(dir, "key.json")
+	const email = "unit@proj.iam.gserviceaccount.com"
+	key := `{"type":"service_account","project_id":"proj","client_email":"` + email + `",` +
+		`"private_key_id":"kid","token_uri":"https://oauth2.googleapis.com/token",` +
+		`"private_key":"-----BEGIN PRIVATE KEY-----\nMIIB\n-----END PRIVATE KEY-----\n"}`
+	if err := os.WriteFile(keyPath, []byte(key), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", keyPath)
+
+	scopes := []string{"https://www.googleapis.com/auth/bigtable.data"}
+	if err := resolveAndWriteIdentity(t.Context(), udsPath, scopes); err != nil {
+		t.Fatalf("resolveAndWriteIdentity: %v", err)
+	}
+
+	path := filepath.Join(dir, identityFilename)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("identity file not written: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("identity file mode = %o, want 600", perm)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc identityDoc
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatalf("unmarshal identity: %v", err)
+	}
+	if doc.Principal != email {
+		t.Errorf("principal = %q, want %q", doc.Principal, email)
+	}
+	if len(doc.Scopes) != 1 || doc.Scopes[0] != scopes[0] {
+		t.Errorf("scopes = %v, want %v", doc.Scopes, scopes)
+	}
+	// The document must never contain the private key material.
+	if strings.Contains(string(b), "PRIVATE KEY") {
+		t.Errorf("identity doc leaked key material: %s", b)
+	}
+}

--- a/bigtable/internal/accelerator/cmd/identity_test.go
+++ b/bigtable/internal/accelerator/cmd/identity_test.go
@@ -20,6 +20,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"golang.org/x/oauth2/google"
 )
 
 func TestEmailFromCredsJSON(t *testing.T) {
@@ -85,7 +87,7 @@ func TestEmailFromImpersonationURL(t *testing.T) {
 	}
 }
 
-func TestResolveAndWriteIdentity_WritesDocNextToSocket(t *testing.T) {
+func TestWriteIdentity_WritesDocNextToSocket(t *testing.T) {
 	dir := t.TempDir()
 	udsPath := filepath.Join(dir, "sock")
 
@@ -102,8 +104,18 @@ func TestResolveAndWriteIdentity_WritesDocNextToSocket(t *testing.T) {
 	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", keyPath)
 
 	scopes := []string{"https://www.googleapis.com/auth/bigtable.data"}
-	if err := resolveAndWriteIdentity(t.Context(), udsPath, scopes); err != nil {
-		t.Fatalf("resolveAndWriteIdentity: %v", err)
+	// Resolve ADC once (as main.go does) and derive the principal from those same
+	// creds, rather than a second FindDefaultCredentials call inside resolution.
+	creds, err := google.FindDefaultCredentials(t.Context(), scopes...)
+	if err != nil {
+		t.Fatalf("FindDefaultCredentials: %v", err)
+	}
+	principal, err := principalFromCreds(t.Context(), creds)
+	if err != nil {
+		t.Fatalf("principalFromCreds: %v", err)
+	}
+	if err := writeIdentity(udsPath, principal, scopes); err != nil {
+		t.Fatalf("writeIdentity: %v", err)
 	}
 
 	path := filepath.Join(dir, identityFilename)

--- a/bigtable/internal/accelerator/cmd/main.go
+++ b/bigtable/internal/accelerator/cmd/main.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Binary accelerator runs the in-process gRPC proxy daemon: it listens on a
+// Unix domain socket, accepts standard google.bigtable.v2.Bigtable RPCs, and
+// forwards each one through an Channel that rides the Jetstream
+// session transport.
+//
+// One daemon serves one (project, instance, appProfile) tuple. Cross-language
+// clients spawn the binary, wait for the UDS to become connectable, then talk
+// standard Bigtable V2 protos over it.
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"strings"
+
+	"cloud.google.com/go/bigtable/internal/accelerator"
+	"google.golang.org/api/option"
+)
+
+func main() {
+	udsPath := flag.String("uds-path", "", "path to unix domain socket (required)")
+	project := flag.String("project", "", "GCP project ID (required)")
+	instance := flag.String("instance", "", "Bigtable instance ID (required)")
+	appProfile := flag.String("app-profile", "", "Bigtable app profile (optional)")
+	// Endpoint overrides. When empty, NewChannel falls back to the
+	// default Bigtable data-plane endpoint (bigtable.googleapis.com:443). The
+	// spawning client supplies these when it targets a non-default endpoint or a
+	// non-GDU universe.
+	dataEndpoint := flag.String("data-endpoint", "", "override Bigtable data-plane endpoint, e.g. bigtable.googleapis.com:443 (optional)")
+	universeDomain := flag.String("universe-domain", "", "override the service universe domain, e.g. googleapis.com (optional)")
+	scopesFlag := flag.String("scopes", "", "comma-separated OAuth scopes to override the default data scope (optional)")
+	quotaProject := flag.String("quota-project", "", "quota/billing project override (optional)")
+	flag.Parse()
+
+	if *udsPath == "" {
+		log.Fatal("Missing required flag: --uds-path")
+	}
+	if *project == "" {
+		log.Fatal("Missing required flag: --project")
+	}
+	if *instance == "" {
+		log.Fatal("Missing required flag: --instance")
+	}
+
+	// Only forward overrides that were actually set; leaving them unset lets
+	// the default endpoint/universe-domain resolution apply.
+	var opts []option.ClientOption
+	if *dataEndpoint != "" {
+		opts = append(opts, option.WithEndpoint(*dataEndpoint))
+	}
+	if *universeDomain != "" {
+		opts = append(opts, option.WithUniverseDomain(*universeDomain))
+	}
+	// Caller opts are appended after the channel's defaults, so WithScopes here
+	// overrides the hardcoded data scope.
+	scopes := splitScopes(*scopesFlag)
+	if len(scopes) > 0 {
+		opts = append(opts, option.WithScopes(scopes...))
+	}
+	if *quotaProject != "" {
+		opts = append(opts, option.WithQuotaProject(*quotaProject))
+	}
+
+	ctx := context.Background()
+	channel, err := accelerator.NewChannel(ctx, *project, *instance, *appProfile, opts...)
+	if err != nil {
+		log.Fatalf("failed to construct accelerator channel: %v", err)
+	}
+	srv := accelerator.NewServer(*udsPath, channel)
+	log.Printf("Starting accelerator daemon on UDS=%s project=%s instance=%s app-profile=%q data-endpoint=%q universe-domain=%q scopes=%q quota-project=%q",
+		*udsPath, *project, *instance, *appProfile, *dataEndpoint, *universeDomain, *scopesFlag, *quotaProject)
+
+	// Resolve and publish the daemon's identity BEFORE binding the socket, so
+	// the file is present by the time the client detects a connectable UDS.
+	// Non-fatal on failure: the client's verify step falls back to native.
+	if err := resolveAndWriteIdentity(ctx, *udsPath, scopes); err != nil {
+		log.Printf("warning: failed to write identity document: %v", err)
+	}
+
+	if err := srv.Start(); err != nil {
+		log.Fatalf("failed to start accelerator server: %v", err)
+	}
+	defer srv.Stop()
+
+	// Block until the watchdog (stdin EOF or parent-PID change) trips.
+	<-srv.ShutdownChan()
+	log.Printf("Teardown signal detected, exiting...")
+}
+
+// splitScopes parses a comma-separated scopes flag into a trimmed, non-empty
+// slice. Returns an empty (non-nil) slice when the flag is empty or blank, so
+// callers get a consistent slice value and it marshals to [] rather than null.
+func splitScopes(raw string) []string {
+	scopes := []string{}
+	for _, s := range strings.Split(raw, ",") {
+		if s = strings.TrimSpace(s); s != "" {
+			scopes = append(scopes, s)
+		}
+	}
+	return scopes
+}

--- a/bigtable/internal/accelerator/cmd/main.go
+++ b/bigtable/internal/accelerator/cmd/main.go
@@ -26,11 +26,21 @@ import (
 	"context"
 	"flag"
 	"log"
+	"os"
+	"os/signal"
 	"strings"
+	"syscall"
+	"time"
 
 	"cloud.google.com/go/bigtable/internal/accelerator"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 )
+
+// identityResolveTimeout bounds the pre-bind identity resolution so a hung
+// metadata server (GCE/GKE) can never stall daemon startup. On timeout the
+// principal is left unresolved and the client falls back to its native path.
+const identityResolveTimeout = 15 * time.Second
 
 func main() {
 	udsPath := flag.String("uds-path", "", "path to unix domain socket (required)")
@@ -77,6 +87,25 @@ func main() {
 	}
 
 	ctx := context.Background()
+
+	// Resolve ADC once, using the effective scopes the channel will dial with,
+	// then hand the resolved credentials to both the channel (via
+	// WithCredentials) and the identity resolver below. This avoids a second
+	// FindDefaultCredentials lookup in identity resolution and guarantees the
+	// published principal matches the credentials the channel actually dials.
+	effectiveScopes := scopes
+	if len(effectiveScopes) == 0 {
+		effectiveScopes = []string{accelerator.DataScope}
+	}
+	creds, err := google.FindDefaultCredentials(ctx, effectiveScopes...)
+	if err != nil {
+		log.Fatalf("failed to resolve credentials: %v", err)
+	}
+	// Appended last so it overrides the channel's default credential resolution;
+	// the dial can no longer re-resolve to a different principal than the one we
+	// publish in identity.json.
+	opts = append(opts, option.WithCredentials(creds))
+
 	channel, err := accelerator.NewChannel(ctx, *project, *instance, *appProfile, opts...)
 	if err != nil {
 		log.Fatalf("failed to construct accelerator channel: %v", err)
@@ -87,8 +116,19 @@ func main() {
 
 	// Resolve and publish the daemon's identity BEFORE binding the socket, so
 	// the file is present by the time the client detects a connectable UDS.
-	// Non-fatal on failure: the client's verify step falls back to native.
-	if err := resolveAndWriteIdentity(ctx, *udsPath, scopes); err != nil {
+	// Non-fatal on failure: the client's verify step falls back to native. The
+	// resolution is bound by a timeout so a hung metadata server can't stall
+	// startup.
+	identityCtx, cancelIdentity := context.WithTimeout(ctx, identityResolveTimeout)
+	principal, err := principalFromCreds(identityCtx, creds)
+	if err != nil {
+		log.Printf("warning: principal resolution failed: %v", err)
+	}
+	cancelIdentity()
+	// Record effectiveScopes (not the raw override), so identity.json reflects
+	// the scope the daemon actually dials with rather than an empty list when no
+	// --scopes flag was passed.
+	if err := writeIdentity(*udsPath, principal, effectiveScopes); err != nil {
 		log.Printf("warning: failed to write identity document: %v", err)
 	}
 
@@ -97,9 +137,18 @@ func main() {
 	}
 	defer srv.Stop()
 
-	// Block until the watchdog (stdin EOF or parent-PID change) trips.
-	<-srv.ShutdownChan()
-	log.Printf("Teardown signal detected, exiting...")
+	// Block until either the watchdog (stdin EOF or parent-PID change) trips or
+	// the process receives a termination signal, then shut down cleanly.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(sigCh)
+
+	select {
+	case <-srv.ShutdownChan():
+		log.Printf("accelerator: watchdog-initiated shutdown, exiting...")
+	case s := <-sigCh:
+		log.Printf("accelerator: received %s, shutting down...", s)
+	}
 }
 
 // splitScopes parses a comma-separated scopes flag into a trimmed, non-empty


### PR DESCRIPTION
cmd/main.go wires NewChannel + NewServer and publishes an identity document before binding the socket; cmd/identity.go writes/handles the on-disk handshake payload.