### PR TITLE
feat(bigtable): share underlying session.Client across NewClient calls with matching identity

### DIFF
--- a/bigtable/client.go
+++ b/bigtable/client.go
@@ -78,6 +78,24 @@ type Client struct {
 	// calls Close() on the returned handle. See
 	// internal/session/table_cache.go.
 	sessionTables *session.TableCache
+
+	// sessionRelease decrements this Client's reference in the
+	// process-wide shared-session cache. Non-nil iff sessionImpl was
+	// obtained via acquireSharedSession (which is the case for every
+	// non-preDialed, non-DisableSession Client built through
+	// NewClientWithConfig). Close invokes it in place of
+	// sessionImpl.Close so the underlying session.Client only tears
+	// down when the LAST bigtable.Client holding it releases. See
+	// shared_session.go for the intern cache.
+	sessionRelease func() error
+	// sessionListenerUnregister detaches this Client's Diverter from
+	// the shared session's SessionLoad listener list. Non-nil iff we
+	// registered one at construction (i.e. iff sessionImpl is
+	// non-nil). Close invokes it BEFORE sessionRelease so a late
+	// config-poll firing during teardown cannot deliver a
+	// SessionLoad update to a Diverter whose owning Client is on the
+	// way out.
+	sessionListenerUnregister func()
 }
 
 // ClientConfig has configurations for the client.
@@ -300,22 +318,54 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 	// resolver target (fails with "passthrough: received empty target
 	// in Build()"), breaking every emulator-based test.
 	preDialed := false
+	var resolvedEndpoint string
 	if uResolver, resErr := internaloption.NewUnsafeResolver(o...); resErr == nil {
 		preDialed = uResolver.ResolvedGRPCConnIsCustom()
+		// Endpoint captures option.WithEndpoint and (indirectly)
+		// option.WithUniverseDomain via the resolver's endpoint
+		// computation. Feeds into the shared-session cache key so two
+		// Clients targeting different endpoints — even with the same
+		// (project, instance, appProfile) — get distinct sessions.
+		// A resolve error just leaves the field empty; the key still
+		// dedups on the other axes and any two calls with unresolved
+		// endpoints treat each other as endpoint-equivalent.
+		resolvedEndpoint, _ = uResolver.ResolvedGRPCEndpoint()
 	}
 	// Skip session-client construction when either (a) caller pre-dialed
 	// a custom conn (session.NewClient can't dial through it) or (b)
 	// caller opted out via ClientConfig.DisableSession. In both cases
 	// sessionImpl + sessionTables stay nil; every downstream caller
 	// (open.go's getOrCreateSession*, Client.Close) already nil-guards
-	// on that state.
+	// on that state. Neither path touches the shared-session cache so
+	// callers who opt out pay no cache-lookup cost and cannot conflict
+	// with a shared session another Client is holding.
 	if !preDialed && !config.DisableSession {
-		// Pass the fully-merged option list (o), not the raw caller
-		// opts. gtransport.Dial needs the DefaultClientOptions merged
-		// in (endpoint, scopes, user-agent, interceptors) — passing
-		// bare opts leaves the resolver target empty and the dial
-		// aborts with "passthrough: received empty target in Build()".
-		sc, sessionErr := session.NewClient(ctx, project, instance, config.AppProfile, metricsProvider, featureFlagsProto, o...)
+		// Two NewClient callers with matching (project, instance,
+		// appProfile, endpoint) share ONE underlying session.Client —
+		// one channel pool, one ConfigurationManager poll goroutine,
+		// one per-resource session-pool set. See shared_session.go for
+		// the intern cache and the incompatible-options guardrail.
+		key := sharedKey{
+			project:    project,
+			instance:   instance,
+			appProfile: config.AppProfile,
+			endpoint:   resolvedEndpoint,
+		}
+		fp := sessionFingerprint{
+			metricsProviderKind:      metricsProviderKind(metricsProvider),
+			clientSideMetricsEnabled: metricsTracerFactory.Enabled,
+			enableDirectAccess:       isDirectAccessEnabled(config),
+		}
+		build := func() (session.Client, error) {
+			// Pass the fully-merged option list (o), not the raw
+			// caller opts. gtransport.Dial needs the
+			// DefaultClientOptions merged in (endpoint, scopes,
+			// user-agent, interceptors) — passing bare opts leaves
+			// the resolver target empty and the dial aborts with
+			// "passthrough: received empty target in Build()".
+			return session.NewClient(ctx, project, instance, config.AppProfile, metricsProvider, featureFlagsProto, o...)
+		}
+		sc, release, sessionErr := acquireSharedSession(key, fp, build)
 		if sessionErr != nil {
 			// Best-effort cleanup of the classic pool since we won't
 			// return c to the caller. Go through the ManagedChannelPool
@@ -325,8 +375,15 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 			_ = mPool.Close()
 			return nil, fmt.Errorf("bigtable: session.NewClient: %w", sessionErr)
 		}
-		sc.AddSessionLoadListener(c.diverter.SetSessionLoad)
+		// Register THIS Client's Diverter with the shared session's
+		// config manager. Multiple bigtable.Clients sharing one
+		// session each fan out their own listener so a server-driven
+		// SessionLoad update propagates to every Client's Diverter
+		// independently. The unregister thunk is stored so Close can
+		// detach the listener before we release our refcount.
+		c.sessionListenerUnregister = sc.AddSessionLoadListener(c.diverter.SetSessionLoad)
 		c.sessionImpl = sc
+		c.sessionRelease = release
 
 		// Per-resource TableAPI cache with TTL-on-idle eviction. The
 		// cache is opener-agnostic — each getOrCreateSession* helper
@@ -334,6 +391,9 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 		// qualified resource name as the cache key. Only constructed
 		// when the session backend is actually wired — a sweeper
 		// goroutine over an always-empty map would be dead weight.
+		// This cache stays per-Client even under session sharing —
+		// each bigtable.Client vends its own TableAPI handles that
+		// route through the shared session's pools underneath.
 		c.sessionTables = session.NewTableCache(session.DefaultTableCacheTTL, session.DefaultTableCacheSweepInterval, nil /* time.Now */)
 	}
 
