### PR TITLE
feat(bigtable/accelerator): add --user-agent flag to daemon

### DIFF
--- a/bigtable/internal/accelerator/accelerator_core.go
+++ b/bigtable/internal/accelerator/accelerator_core.go
@@ -29,6 +29,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"strings"
 
 	v2pb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
 	"cloud.google.com/go/bigtable/internal"
@@ -61,7 +62,20 @@ const (
 // credentials back via option.WithCredentials (avoiding a second ADC lookup).
 const DataScope = "https://www.googleapis.com/auth/bigtable.data"
 
-var userAgent = "cbt-go-accelerator/v" + internal.Version
+var userAgent = "go-acc/v" + internal.Version
+
+// ComposeUserAgent joins a caller-supplied user-agent prefix with the daemon's
+// own token. Cross-language clients (e.g. the Python SDK) pass their own client
+// user agent so the service sees both the caller and the accelerator build, e.g.
+// "python-bigtable/2.1.0 go-acc/v1.38.0". Tokens are space-separated
+// per the HTTP/gRPC user-agent product-token convention. An empty or blank
+// prefix yields the daemon token alone.
+func ComposeUserAgent(prefix string) string {
+	if prefix = strings.TrimSpace(prefix); prefix == "" {
+		return userAgent
+	}
+	return prefix + " " + userAgent
+}
 
 // Ensure Channel implements grpc.ClientConnInterface.
 var _ grpc.ClientConnInterface = (*Channel)(nil)

--- a/bigtable/internal/accelerator/accelerator_core_test.go
+++ b/bigtable/internal/accelerator/accelerator_core_test.go
@@ -756,3 +756,22 @@ func TestNewStream_UnknownMethod_ReturnsUnimplemented(t *testing.T) {
 		t.Errorf("NewStream(unknown) code = %v; want Unimplemented", status.Code(err))
 	}
 }
+
+func TestComposeUserAgent(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		prefix string
+		want   string
+	}{
+		{name: "empty prefix returns daemon token", prefix: "", want: userAgent},
+		{name: "blank prefix returns daemon token", prefix: "   ", want: userAgent},
+		{name: "prefix is prepended and space-separated", prefix: "python-bigtable/2.1.0", want: "python-bigtable/2.1.0 " + userAgent},
+		{name: "prefix is trimmed before joining", prefix: "  python-bigtable/2.1.0  ", want: "python-bigtable/2.1.0 " + userAgent},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ComposeUserAgent(tc.prefix); got != tc.want {
+				t.Errorf("ComposeUserAgent(%q) = %q; want %q", tc.prefix, got, tc.want)
+			}
+		})
+	}
+}

--- a/bigtable/internal/accelerator/cmd/main.go
+++ b/bigtable/internal/accelerator/cmd/main.go
@@ -55,6 +55,10 @@ func main() {
 	universeDomain := flag.String("universe-domain", "", "override the service universe domain, e.g. googleapis.com (optional)")
 	scopesFlag := flag.String("scopes", "", "comma-separated OAuth scopes to override the default data scope (optional)")
 	quotaProject := flag.String("quota-project", "", "quota/billing project override (optional)")
+	// User-agent prefix. Cross-language clients (e.g. the Python SDK) pass their
+	// own client user agent here so the service sees both the caller and the
+	// daemon build, e.g. "python-bigtable/2.1.0 go-acc/v1.38.0".
+	userAgent := flag.String("user-agent", "", "user-agent prefix prepended to the daemon's own token (optional)")
 	flag.Parse()
 
 	if *udsPath == "" {
@@ -85,6 +89,12 @@ func main() {
 	if *quotaProject != "" {
 		opts = append(opts, option.WithQuotaProject(*quotaProject))
 	}
+	// Prepend the caller's user-agent prefix to the daemon's own token. Appended
+	// after the channel's defaults so it overrides the default WithUserAgent; a
+	// blank flag leaves the default (daemon-token-only) user agent untouched.
+	if strings.TrimSpace(*userAgent) != "" {
+		opts = append(opts, option.WithUserAgent(accelerator.ComposeUserAgent(*userAgent)))
+	}
 
 	ctx := context.Background()
 
@@ -111,8 +121,8 @@ func main() {
 		log.Fatalf("failed to construct accelerator channel: %v", err)
 	}
 	srv := accelerator.NewServer(*udsPath, channel)
-	log.Printf("Starting accelerator daemon on UDS=%s project=%s instance=%s app-profile=%q data-endpoint=%q universe-domain=%q scopes=%q quota-project=%q",
-		*udsPath, *project, *instance, *appProfile, *dataEndpoint, *universeDomain, *scopesFlag, *quotaProject)
+	log.Printf("Starting accelerator daemon on UDS=%s project=%s instance=%s app-profile=%q data-endpoint=%q universe-domain=%q scopes=%q quota-project=%q user-agent=%q",
+		*udsPath, *project, *instance, *appProfile, *dataEndpoint, *universeDomain, *scopesFlag, *quotaProject, accelerator.ComposeUserAgent(*userAgent))
 
 	// Resolve and publish the daemon's identity BEFORE binding the socket, so
 	// the file is present by the time the client detects a connectable UDS.


### PR DESCRIPTION
Add a --user-agent flag to the daemon binary so cross-language clients (e.g. the Python SDK) can identify themselves to the Bigtable service. The flag value is prepended to the daemon's own token, space-separated per the gRPC user-agent product-token convention, e.g. "python-bigtable/2.1.0 go-acc/v1.38.0". A blank flag leaves the daemon-token-only user agent unchanged.

Also shorten the daemon's own token from "cbt-go-accelerator/v<ver>" to "go-acc/v<ver>".

Composition lives in the exported ComposeUserAgent helper, covered by a new unit test.