### PR TITLE
fix(bigtable): session client — set AllowNonDefaultServiceAccount on DirectPath dial

### DIFF
--- a/bigtable/client.go
+++ b/bigtable/client.go
@@ -187,14 +187,12 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 		option.WithGRPCDialOption(grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(1<<28), grpc.MaxCallRecvMsgSize(1<<28))),
 	)
 
-	var directAccessOptions = []option.ClientOption{
-		internaloption.EnableDirectPath(true),
-		internaloption.EnableDirectPathXds(),
-		internaloption.AllowHardBoundTokens("ALTS"),
-	}
+	// DirectAccess opt-set is centralized in btopt so the classic
+	// client, the DirectAccess probe (direct_access_check.go), and the
+	// session client (internal/session) cannot drift on which options
+	// are applied to a DirectPath dial.
+	directAccessOptions := btopt.DirectAccessOptions()
 
-	// Allow non-default service account in DirectPath.
-	o = append(o, internaloption.AllowNonDefaultServiceAccount(true))
 	o = append(o, opts...)
 	o = append(o, internaloption.EnableNewAuthLibrary())
 	o = append(o, internaloption.EnableJwtWithScope())

--- a/bigtable/direct_access_check.go
+++ b/bigtable/direct_access_check.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"strings"
 
+	btopt "cloud.google.com/go/bigtable/internal/option"
 	"google.golang.org/api/option"
-	"google.golang.org/api/option/internaloption"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
 )
@@ -90,13 +90,9 @@ func CheckDirectAccessSupported(ctx context.Context, project, instance, appProfi
 		option.WithGRPCDialOption(grpc.WithUnaryInterceptor(interceptor)),
 	}, opts...)
 
-	// Force DirectPath and ALTS using internal options
-	allOpts = append(allOpts,
-		internaloption.EnableDirectPath(true),
-		internaloption.EnableDirectPathXds(),
-		internaloption.AllowHardBoundTokens("ALTS"),
-		internaloption.AllowNonDefaultServiceAccount(true),
-	)
+	// Force DirectPath and ALTS. Shared with the classic client and the
+	// session client via btopt so the three call sites cannot drift.
+	allOpts = append(allOpts, btopt.DirectAccessOptions()...)
 
 	config := ClientConfig{
 		AppProfile:      appProfile,

--- a/bigtable/internal/option/option.go
+++ b/bigtable/internal/option/option.go
@@ -129,6 +129,28 @@ func DefaultClientOptions(endpoint, mtlsEndpoint, scope, userAgent string) ([]op
 	return o, nil
 }
 
+// DirectAccessOptions returns the option set that opts a gRPC dial in to
+// Bigtable DirectAccess (DirectPath + DirectPathXds + ALTS-bound tokens).
+//
+// All four options must be applied together. Omitting
+// AllowNonDefaultServiceAccount causes api/transport's DirectPath
+// compatibility check (isTokenSourceDirectPathCompatible in
+// google.golang.org/api/transport/grpc/dial.go) to require the ADC
+// token's legacy oauth2.google.tokenSource / oauth2.google.serviceAccount
+// extras. The newer cloud.google.com/go/auth library — now the default
+// ADC path — does not populate those extras, so the check fails and the
+// dial silently falls back to CFE+TLS instead of DirectPath. This helper
+// keeps the classic client, the DirectAccess probe, and the session
+// client on one option set so they cannot drift.
+func DirectAccessOptions() []option.ClientOption {
+	return []option.ClientOption{
+		internaloption.EnableDirectPath(true),
+		internaloption.EnableDirectPathXds(),
+		internaloption.AllowHardBoundTokens("ALTS"),
+		internaloption.AllowNonDefaultServiceAccount(true),
+	}
+}
+
 // ClientInterceptorOptions returns client options to use for the client's gRPC
 // connection, using the given streaming and unary RPC interceptors.
 //

--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -313,10 +313,19 @@ func NewClient(
 		}
 		return btransport.NewBigtableConn(grpcConn), nil
 	}