@@ -351,13 +411,29 @@ func (c *Client) Close() error {
 	// on hand-built Clients that skipped session-backend wiring; the
 	// cache's own Close() nil-checks for that.
 	c.sessionTables.Close()
-	// Then the session backend — its bookkeeping (session pools,
-	// ConfigurationManager poller) winds down before we drop the
-	// shared gRPC channels. Any error is aggregated with the classic
+	// Then the session backend. Under process-wide session sharing
+	// (see shared_session.go) sessionRelease decrements THIS Client's
+	// refcount on the shared entry; the underlying session.Client is
+	// only torn down when the LAST Client using it releases. Detach
+	// this Client's Diverter listener BEFORE releasing so a late
+	// config-poll firing between unregister and release cannot
+	// deliver a SessionLoad update to a Diverter whose owning Client
+	// is on the way out. Any error is aggregated with the classic
 	// pool's Close error.
 	var sessionErr error
 	if c.sessionImpl != nil {
-		sessionErr = c.sessionImpl.Close()
+		if c.sessionListenerUnregister != nil {
+			c.sessionListenerUnregister()
+		}
+		if c.sessionRelease != nil {
+			sessionErr = c.sessionRelease()
+		} else {
+			// Defensive: no shared-cache path wired the release
+			// closure. Fall back to closing the session directly so
+			// hand-built Clients that stashed a sessionImpl outside
+			// NewClientWithConfig still tear it down.
+			sessionErr = c.sessionImpl.Close()
+		}
 	}
 	if err := c.mPool.Close(); err != nil {
 		if sessionErr != nil {

--- a/bigtable/shared_session.go
+++ b/bigtable/shared_session.go
@@ -1,0 +1,279 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigtable
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"cloud.google.com/go/bigtable/internal/session"
+)
+
+// This file implements process-wide implicit sharing of the underlying
+// session.Client across NewClient calls that target the same tuple.
+// Two bigtable.NewClient calls with matching (project, instance,
+// appProfile, endpoint) end up backed by ONE session.Client — one gRPC
+// channel pool, one ClientConfigurationManager poll goroutine, one
+// per-resource session-pool set.
+//
+// Java-parity note: matches the intent of google-cloud-java PR #13829
+// (BigtableDataClientFactory session support). The Go side does it
+// implicitly via an intern cache rather than introducing a new public
+// factory type — callers keep using NewClient / NewClientWithConfig and
+// automatically get sharing when their identity tuples line up.
+//
+// What is shared: the session.Client (channel pool, config manager,
+// per-resource session pools + streams).
+//
+// What stays per-Client: the classic gRPC ConnPool + client stub, the
+// metrics tracer factory, the Diverter, and the session.TableCache
+// wrapping per-Client TableAPI handles. The per-Client Diverter is
+// wired into the shared session via its own AddSessionLoadListener
+// entry so each Client's Diverter still receives server-driven session
+// load updates.
+
+// sharedKey identifies one shared session.Client entry. Callers with
+// matching sharedKey values share one underlying session.Client. Fields
+// are chosen so equality corresponds to "these callers can safely share
+// one on-wire connection to Bigtable":
+//
+//   - project / instance / appProfile: the resource-identity triple the
+//     session client bakes into every request.
+//   - endpoint: the resolved gRPC endpoint (via
+//     internaloption.UnsafeResolver.ResolvedGRPCEndpoint). Captures both
+//     option.WithEndpoint and option.WithUniverseDomain, since the
+//     latter feeds into endpoint resolution.
+//
+// Credentials, custom dialers, gRPC dial options, and callers that
+// pre-dial via option.WithGRPCConn are NOT keyed. Pre-dialed callers
+// skip the shared cache entirely (see NewClientWithConfig's preDialed
+// gate). For non-pre-dialed callers with a custom dialer, sharing is
+// still applied — the assumption is that the shared session's dial
+// path is legitimate for any caller with the same identity tuple. This
+// matters mostly in tests that dial different fake servers through
+// bufconn using the same "test-project"/"test-instance" pair; those
+// tests run sequentially, close their Client at teardown (which
+// releases the shared session's refcount), so the next test cleanly
+// re-builds its own session.
+type sharedKey struct {
+	project    string
+	instance   string
+	appProfile string
+	endpoint   string
+}
+
+func (k sharedKey) String() string {
+	return fmt.Sprintf("project=%q instance=%q appProfile=%q endpoint=%q",
+		k.project, k.instance, k.appProfile, k.endpoint)
+}
+
+// sessionFingerprint captures the option-derived properties of a
+// session.Client that must AGREE across all callers sharing one
+// underlying instance. The fingerprint is compared via == on cache
+// hit; any mismatch is a hard error at NewClient time so a caller
+// cannot silently attach to a session that was constructed with
+// different metrics / feature-flag settings than it asked for.
+//
+// Fields are chosen so equality implies "the session-side wire
+// behavior would be identical if we built a fresh one":
+//
+//   - metricsProviderKind is the normalized MetricsProvider type
+//     (nil and DefaultMetricsProvider{} both map to "default", since
+//     metrics.NewFactory treats them the same).
+//   - clientSideMetricsEnabled + enableDirectAccess drive the
+//     FeatureFlags proto stamped onto every OpenSessionRequest.Flags
+//     and mirrored in the bigtable-features header. Server rejects
+//     OpenSession with INVALID_ARGUMENT when these disagree, so
+//     two callers with different values genuinely cannot share.
+type sessionFingerprint struct {
+	metricsProviderKind      string
+	clientSideMetricsEnabled bool
+	enableDirectAccess       bool
+}
+
+// diff returns a comma-separated description of every field that
+// differs between want and got. Used to render the incompatible-options
+// error message in a form that tells the caller which knob they need
+// to normalize.
+func (want sessionFingerprint) diff(got sessionFingerprint) string {
+	var diffs []string
+	if want.metricsProviderKind != got.metricsProviderKind {
+		diffs = append(diffs, fmt.Sprintf("MetricsProvider=%s existing=%s", got.metricsProviderKind, want.metricsProviderKind))
+	}
+	if want.clientSideMetricsEnabled != got.clientSideMetricsEnabled {
+		diffs = append(diffs, fmt.Sprintf("clientSideMetricsEnabled=%t existing=%t", got.clientSideMetricsEnabled, want.clientSideMetricsEnabled))
+	}
+	if want.enableDirectAccess != got.enableDirectAccess {
+		diffs = append(diffs, fmt.Sprintf("enableDirectAccess=%t existing=%t", got.enableDirectAccess, want.enableDirectAccess))
+	}
+	sort.Strings(diffs)
+	return strings.Join(diffs, ", ")
+}
+
+// metricsProviderKind normalizes a MetricsProvider value into the
+// discriminator used by the fingerprint. Nil and DefaultMetricsProvider{}
+// collapse to the same "default" bucket because metrics.NewFactory
+// treats them identically (see internal/metrics/factory.go). Unknown
+// user-supplied implementations fall through to their Go type name so
+// two different custom providers never share a session by accident.
+func metricsProviderKind(mp MetricsProvider) string {
+	switch mp.(type) {
+	case nil, DefaultMetricsProvider:
+		return "default"
+	case NoopMetricsProvider:
+		return "noop"
+	default:
+		return fmt.Sprintf("%T", mp)
+	}
+}
+
+// refcountedSession is one intern-cache entry. sc is the shared
+// session.Client; refs counts live NewClient acquisitions that have
+// not yet released via their Close(). The entry is removed from
+// sharedSessions and sc.Close is invoked when refs drops to zero.
+type refcountedSession struct {
+	sc          session.Client
+	fingerprint sessionFingerprint
+	refs        int
+}
+
+var (
+	// sharedSessionsMu serializes the entire acquire/release/close
+	// dance. Also held across the build closure on cache miss so
+	// concurrent NewClient calls with the same sharedKey dedup to a
+	// single session build — the second caller blocks on the mutex,
+	// finds the entry populated on wake, and takes a reference.
+	//
+	// Holding the lock across a real gRPC dial is a startup-only cost
+	// (the dial only runs once per (key) per process lifetime) and
+	// keeps the state machine trivially correct. Concurrent NewClient
+	// calls with DIFFERENT keys briefly queue behind each other; this
+	// is acceptable given how rarely NewClient is called in practice.
+	sharedSessionsMu sync.Mutex
+	sharedSessions   = map[sharedKey]*refcountedSession{}
+)
+
+// acquireSharedSession returns the session.Client for key, either by
+// incrementing the refcount on an existing cached entry or by calling
+// build to construct a fresh one on cache miss.
+//
+// On success it returns a release closure the caller MUST invoke
+// exactly once when it is done with the returned session.Client. The
+// closure decrements the refcount and, when it reaches zero, deletes
+// the cache entry and calls sc.Close. Multiple invocations of the
+// same release closure past the first are no-ops (idempotent).
+//
+// On cache hit, the caller's fp is compared against the cached
+// entry's fingerprint. A mismatch returns an error without
+// incrementing any refcount so the caller cannot silently attach to a
+// session that would behave differently from what it configured. The
+// build closure is NOT invoked in that case.
+func acquireSharedSession(key sharedKey, fp sessionFingerprint, build func() (session.Client, error)) (session.Client, func() error, error) {
+	sharedSessionsMu.Lock()
+	defer sharedSessionsMu.Unlock()
+	if entry, ok := sharedSessions[key]; ok {
+		if entry.fingerprint != fp {
+			return nil, nil, fmt.Errorf(
+				"bigtable: NewClient called with same (%s) but incompatible options (%s); "+
+					"to use different options, use different resource identifiers",
+				key, entry.fingerprint.diff(fp))
+		}
+		entry.refs++
+		return entry.sc, releaseFor(key), nil
+	}
+	sc, err := build()
+	if err != nil {
+		return nil, nil, err
+	}
+	sharedSessions[key] = &refcountedSession{sc: sc, fingerprint: fp, refs: 1}
+	return sc, releaseFor(key), nil
+}
+
+// releaseFor returns a release closure bound to key. The closure is
+// idempotent — repeat invocations after the first return nil without
+// touching the cache. On the invocation that drops the refcount to
+// zero, the entry is deleted and sc.Close is called; that Close's
+// error is returned to the caller.
+//
+// Idempotence comes from the "not found" branch below: once the entry
+// has been removed (either by our own last-close or by
+// ForceCloseSharedSessions), subsequent calls find nothing and no-op.
+func releaseFor(key sharedKey) func() error {
+	var once sync.Once
+	var closeErr error
+	return func() error {
+		once.Do(func() {
+			sharedSessionsMu.Lock()
+			entry, ok := sharedSessions[key]
+			if !ok {
+				sharedSessionsMu.Unlock()
+				return
+			}
+			entry.refs--
+			if entry.refs > 0 {
+				sharedSessionsMu.Unlock()
+				return
+			}
+			delete(sharedSessions, key)
+			sc := entry.sc
+			sharedSessionsMu.Unlock()
+			closeErr = sc.Close()
+		})
+		return closeErr
+	}
+}
+
+// ForceCloseSharedSessions closes every cached session.Client and
+// empties the shared-session cache. Intended for test teardown between
+// suites and for drastic process-wide session shutdown; production
+// code should rely on Client.Close to reference-count entries down to
+// zero naturally.
+//
+// Callers that still hold a *Client after ForceCloseSharedSessions
+// runs will see subsequent RPCs on that Client fail — the session
+// backing it has been torn down out from under it. This is the
+// intended tradeoff for a "burn it all down" teardown hook; wire it
+// only from tests or from a shutdown path where you know no Client is
+// still expected to serve traffic.
+func ForceCloseSharedSessions() {
+	sharedSessionsMu.Lock()
+	old := sharedSessions
+	sharedSessions = map[sharedKey]*refcountedSession{}
+	sharedSessionsMu.Unlock()
+	for _, entry := range old {
+		_ = entry.sc.Close()
+	}
+}
+
+// sharedSessionCount returns the number of live cache entries.
+// Exposed for tests only.
+func sharedSessionCount() int {
+	sharedSessionsMu.Lock()
+	defer sharedSessionsMu.Unlock()
+	return len(sharedSessions)
+}
+
+// sharedSessionRefs returns the refcount for key, or 0 if absent.
+// Exposed for tests only.
+func sharedSessionRefs(key sharedKey) int {
+	sharedSessionsMu.Lock()
+	defer sharedSessionsMu.Unlock()
+	if e, ok := sharedSessions[key]; ok {
+		return e.refs
+	}
+	return 0
+}

--- a/bigtable/shared_session_test.go
+++ b/bigtable/shared_session_test.go
@@ -1,0 +1,481 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigtable
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"cloud.google.com/go/bigtable/internal/session"
+)
+
+// resetSharedSessionCache is the standard per-test cleanup for tests
+// that touch acquireSharedSession. Every test in this file registers
+// it via t.Cleanup so a failure in one test cannot leak entries into
+// the next test's cache view.
+func resetSharedSessionCache(t *testing.T) {
+	t.Helper()
+	t.Cleanup(ForceCloseSharedSessions)
+	// Also snapshot at start so a previous test's leak doesn't taint us.
+	ForceCloseSharedSessions()
+}
+
+// buildFake returns a build closure that always constructs a fresh
+// fakeSessionClient and counts how many times it was invoked. Tests
+// use the count to assert cache-hit vs. cache-miss.
+func buildFake() (build func() (session.Client, error), calls *atomic.Int32, lastBuilt func() *fakeSessionClient) {
+	var count atomic.Int32
+	var mu sync.Mutex
+	var last *fakeSessionClient
+	build = func() (session.Client, error) {
+		count.Add(1)
+		fsc := newFakeSessionClient()
+		mu.Lock()
+		last = fsc
+		mu.Unlock()
+		return fsc, nil
+	}
+	return build, &count, func() *fakeSessionClient {
+		mu.Lock()
+		defer mu.Unlock()
+		return last
+	}
+}
+
+func fpBase() sessionFingerprint {
+	return sessionFingerprint{
+		metricsProviderKind:      "noop",
+		clientSideMetricsEnabled: false,
+		enableDirectAccess:       true,
+	}
+}
+
+// TestSharedSession_SameKeyReturnsSameInstance pins the primary
+// contract: two acquireSharedSession calls with the same key return
+// the same underlying session.Client and the build closure is invoked
+// exactly once.
+func TestSharedSession_SameKeyReturnsSameInstance(t *testing.T) {
+	resetSharedSessionCache(t)
+	key := sharedKey{project: "p", instance: "i", appProfile: "ap", endpoint: "e"}
+	build, calls, _ := buildFake()
+
+	sc1, rel1, err := acquireSharedSession(key, fpBase(), build)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	t.Cleanup(func() { _ = rel1() })
+
+	sc2, rel2, err := acquireSharedSession(key, fpBase(), build)
+	if err != nil {
+		t.Fatalf("second acquire: %v", err)
+	}
+	t.Cleanup(func() { _ = rel2() })
+
+	if sc1 != sc2 {
+		t.Errorf("second acquire returned distinct session.Client: sc1=%p sc2=%p", sc1, sc2)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("build calls = %d, want 1", got)
+	}
+	if got := sharedSessionRefs(key); got != 2 {
+		t.Errorf("refcount = %d, want 2", got)
+	}
+}
+
+// TestSharedSession_DifferentKeysReturnDistinct pins that varying any
+// axis of sharedKey (project, instance, appProfile, endpoint)
+// produces a distinct entry and a distinct session.Client.
+func TestSharedSession_DifferentKeysReturnDistinct(t *testing.T) {
+	resetSharedSessionCache(t)
+
+	base := sharedKey{project: "p", instance: "i", appProfile: "ap", endpoint: "e"}
+	variants := []struct {
+		name string
+		mut  func(sharedKey) sharedKey
+	}{
+		{"project", func(k sharedKey) sharedKey { k.project = "p2"; return k }},
+		{"instance", func(k sharedKey) sharedKey { k.instance = "i2"; return k }},
+		{"appProfile", func(k sharedKey) sharedKey { k.appProfile = "ap2"; return k }},
+		{"endpoint", func(k sharedKey) sharedKey { k.endpoint = "e2"; return k }},
+	}
+	build, calls, _ := buildFake()
+	sc0, rel0, err := acquireSharedSession(base, fpBase(), build)
+	if err != nil {
+		t.Fatalf("acquire base: %v", err)
+	}
+	// Hold every release until after the whole-suite assertions so
+	// sub-test cleanups don't drop the refcount to 0 mid-test.
+	rels := []func() error{rel0}
+	t.Cleanup(func() {
+		for _, r := range rels {
+			_ = r()
+		}
+	})
+
+	for _, v := range variants {
+		v := v
+		t.Run(v.name, func(t *testing.T) {
+			k := v.mut(base)
+			sc, rel, err := acquireSharedSession(k, fpBase(), build)
+			if err != nil {
+				t.Fatalf("acquire %s-variant: %v", v.name, err)
+			}
+			rels = append(rels, rel)
+			if sc == sc0 {
+				t.Errorf("variant %s returned same session.Client as base (want distinct)", v.name)
+			}
+		})
+	}
+	// 5 total: 1 base + 4 variants.
+	if got := calls.Load(); got != 5 {
+		t.Errorf("build calls = %d, want 5", got)
+	}
+	if got := sharedSessionCount(); got != 5 {
+		t.Errorf("cache size = %d, want 5", got)
+	}
+}
+
+// TestSharedSession_RefcountReleaseOnLastClose pins the reference-
+// counting: two acquires + one release leaves the session live; the
+// second release tears it down (session.Client.Close called exactly
+// once). Subsequent release invocations on either closure are no-ops
+// so double-Close from a bigtable.Client can't turn into a double-
+// Close on the underlying session.
+func TestSharedSession_RefcountReleaseOnLastClose(t *testing.T) {
+	resetSharedSessionCache(t)
+	key := sharedKey{project: "p", instance: "i", appProfile: "ap", endpoint: "e"}
+	build, _, lastBuilt := buildFake()
+
+	_, rel1, err := acquireSharedSession(key, fpBase(), build)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	_, rel2, err := acquireSharedSession(key, fpBase(), build)
+	if err != nil {
+		t.Fatalf("second acquire: %v", err)
+	}
+	fsc := lastBuilt()
+	if fsc == nil {
+		t.Fatal("no fake session built")
+	}
+
+	if err := rel1(); err != nil {
+		t.Errorf("first release: %v", err)
+	}
+	if got := fsc.closeCalls; got != 0 {
+		t.Errorf("after first release, Close calls = %d, want 0", got)
+	}
+	if got := sharedSessionRefs(key); got != 1 {
+		t.Errorf("after first release, refcount = %d, want 1", got)
+	}
+
+	if err := rel2(); err != nil {
+		t.Errorf("second release: %v", err)
+	}
+	if got := fsc.closeCalls; got != 1 {
+		t.Errorf("after second release, Close calls = %d, want 1", got)
+	}
+	if got := sharedSessionCount(); got != 0 {
+		t.Errorf("cache size after last release = %d, want 0", got)
+	}
+
+	// Idempotence: calling either release again is a no-op.
+	if err := rel1(); err != nil {
+		t.Errorf("repeat rel1 after teardown: %v", err)
+	}
+	if err := rel2(); err != nil {
+		t.Errorf("repeat rel2 after teardown: %v", err)
+	}
+	if got := fsc.closeCalls; got != 1 {
+		t.Errorf("after repeat releases, Close calls = %d, want 1 (idempotent)", got)
+	}
+}
+
+// TestSharedSession_ForceClose_TearsDownAll pins ForceCloseSharedSessions
+// as an all-at-once teardown that closes every cached session.Client
+// and empties the map. Refcount-tracking release closures on the
+// still-live handles become no-ops.
+func TestSharedSession_ForceClose_TearsDownAll(t *testing.T) {
+	resetSharedSessionCache(t)
+	build, _, _ := buildFake()
+
+	// Track every fake we build so we can assert Close was called on
+	// each after ForceClose (the buildFake helper only remembers the
+	// last one).
+	var built []*fakeSessionClient
+	var builtMu sync.Mutex
+	trackedBuild := func() (session.Client, error) {
+		sc, err := build()
+		if err != nil {
+			return nil, err
+		}
+		builtMu.Lock()
+		built = append(built, sc.(*fakeSessionClient))
+		builtMu.Unlock()
+		return sc, nil
+	}
+
+	const N = 5
+	releases := make([]func() error, 0, N)
+	for i := 0; i < N; i++ {
+		key := sharedKey{project: fmt.Sprintf("p%d", i), instance: "i", appProfile: "ap", endpoint: "e"}
+		_, rel, err := acquireSharedSession(key, fpBase(), trackedBuild)
+		if err != nil {
+			t.Fatalf("acquire %d: %v", i, err)
+		}
+		releases = append(releases, rel)
+	}
+	if got := sharedSessionCount(); got != N {
+		t.Errorf("cache size before ForceClose = %d, want %d", got, N)
+	}
+
+	ForceCloseSharedSessions()
+
+	if got := sharedSessionCount(); got != 0 {
+		t.Errorf("cache size after ForceClose = %d, want 0", got)
+	}
+	builtMu.Lock()
+	defer builtMu.Unlock()
+	for i, fsc := range built {
+		if fsc.closeCalls != 1 {
+			t.Errorf("built[%d].closeCalls = %d, want 1", i, fsc.closeCalls)
+		}
+	}
+	// Now-stale release closures must be no-ops (the entry is gone).
+	for i, rel := range releases {
+		if err := rel(); err != nil {
+			t.Errorf("release[%d] after ForceClose: %v", i, err)
+		}
+	}
+	for i, fsc := range built {
+		if fsc.closeCalls != 1 {
+			t.Errorf("built[%d].closeCalls after post-ForceClose releases = %d, want 1", i, fsc.closeCalls)
+		}
+	}
+}
+
+// TestSharedSession_IncompatibleOptions_Error pins the safety
+// guardrail: a second acquire with the same key but a different
+// fingerprint returns an error, does NOT increment the refcount, and
+// does NOT invoke the build closure.
+func TestSharedSession_IncompatibleOptions_Error(t *testing.T) {
+	resetSharedSessionCache(t)
+	key := sharedKey{project: "p", instance: "i", appProfile: "ap", endpoint: "e"}
+	build, calls, _ := buildFake()
+
+	_, rel1, err := acquireSharedSession(key, fpBase(), build)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	t.Cleanup(func() { _ = rel1() })
+
+	incompat := fpBase()
+	incompat.enableDirectAccess = !incompat.enableDirectAccess
+	sc2, rel2, err := acquireSharedSession(key, incompat, build)
+	if err == nil {
+		t.Fatalf("incompatible acquire succeeded (sc=%v), want error", sc2)
+	}
+	if rel2 != nil {
+		t.Errorf("incompatible acquire returned non-nil release closure")
+	}
+	if sc2 != nil {
+		t.Errorf("incompatible acquire returned non-nil session.Client %v", sc2)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("build calls after incompatible acquire = %d, want 1 (must not re-build)", got)
+	}
+	if got := sharedSessionRefs(key); got != 1 {
+		t.Errorf("refcount after incompatible acquire = %d, want 1 (must not increment)", got)
+	}
+	// Error message must name the diverging field so callers can act on it.
+	if !strings.Contains(err.Error(), "enableDirectAccess") {
+		t.Errorf("error %q does not mention the diverging field", err.Error())
+	}
+	if !strings.Contains(err.Error(), "incompatible options") {
+		t.Errorf("error %q missing 'incompatible options' phrase", err.Error())
+	}
+}
+
+// TestSharedSession_CloseAndReopen_FreshInstance pins that once the
+// refcount drops to zero and the cache entry is evicted, a subsequent
+// acquire builds a NEW session.Client rather than resurrecting the
+// closed one.
+func TestSharedSession_CloseAndReopen_FreshInstance(t *testing.T) {
+	resetSharedSessionCache(t)
+	key := sharedKey{project: "p", instance: "i", appProfile: "ap", endpoint: "e"}
+	build, calls, _ := buildFake()
+
+	sc1, rel1, err := acquireSharedSession(key, fpBase(), build)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	if err := rel1(); err != nil {
+		t.Fatalf("release to zero: %v", err)
+	}
+	if got := sharedSessionCount(); got != 0 {
+		t.Fatalf("cache size after full release = %d, want 0", got)
+	}
+
+	sc2, rel2, err := acquireSharedSession(key, fpBase(), build)
+	if err != nil {
+		t.Fatalf("second acquire after teardown: %v", err)
+	}
+	t.Cleanup(func() { _ = rel2() })
+	if sc1 == sc2 {
+		t.Errorf("second acquire returned resurrected session (%p); want distinct fresh instance", sc1)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("build calls after reopen = %d, want 2", got)
+	}
+}
+
+// TestSharedSession_ConcurrentAcquire_Deduped pins that a burst of
+// concurrent acquire calls on the same key dedups to a single build
+// invocation, each caller gets the same session.Client, and each
+// release closure decrements the refcount independently — releasing
+// all N drops the count to zero and closes the underlying session
+// exactly once.
+func TestSharedSession_ConcurrentAcquire_Deduped(t *testing.T) {
+	resetSharedSessionCache(t)
+	key := sharedKey{project: "p", instance: "i", appProfile: "ap", endpoint: "e"}
+	build, calls, lastBuilt := buildFake()
+
+	const N = 10
+	var wg sync.WaitGroup
+	results := make([]session.Client, N)
+	releases := make([]func() error, N)
+	errs := make([]error, N)
+	start := make(chan struct{})
+	for i := 0; i < N; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			sc, rel, err := acquireSharedSession(key, fpBase(), build)
+			results[i] = sc
+			releases[i] = rel
+			errs[i] = err
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("goroutine %d acquire: %v", i, err)
+		}
+	}
+	// Exactly one build under the global mutex.
+	if got := calls.Load(); got != 1 {
+		t.Errorf("build calls = %d, want 1", got)
+	}
+	fsc := lastBuilt()
+	if fsc == nil {
+		t.Fatal("no fake built")
+	}
+	// Every returned session.Client is the same instance.
+	for i := 1; i < N; i++ {
+		if results[i] != results[0] {
+			t.Errorf("results[%d] != results[0] (%p vs %p)", i, results[i], results[0])
+		}
+	}
+	if got := sharedSessionRefs(key); got != N {
+		t.Errorf("refcount = %d, want %d", got, N)
+	}
+
+	// Release from N goroutines concurrently — must decrement to
+	// zero and Close exactly once.
+	var wg2 sync.WaitGroup
+	relStart := make(chan struct{})
+	for i := 0; i < N; i++ {
+		i := i
+		wg2.Add(1)
+		go func() {
+			defer wg2.Done()
+			<-relStart
+			_ = releases[i]()
+		}()
+	}
+	close(relStart)
+	wg2.Wait()
+
+	if got := fsc.closeCalls; got != 1 {
+		t.Errorf("closeCalls = %d, want 1 (exactly one Close on refcount→0)", got)
+	}
+	if got := sharedSessionCount(); got != 0 {
+		t.Errorf("cache size after all releases = %d, want 0", got)
+	}
+}
+
+// TestSharedSession_BuildErrorNotCached pins that a build failure
+// returns the error to the caller AND does NOT populate the cache —
+// a subsequent acquire retries build. Otherwise a transient dial
+// failure would strand the key permanently.
+func TestSharedSession_BuildErrorNotCached(t *testing.T) {
+	resetSharedSessionCache(t)
+	key := sharedKey{project: "p", instance: "i", appProfile: "ap", endpoint: "e"}
+
+	wantErr := errors.New("dial failed")
+	var calls atomic.Int32
+	buildOnceThenSucceed := func() (session.Client, error) {
+		n := calls.Add(1)
+		if n == 1 {
+			return nil, wantErr
+		}
+		return newFakeSessionClient(), nil
+	}
+
+	_, _, err := acquireSharedSession(key, fpBase(), buildOnceThenSucceed)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("first acquire err = %v, want %v", err, wantErr)
+	}
+	if got := sharedSessionCount(); got != 0 {
+		t.Errorf("cache size after failed build = %d, want 0", got)
+	}
+
+	sc, rel, err := acquireSharedSession(key, fpBase(), buildOnceThenSucceed)
+	if err != nil {
+		t.Fatalf("retry acquire: %v", err)
+	}
+	t.Cleanup(func() { _ = rel() })
+	if sc == nil {
+		t.Error("retry acquire returned nil session.Client")
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("build calls after retry = %d, want 2", got)
+	}
+}
+
+// TestMetricsProviderKind pins the normalization that nil and
+// DefaultMetricsProvider{} collapse into the same fingerprint bucket
+// (matching metrics.NewFactory behavior — both trigger the built-in
+// exporter path), NoopMetricsProvider{} takes its own bucket, and
+// unknown user types fall back to their Go type name.
+func TestMetricsProviderKind(t *testing.T) {
+	if got := metricsProviderKind(nil); got != "default" {
+		t.Errorf("nil → %q, want %q", got, "default")
+	}
+	if got := metricsProviderKind(DefaultMetricsProvider{}); got != "default" {
+		t.Errorf("DefaultMetricsProvider → %q, want %q", got, "default")
+	}
+	if got := metricsProviderKind(NoopMetricsProvider{}); got != "noop" {
+		t.Errorf("NoopMetricsProvider → %q, want %q", got, "noop")
+	}
+}


