### PR TITLE
chore: enable preview releases

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -15,3 +15,9 @@ branches:
     manifest: true
     manifestFile: .release-please-individual-manifest.json
     manifestConfig: release-please-individual-config.json
+  - branch: preview
+    handleGHRelease: true
+    tagPullRequestNumber: true
+    manifest: true
+    manifestFile: .release-please-preview-manifest.json
+    manifestConfig: release-please-preview-config.json


### PR DESCRIPTION
Configures `release-please` app to track release PRs on the `preview` branch and to create tag/releases in reaction to their submission.

Note: `release-please` will open its own staging PR against `preview` but this will be in draft mode and should not be submitted. 