+	// AllowNonDefaultServiceAccount mirrors the classic path (see
+	// bigtable.NewClientWithConfig and direct_access_check.go). Without it,
+	// api/transport's DirectPath compatibility check requires the ADC token
+	// to carry the legacy oauth2 extras oauth2.google.tokenSource=
+	// "compute-metadata" and oauth2.google.serviceAccount="default". The
+	// newer cloud.google.com/go/auth library — now the default ADC path —
+	// does not populate those extras, so the check fails and the dial
+	// silently falls back to CFE+TLS instead of DirectPath.
 	daDialOpts := append(append([]option.ClientOption{}, opts...),
 		internaloption.EnableDirectPath(true),
 		internaloption.EnableDirectPathXds(),
-		internaloption.AllowHardBoundTokens("ALTS"))
+		internaloption.AllowHardBoundTokens("ALTS"),
+		internaloption.AllowNonDefaultServiceAccount(true))
 	daDial := func() (*btransport.BigtableConn, error) {
 		grpcConn, dialErr := gtransport.Dial(ctx, daDialOpts...)
 		if dialErr != nil {

--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -30,7 +30,6 @@ import (
 	btransport "cloud.google.com/go/bigtable/internal/transport"
 	otelmetric "go.opentelemetry.io/otel/metric"
 	"google.golang.org/api/option"
-	"google.golang.org/api/option/internaloption"
 	gtransport "google.golang.org/api/transport/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
@@ -313,19 +312,14 @@ func NewClient(
 		}
 		return btransport.NewBigtableConn(grpcConn), nil
 	}
-	// AllowNonDefaultServiceAccount mirrors the classic path (see
-	// bigtable.NewClientWithConfig and direct_access_check.go). Without it,
-	// api/transport's DirectPath compatibility check requires the ADC token
-	// to carry the legacy oauth2 extras oauth2.google.tokenSource=
-	// "compute-metadata" and oauth2.google.serviceAccount="default". The
-	// newer cloud.google.com/go/auth library — now the default ADC path —
-	// does not populate those extras, so the check fails and the dial
-	// silently falls back to CFE+TLS instead of DirectPath.
-	daDialOpts := append(append([]option.ClientOption{}, opts...),
-		internaloption.EnableDirectPath(true),
-		internaloption.EnableDirectPathXds(),
-		internaloption.AllowHardBoundTokens("ALTS"),
-		internaloption.AllowNonDefaultServiceAccount(true))
+	// DirectAccess opt-set is centralized in btopt (shared with the
+	// classic client and the DirectAccess probe) so the three call
+	// sites cannot drift on which options are applied to a DirectPath
+	// dial. See btopt.DirectAccessOptions for the rationale on each
+	// individual option (in particular AllowNonDefaultServiceAccount,
+	// without which the dial silently falls back to CFE+TLS under the
+	// newer cloud.google.com/go/auth ADC path).
+	daDialOpts := append(append([]option.ClientOption{}, opts...), btopt.DirectAccessOptions()...)
 	daDial := func() (*btransport.BigtableConn, error) {
 		grpcConn, dialErr := gtransport.Dial(ctx, daDialOpts...)
 		if dialErr != nil {

--- a/bigtable/internal/transport/channel_pool_factory.go
+++ b/bigtable/internal/transport/channel_pool_factory.go
@@ -185,7 +185,6 @@ func CreateBigtableChannelPool(
 		directAccessDialerOptions := make([]option.ClientOption, len(o))
 		copy(directAccessDialerOptions, o)
 		directAccessDialerOptions = append(directAccessDialerOptions, directAccessOptions...)
-		directAccessDialerOptions = append(directAccessDialerOptions, internaloption.AllowHardBoundTokens("ALTS"))
 
 		directAccessDialer := func() (*BigtableConn, error) {
 			grpcConn, err := gtransport.Dial(ctx, directAccessDialerOptions...)


### PR DESCRIPTION
## Summary

Add `internaloption.AllowNonDefaultServiceAccount(true)` to the session
client's direct-access dialer opts (`bigtable/internal/session/client.go`),
matching the classic client (`bigtable/client.go`) and the DirectAccess
probe (`bigtable/direct_access_check.go`), both of which set all four
DirectPath-related options.

## Why

Without the flag, api/transport's DirectPath compatibility check
(`google.golang.org/api/transport/grpc/dial.go` — `isTokenSourceDirectPathCompatible`)
requires the ADC token to carry the legacy oauth2 extras
`oauth2.google.tokenSource="compute-metadata"` and
`oauth2.google.serviceAccount="default"`. The newer
`cloud.google.com/go/auth` library — now the default ADC path — does
not populate those extras, so the check fails, prints

```
WARNING: DirectPath is misconfigured. Please make sure the token source
is fetched from GCE metadata server and the default service account is used.
```

and the session client's direct-access dial silently falls back to
CFE+TLS instead of DirectPath.

The classic pool on the same client keeps DirectPath because its base
option list carries the flag. Result: mixed-mode clients silently lose
DirectPath on the session data plane while retaining it on the classic
data plane — a real perf regression that is hard to spot without pprof
or peer inspection of session RPCs.

## Reproduction

On a GCE VM with the default compute service account:

```
$ go test -run TestReadRows_MutateReadRoundTrip_Prod ./bigtable/internal/accelerator/ \
    -it.project=<PROJECT> -it.instance=<INSTANCE> -v
=== RUN   TestReadRows_MutateReadRoundTrip_Prod
WARNING: DirectPath is misconfigured. Please make sure the token source
is fetched from GCE metadata server and the default service account is used.
--- PASS: TestReadRows_MutateReadRoundTrip_Prod (16.23s)
```

With this change the warning is gone and DirectPath engages on the
session dial.

## Compatibility

No behavior change on environments that already produce the legacy
extras — the flag short-circuits the compat check earlier without
altering correctness. On environments where the extras are absent
(all recent api/transport releases), the session dial now uses
DirectPath as intended.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/session/...` clean
- [x] `go test -short ./internal/session/...` passes
- [x] Manual: 5/5 runs of `TestReadRows_MutateReadRoundTrip_Prod` against
      a personal Bigtable instance; warning gone after the fix
- [ ] CI green