### PR DESCRIPTION
## Summary

Two `bigtable.NewClient` calls with the same `(project, instance, appProfile, endpoint)` tuple now automatically share ONE underlying `session.Client`, one gRPC channel pool, and one `ClientConfigurationManager` poll goroutine. Sharing is implicit and scoped to the session data plane only; the classic gRPC ConnPool, metrics tracer factory, `Diverter`, and per-Client `session.TableCache` stay per-Client.

Java-parity: matches the intent of googleapis/google-cloud-java PR #13829 (BigtableDataClientFactory session support). Go does it implicitly via a package-level intern cache rather than introducing a new public factory type — callers get sharing for free without any API change.

## How it works

**Cache key** (`sharedKey` in `bigtable/shared_session.go`): `project`, `instance`, `appProfile`, `endpoint`. Endpoint is resolved via `internaloption.UnsafeResolver.ResolvedGRPCEndpoint`, so `option.WithEndpoint` and (indirectly) `option.WithUniverseDomain` both feed into the identity.

**Refcount** (`refcountedSession`): entry lives as long as at least one `bigtable.Client` holds a reference. Client `Close` releases its reference; when the count hits zero the underlying `session.Client.Close` runs.

**Diverter fan-out**: each Client registers its own `SessionLoad` listener on the shared session's config manager (multiple listeners already supported). The unregister thunk is stored on the Client; `Close` detaches BEFORE releasing so a late config-poll during teardown cannot fire against a Diverter whose owning Client is on the way out.

