### PR TITLE
fix(bigtable): register c2p resolver + RLS balancer for accelerator daemon DirectPath

### DIFF
--- a/bigtable/internal/accelerator/cmd/grpc_dp.go
+++ b/bigtable/internal/accelerator/cmd/grpc_dp.go
@@ -1,0 +1,34 @@
+//go:build !disable_grpc_modules
+
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// The accelerator daemon dials the data plane with DirectAccess enabled (see
+// internal/option.DirectAccessOptions) but, unlike the classic client, it does
+// not import package bigtable -- so it never pulls in that package's grpc_dp.go,
+// which is the only place these two gRPC modules are registered. Without them
+// the daemon requests DirectPath, fails to resolve the "google-c2p" target
+// ("unknown port") or NACKs the xDS route config ("RLS LB policy not
+// registered"), and silently falls back to CloudPath (CFE). Register the same
+// pair here, behind the same build tag, so DirectPath is usable in environments
+// that support it.
+import (
+	// Install the google-c2p resolver, which is required for DirectPath.
+	_ "google.golang.org/grpc/xds/googledirectpath"
+	// Install the RLS load-balancing policy, required by Bigtable's DirectPath
+	// xDS route config (google.golang.org/grpc RLS).
+	_ "google.golang.org/grpc/balancer/rls"
+)


### PR DESCRIPTION
## Summary

The accelerator daemon (`bigtable/internal/accelerator/cmd`) dials the data
plane with DirectAccess enabled (`internal/option.DirectAccessOptions` →
`EnableDirectPath(true)` + `EnableDirectPathXds()`), but — unlike the classic
`bigtable` client — it does **not** import package `bigtable`. Package
`bigtable`'s `grpc_dp.go` (build tag `!disable_grpc_modules`) is the **only**
place two gRPC modules required for DirectPath are registered:

- `google.golang.org/grpc/xds/googledirectpath` — the `google-c2p` resolver
- `google.golang.org/grpc/balancer/rls` — the RLS LB policy that Bigtable's
  DirectPath xDS route config routes through

Without them the daemon requests DirectPath but either fails to resolve
`google-c2p:///bigtable.googleapis.com` (`unknown port`) or NACKs the xDS
Listener (`RLS LB policy not registered`), then silently falls back to
CloudPath (CFE). The symptom is DirectPath-misconfigured warnings while
everything still works over CFE.

## Fix

Add `bigtable/internal/accelerator/cmd/grpc_dp.go` (package `main`, same
`!disable_grpc_modules` build tag) with the same two blank imports as
`bigtable/grpc_dp.go`, so the daemon registers the identical module pair.

## Testing

- `go build` of the accelerator cmd succeeds; both modules enter the cmd's
  dependency graph.
- `gofmt` + `go vet` clean.
- Verified end-to-end that with the modules registered the daemon attempts
  DirectPath (rather than silently using CFE).