**Incompatible-options guardrail**: two `NewClient` calls with matching `sharedKey` but different `MetricsProvider` / `FeatureFlags`-driving settings return an error at `NewClient` time. `sessionFingerprint` is compared on cache hit; a mismatch is a hard error with a diff-style message naming the diverging fields so callers can normalize.

**Opt-outs**: `DisableSession=true` and pre-dialed callers (`option.WithGRPCConn`) skip the shared cache entirely. Unchanged behavior.

**Accelerator package untouched**: `internal/accelerator` continues to dial `session.NewClient` directly with its own lifecycle. Sharing is only at the `bigtable.NewClient` layer.

**Public API**: `ForceCloseSharedSessions()` is exported for test teardown and drastic process-wide session shutdown; production code should let refcounts drop naturally via `Client.Close`.

## What is shared vs. per-Client

| Component | Shared | Per-Client |
|-----------|--------|------------|
| `session.Client` (channel pool, config manager, session pools) | yes | — |
| `SessionLoad` listener list entry | — | yes (one per Client) |
| Classic gRPC `ConnPool` | — | yes |
| Classic Bigtable stub | — | yes |
| `metrics.Factory` | — | yes |
| `Diverter` | — | yes |
| `session.TableCache` (per-resource `TableAPI` handles) | — | yes |

## Trade-off

Two `bigtable.Client`s sharing one `session.Client` merge their session-level dispatch metrics into a single per-session histogram (the dispatch-metrics counters live on the shared `*sessionClient`). This matches Java parity and is accepted as an implicit-sharing consequence — worth noting in release notes when the sharing lands.

## Test plan

- [x] `bigtable/shared_session_test.go`: cache basics (same key → same instance; different keys → distinct); refcount release semantics; `ForceCloseSharedSessions` all-at-once teardown; incompatible-options error path; close-and-reopen freshness; 10-way concurrent acquire dedups to a single build and single Close; build error not cached (retry works); `metricsProviderKind` normalization.
- [x] Full `bigtable/`, `bigtable/internal/session/`, `bigtable/internal/transport/` short test suites pass under `-race`.
- [x] Session vRPC integration harness tests (15 tests, each spinning up a fresh bufconn fake) pass under `-race -count=5`.
- [x] `TestSharedSession_ConcurrentAcquire_Deduped` passes under `-race -count=100`.