### PR TITLE
fix(bigtable): session pool — don't let a discarded sessionTable close a shared pool

### DIFF
--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -127,6 +127,15 @@ type Config struct {
 type managedSessionPool struct {
 	pool       *btransport.SessionPoolImpl
 	unregister func()
+	// refs counts the live sessionTables that have opened this pool.
+	// getOrCreateSessionPool does +1 (on both create and cache-hit);
+	// releaseSessionPool does -1 and tears the pool down only at zero.
+	// Guarded by sessionPoolsMu. This keeps a pool alive when two
+	// sessionTables transiently share it — e.g. a TTL-sweep eviction
+	// handing the still-mapped pool to a fresh handle during the
+	// delete-then-close window — so the departing owner can't close it
+	// out from under the arriving one.
+	refs int
 }
 
 // permission is the read/write axis of a pool's identity. Kept as a
@@ -623,6 +632,13 @@ func (sc *sessionClient) releaseSessionPool(key poolKey) error {
 		sc.sessionPoolsMu.Unlock()
 		return nil
 	}
+	mp.refs--
+	if mp.refs > 0 {
+		// Another live sessionTable still holds this pool (transient
+		// sharing across an evict/reopen). Drop our reference only.
+		sc.sessionPoolsMu.Unlock()
+		return nil
+	}
 	delete(sc.sessionPools, key)
 	sc.sessionPoolsMu.Unlock()
 
@@ -694,6 +710,7 @@ func (sc *sessionClient) getOrCreateSessionPool(
 		return nil
 	}
 	if mp, ok := sc.sessionPools[key]; ok {
+		mp.refs++
 		sc.sessionPoolsMu.Unlock()
 		return mp.pool
 	}
@@ -710,7 +727,7 @@ func (sc *sessionClient) getOrCreateSessionPool(
 		poolName, streamFactory, openSessionRequest, md, sessionType,
 		sc.enableDebug,
 	)
-	mp := &managedSessionPool{pool: pool}
+	mp := &managedSessionPool{pool: pool, refs: 1}
 	sc.sessionPools[key] = mp
 	configManager := sc.configManager
 	backgroundCtx := sc.cfg.BackgroundCtx

--- a/bigtable/internal/session/client_test.go
+++ b/bigtable/internal/session/client_test.go
@@ -515,6 +515,7 @@ func TestReleaseSessionPool_RemovesEntryAndInvokesUnregister(t *testing.T) {
 	sc.sessionPools[key] = &managedSessionPool{
 		pool:       pool,
 		unregister: func() { unregistered++ },
+		refs:       1, // sole owner; the one release below drops it to 0
 	}
 	if err := sc.releaseSessionPool(key); err != nil {
 		t.Fatalf("releaseSessionPool = %v, want nil", err)
@@ -531,5 +532,137 @@ func TestReleaseSessionPool_RemovesEntryAndInvokesUnregister(t *testing.T) {
 	}
 	if unregistered != 1 {
 		t.Errorf("unregister fired %d times after second release, want still 1", unregistered)
+	}
+}
+
+// TestGetOrCreateSessionPool_RefcountsSharedPool exercises the refcount
+// that keeps a pool alive while two sessionTables transiently share it
+// (the TTL-sweep evict/reopen window). A cache hit does +1; each release
+// does -1; the pool is torn down only when the LAST reference drops.
+func TestGetOrCreateSessionPool_RefcountsSharedPool(t *testing.T) {
+	sc := newTestClient(t, &fakeChannelPool{}, Config{})
+	key := poolKey{"table:foo", permissionRead}
+	pool := btransport.NewSessionPoolImpl(
+		1, "test-pool",
+		func(ctx context.Context) (btransport.Stream, error) { return nil, errors.New("test never dials") },
+		&btpb.OpenSessionRequest{}, nil,
+		btransport.SessionTypeTable, false,
+	)
+	var unregistered int
+	// First owner already holds a reference.
+	sc.sessionPools[key] = &managedSessionPool{
+		pool:       pool,
+		unregister: func() { unregistered++ },
+		refs:       1,
+	}
+
+	// Second owner opens the same key: the cache-hit branch bumps refs to
+	// 2 and hands back the SAME pool rather than minting a new one.
+	if got := sc.getOrCreateSessionPool(key, nil, nil, nil, btransport.SessionTypeTable); got != pool {
+		t.Fatalf("getOrCreateSessionPool cache hit returned a different pool, want the existing one")
+	}
+	if got := sc.sessionPools[key].refs; got != 2 {
+		t.Fatalf("refs after second open = %d, want 2", got)
+	}
+
+	// First release drops to 1 — pool stays mapped and is NOT torn down.
+	if err := sc.releaseSessionPool(key); err != nil {
+		t.Fatalf("releaseSessionPool #1: %v", err)
+	}
+	mp, ok := sc.sessionPools[key]
+	if !ok {
+		t.Fatal("pool removed after first release, want still present (refs=1)")
+	}
+	if mp.refs != 1 {
+		t.Errorf("refs after first release = %d, want 1", mp.refs)
+	}
+	if unregistered != 0 {
+		t.Errorf("unregister fired %d times after first release, want 0 (still referenced)", unregistered)
+	}
+
+	// Second (last) release drops to 0 — pool removed, unregister fires.
+	if err := sc.releaseSessionPool(key); err != nil {
+		t.Fatalf("releaseSessionPool #2: %v", err)
+	}
+	if _, ok := sc.sessionPools[key]; ok {
+		t.Error("pool still mapped after last release, want removed")
+	}
+	if unregistered != 1 {
+		t.Errorf("unregister fired %d times after last release, want 1", unregistered)
+	}
+}
+
+// TestSessionTable_Close_SecondCloseDoesNotReleaseSuccessorPool is the
+// integration guard for the Close idempotency fix, driving the REAL
+// sessionClient refcount. A stale sessionTable that already released its
+// pool must not, on a second Close, decrement the refcount of a DIFFERENT
+// pool freshly minted under the same key.
+//
+// Timeline:
+//  1. tbl opens its read pool (refs=1) and Closes once → refs 1->0,
+//     pool-1 removed.
+//  2. A fresh owner mints a successor pool under the SAME key (refs=1).
+//  3. tbl.Close() runs AGAIN. opened() is still true (monotonic), so
+//     without the once-guard closeRead would fire and drop the successor's
+//     refs to 0, closing it out from under its live owner. The guard
+//     makes the second Close a no-op, so the successor survives.
+func TestSessionTable_Close_SecondCloseDoesNotReleaseSuccessorPool(t *testing.T) {
+	sc := newTestClient(t, &fakeChannelPool{}, Config{})
+	key := poolKey{"table:foo", permissionRead}
+	newPool := func(name string) *btransport.SessionPoolImpl {
+		return btransport.NewSessionPoolImpl(
+			1, name,
+			func(ctx context.Context) (btransport.Stream, error) { return nil, errors.New("test never dials") },
+			&btpb.OpenSessionRequest{}, nil,
+			btransport.SessionTypeTable, false,
+		)
+	}
+
+	// tbl's pool, with tbl as the sole (refs=1) owner.
+	sc.sessionPools[key] = &managedSessionPool{pool: newPool("pool-1"), refs: 1}
+
+	var closeReads int
+	tbl := newSessionTable(
+		"foo",
+		func() (Invoker, error) { return &fakeInvoker{}, nil },
+		nil,
+		func() error { closeReads++; return sc.releaseSessionPool(key) },
+		nil,
+		&btransport.VRpcDescriptorImpl{MethodName: "test.ReadRow"},
+		nil,
+		nil, nil,
+	)
+	if _, err := tbl.readPool.get(); err != nil { // mark the pool opened
+		t.Fatalf("readPool.get: %v", err)
+	}
+
+	// First Close releases tbl's pool: refs 1->0, removed.
+	if err := tbl.Close(); err != nil {
+		t.Fatalf("Close #1: %v", err)
+	}
+	if _, ok := sc.sessionPools[key]; ok {
+		t.Fatal("pool-1 still mapped after first Close, want removed")
+	}
+
+	// A fresh owner mints a successor pool under the same key.
+	successor := newPool("pool-2")
+	sc.sessionPools[key] = &managedSessionPool{pool: successor, refs: 1}
+
+	// Second Close MUST be a no-op — it must not touch the successor.
+	if err := tbl.Close(); err != nil {
+		t.Fatalf("Close #2: %v", err)
+	}
+	if closeReads != 1 {
+		t.Errorf("closeRead ran %d times, want 1 (second Close is once-guarded)", closeReads)
+	}
+	mp, ok := sc.sessionPools[key]
+	if !ok {
+		t.Fatal("successor pool was removed by the stale second Close, want still present")
+	}
+	if mp.pool != successor {
+		t.Error("mapped pool is not the successor after the second Close")
+	}
+	if mp.refs != 1 {
+		t.Errorf("successor refs = %d, want 1 (untouched by the stale Close)", mp.refs)
 	}
 }

--- a/bigtable/internal/session/lazy_pool.go
+++ b/bigtable/internal/session/lazy_pool.go
@@ -17,6 +17,7 @@ package session
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	btransport "cloud.google.com/go/bigtable/internal/transport"
 )
@@ -50,6 +51,14 @@ type lazyPool struct {
 	mu   sync.Mutex
 	pool Invoker
 	open func() (Invoker, error)
+	// openedFlag mirrors "pool != nil" but is readable WITHOUT mu.
+	// get() holds mu for the whole open() (a dial that can block for
+	// seconds), so a mu-guarded opened() would make any concurrent
+	// reader — notably sessionTable.Close's ownership gate — stall
+	// behind, or deadlock against, an in-flight open. Set to true only
+	// on a successful open, under mu, so the lock-free load is
+	// monotonic false->true and never observes a half-open pool.
+	openedFlag atomic.Bool
 }
 
 // get returns the underlying pool, opening it on first call.
@@ -68,17 +77,18 @@ func (l *lazyPool) get() (Invoker, error) {
 		return nil, err
 	}
 	l.pool = p
+	l.openedFlag.Store(true)
 	return p, nil
 }
 
-// opened reports whether the pool has been opened yet — for tests
-// and for the sessionz debug UI which wants to render "read pool:
-// not yet opened" vs a live pool.
+// opened reports whether the pool has been opened yet — for tests, for
+// the sessionz debug UI ("read pool: not yet opened" vs a live pool),
+// and for sessionTable.Close's ownership gate. Reads openedFlag
+// lock-free so a caller racing an in-flight open() (which holds mu for
+// the whole dial) neither stalls nor deadlocks on mu.
 func (l *lazyPool) opened() bool {
 	if l == nil {
 		return false
 	}
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	return l.pool != nil
+	return l.openedFlag.Load()
 }

--- a/bigtable/internal/session/table.go
+++ b/bigtable/internal/session/table.go
@@ -73,11 +73,14 @@ type sessionTable struct {
 	// write side of the openRead/openWrite pair.
 	closeRead  func() error
 	closeWrite func() error
-	// closed is set by Close() BEFORE the releasers run, and re-checked
+	// closed serves two roles for Close(). (1) It is the once-guard:
+	// Close swaps it false->true and a second Close returns early, so the
+	// per-pool refcount releasers run at most once. (2) It is re-checked
 	// inside the lazy-open wrapper (guardOpen) around openRead/openWrite
 	// so an opener whose slow path straddles Close cleans up its own
 	// insert instead of leaking a fresh pool that the releaser missed.
-	// See guardOpen for the interleaving rules.
+	// The swap happens BEFORE the releasers run so the guardOpen re-check
+	// observes it. See guardOpen for the interleaving rules.
 	closed atomic.Bool
 }
 
@@ -118,14 +121,17 @@ func newSessionTable(
 // against t.closed. Interleaving cases:
 //
 //   - Close ran first: early check trips, opener never runs. No leak.
-//   - Close runs while opener's slow path holds sessionPoolsMu: post-check
+//   - Close runs while opener's slow path is still dialing: post-check
 //     trips after opener returns; guardOpen invokes release itself to tear
-//     down the pool the opener just inserted. releaseSessionPool is
-//     idempotent, so Close's parallel call to release harmlessly no-ops.
-//   - Close runs after guardOpen returns: normal path — Close's releaser
-//     finds the pool in sessionPools and closes it. In-flight Invoke on
-//     the returned pool may fail with a "pool closed" error; the client
-//     was concurrently being torn down, so that's expected.
+//     down the pool the opener just inserted, then returns an error. Because
+//     get() only sets lazyPool.openedFlag on a SUCCESSFUL open, the flag
+//     stays false, so Close's own opened()-gated releaser skips this pool —
+//     exactly one release runs, keeping the pool refcount balanced.
+//   - Close runs after guardOpen returns: normal path — the open succeeded
+//     and set openedFlag, so Close's releaser finds the pool in sessionPools
+//     and closes it. In-flight Invoke on the returned pool may fail with a
+//     "pool closed" error; the client was concurrently being torn down, so
+//     that's expected.
 //
 // A nil opener passes through as nil so the MV write side (no write pool)
 // stays a lazyPool-with-nil-open ("no session support"), not a
@@ -282,17 +288,21 @@ func dispatch[Args any, R any, Resp interface {
 }
 
 // Close releases this sessionTable's underlying read + write session
-// pools from the sessionClient's per-resource keyed map. Both release
-// closures are idempotent (second call finds the map entry absent
-// and no-ops) so double-close from the cache sweeper + explicit
-// caller is safe.
+// pools from the sessionClient's per-resource keyed map.
 //
-// Ordering matters: closed is Store'd BEFORE the releasers run so an
-// opener whose slow path is straddling this Close (already past its
-// early check, still dialing) sees closed=true on its post-insert
-// re-check inside guardOpen and cleans up its own insert. See guardOpen.
-// Otherwise the releaser would no-op on the empty map and the
-// post-insert would leak a fresh pool.
+// Idempotent: the closed.Swap guard makes a second Close a no-op. This
+// matters because each releaser now decrements a refcount on the shared,
+// resource-keyed pool; a second Close would decrement again with no
+// matching open, and if a fresh pool had since been minted under the same
+// key it would strand that pool by dropping its refcount to zero. The
+// guard also serves the cache sweeper + explicit caller double-close path.
+//
+// Ordering matters: closed is set BEFORE the releasers run so an opener
+// whose slow path is straddling this Close (already past its early check,
+// still dialing) sees closed=true on its post-insert re-check inside
+// guardOpen and cleans up its own insert. See guardOpen. Otherwise the
+// releaser would no-op on the empty map and the post-insert would leak a
+// fresh pool.
 //
 // Safety of per-handle pool teardown also rests on a caller-side
 // invariant: bigtable.Client's session.TableCache guarantees at-most-one
@@ -304,7 +314,9 @@ func dispatch[Args any, R any, Resp interface {
 // Returns the joined read + write teardown errors (nil for the
 // materialized-view case where closeWrite is nil).
 func (t *sessionTable) Close() error {
-	t.closed.Store(true)
+	if t.closed.Swap(true) {
+		return nil
+	}
 	var errs []error
 	// Only release a pool this sessionTable actually opened. A sessionTable
 	// discarded by TableCache.GetOrOpen's concurrent-miss race (the loser of

--- a/bigtable/internal/session/table.go
+++ b/bigtable/internal/session/table.go
@@ -306,12 +306,22 @@ func dispatch[Args any, R any, Resp interface {
 func (t *sessionTable) Close() error {
 	t.closed.Store(true)
 	var errs []error
-	if t.closeRead != nil {
+	// Only release a pool this sessionTable actually opened. A sessionTable
+	// discarded by TableCache.GetOrOpen's concurrent-miss race (the loser of
+	// two racing opens for the same resource) never dispatches, so its
+	// lazyPools stay unopened. Releasing unconditionally would run
+	// releaseSessionPool on the shared, resource-keyed pool the *winning*
+	// sessionTable owns (readKey/writeKey are derived from the resource and
+	// identical across every sessionTable for it), closing it out from under
+	// the winner — which then serves ErrPoolClosed for the rest of the run.
+	// opened() is monotonic false->true and serialized against open() by
+	// lazyPool.mu, so gating here never skips a release the true owner needs.
+	if t.closeRead != nil && t.readPool.opened() {
 		if err := t.closeRead(); err != nil {
 			errs = append(errs, err)
 		}
 	}
-	if t.closeWrite != nil {
+	if t.closeWrite != nil && t.writePool.opened() {
 		if err := t.closeWrite(); err != nil {
 			errs = append(errs, err)
 		}

--- a/bigtable/internal/session/table_test.go
+++ b/bigtable/internal/session/table_test.go
@@ -489,24 +489,59 @@ func TestSessionTable_ReadAndWritePoolsDoNotShareSessions(t *testing.T) {
 // --- Close teardown ---------------------------------------------------------
 
 // TestSessionTable_Close_CallsBothReleasers verifies Close fires the
-// closeRead and closeWrite release closures exactly once each.
+// closeRead and closeWrite release closures exactly once each, once both
+// pools have actually been opened (Close gates each releaser on the
+// corresponding lazyPool.opened()).
 func TestSessionTable_Close_CallsBothReleasers(t *testing.T) {
 	var reads, writes int
 	tbl := newSessionTable(
 		"t",
-		func() (Invoker, error) { return nil, nil },
-		func() (Invoker, error) { return nil, nil },
+		func() (Invoker, error) { return &fakeInvoker{}, nil },
+		func() (Invoker, error) { return &fakeInvoker{}, nil },
 		func() error { reads++; return nil },
 		func() error { writes++; return nil },
 		&btransport.VRpcDescriptorImpl{MethodName: "test.ReadRow"},
 		&btransport.VRpcDescriptorImpl{MethodName: "test.MutateRow"},
 		nil, nil,
 	)
+	// Open both pools so the ownership gate lets their releasers run.
+	if _, err := tbl.readPool.get(); err != nil {
+		t.Fatalf("readPool.get: %v", err)
+	}
+	if _, err := tbl.writePool.get(); err != nil {
+		t.Fatalf("writePool.get: %v", err)
+	}
 	if err := tbl.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
 	if reads != 1 || writes != 1 {
 		t.Errorf("release call counts = (read=%d write=%d), want (1,1)", reads, writes)
+	}
+}
+
+// TestSessionTable_Close_UnopenedPoolsSkipReleasers is the flip side:
+// a sessionTable whose pools were never opened — e.g. the loser of a
+// concurrent TableCache.GetOrOpen miss race, which never dispatches —
+// must NOT run its releasers on Close. Releasing would tear down the
+// shared, resource-keyed pool the winning sessionTable owns.
+func TestSessionTable_Close_UnopenedPoolsSkipReleasers(t *testing.T) {
+	var reads, writes int
+	tbl := newSessionTable(
+		"t",
+		func() (Invoker, error) { return &fakeInvoker{}, nil },
+		func() (Invoker, error) { return &fakeInvoker{}, nil },
+		func() error { reads++; return nil },
+		func() error { writes++; return nil },
+		&btransport.VRpcDescriptorImpl{MethodName: "test.ReadRow"},
+		&btransport.VRpcDescriptorImpl{MethodName: "test.MutateRow"},
+		nil, nil,
+	)
+	// No get() calls — both pools stay unopened.
+	if err := tbl.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if reads != 0 || writes != 0 {
+		t.Errorf("release call counts = (read=%d write=%d), want (0,0) — unopened pools must not release", reads, writes)
 	}
 }
 
@@ -517,7 +552,7 @@ func TestSessionTable_Close_NilWriteReleaserOK(t *testing.T) {
 	var reads int
 	tbl := newSessionTable(
 		"",
-		func() (Invoker, error) { return nil, nil },
+		func() (Invoker, error) { return &fakeInvoker{}, nil },
 		nil,
 		func() error { reads++; return nil },
 		nil,
@@ -525,6 +560,9 @@ func TestSessionTable_Close_NilWriteReleaserOK(t *testing.T) {
 		nil,
 		nil, nil,
 	)
+	if _, err := tbl.readPool.get(); err != nil {
+		t.Fatalf("readPool.get: %v", err)
+	}
 	if err := tbl.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
@@ -541,14 +579,20 @@ func TestSessionTable_Close_JoinsErrors(t *testing.T) {
 	writeErr := status.Error(codes.Internal, "write pool teardown failed")
 	tbl := newSessionTable(
 		"t",
-		func() (Invoker, error) { return nil, nil },
-		func() (Invoker, error) { return nil, nil },
+		func() (Invoker, error) { return &fakeInvoker{}, nil },
+		func() (Invoker, error) { return &fakeInvoker{}, nil },
 		func() error { return readErr },
 		func() error { return writeErr },
 		&btransport.VRpcDescriptorImpl{MethodName: "test.ReadRow"},
 		&btransport.VRpcDescriptorImpl{MethodName: "test.MutateRow"},
 		nil, nil,
 	)
+	if _, err := tbl.readPool.get(); err != nil {
+		t.Fatalf("readPool.get: %v", err)
+	}
+	if _, err := tbl.writePool.get(); err != nil {
+		t.Fatalf("writePool.get: %v", err)
+	}
 	err := tbl.Close()
 	if err == nil {
 		t.Fatal("Close returned nil, want joined errors")
@@ -558,17 +602,18 @@ func TestSessionTable_Close_JoinsErrors(t *testing.T) {
 	}
 }
 
-// TestSessionTable_Close_ReleasersIdempotent verifies a second Close
-// call still runs the release closures (they're idempotent at the
-// sessionClient layer — second releaseSessionPool call finds the
-// entry absent and no-ops). The point is that sessionTable.Close
-// itself does not gate on a once — the underlying release is where
-// idempotency lives.
-func TestSessionTable_Close_ReleasersIdempotent(t *testing.T) {
+// TestSessionTable_Close_Idempotent verifies sessionTable.Close is
+// once-guarded: a second Close is a no-op and does NOT re-run the
+// release closures. This matters now that each releaser decrements a
+// refcount on the shared, resource-keyed pool — a second release with
+// no matching open would corrupt that refcount (see
+// TestSessionTable_Close_SecondCloseDoesNotReleaseSuccessorPool for the
+// concrete hazard).
+func TestSessionTable_Close_Idempotent(t *testing.T) {
 	var reads int
 	tbl := newSessionTable(
 		"t",
-		func() (Invoker, error) { return nil, nil },
+		func() (Invoker, error) { return &fakeInvoker{}, nil },
 		nil,
 		func() error { reads++; return nil },
 		nil,
@@ -576,52 +621,54 @@ func TestSessionTable_Close_ReleasersIdempotent(t *testing.T) {
 		nil,
 		nil, nil,
 	)
+	if _, err := tbl.readPool.get(); err != nil {
+		t.Fatalf("readPool.get: %v", err)
+	}
 	if err := tbl.Close(); err != nil {
 		t.Fatalf("Close #1: %v", err)
 	}
 	if err := tbl.Close(); err != nil {
 		t.Fatalf("Close #2: %v", err)
 	}
-	if reads != 2 {
-		t.Errorf("closeRead called %d times across two Close calls, want 2 (release is caller-idempotent, not sessionTable-once-guarded)", reads)
+	if reads != 1 {
+		t.Errorf("closeRead called %d times across two Close calls, want 1 (Close is once-guarded)", reads)
 	}
 }
 
 // TestSessionTable_Close_RacingLazyOpen_NoLeak proves the guardOpen
-// wrapper cleans up a fresh pool that the underlying opener inserted
-// AFTER Close's releaser already no-op'd on an empty map. Reproduces
-// PR #20264 review comment (high): openRead's slow path straddles
-// Close, releaser sees no entry, opener finishes and inserts → leak.
+// wrapper cleans up a fresh pool that the underlying opener produced
+// AFTER Close ran. Reproduces PR #20264 review comment (high): openRead's
+// slow path straddles Close, the opener finishes and returns a pool that
+// would otherwise leak.
 //
 // Interleaving:
-//  1. Goroutine A calls readPool.get() → guardOpen check passes
-//     (closed=false) → openRead blocks on unblockOpen chan.
-//  2. Main calls tbl.Close() → sets closed=true → invokes closeRead
-//     which increments releaseCalls; simulated "map lookup misses"
-//     because openRead hasn't inserted yet (fake release no-ops but
-//     the counter records the attempt).
-//  3. Main unblocks openRead. openRead returns "inserted a pool".
-//  4. guardOpen's post-check sees closed=true → calls release AGAIN
-//     to clean up its own insert. releaseCalls == 2.
+//  1. Goroutine A calls readPool.get() → holds lazyPool.mu → guardOpen
+//     early check passes (closed=false) → openRead blocks on unblockOpen.
+//  2. Main calls tbl.Close() → sets closed=true, then reads
+//     readPool.opened(). The lock-free openedFlag is still false (the
+//     open hasn't completed), so Close skips its own releaser AND does
+//     not stall on lazyPool.mu (which A still holds). releaseCalls stays 0.
+//  3. Main unblocks openRead. openRead returns a pool.
+//  4. guardOpen's post-check sees closed=true → calls release once to
+//     clean up the pool it just produced. releaseCalls == 1. Because the
+//     open returned an error, get() never sets openedFlag, so the earlier
+//     Close was right to skip — no double release.
 //  5. Return ErrClientClosed to the caller.
 //
-// Without the fix: releaseCalls == 1 (Close-side only), openRead
-// returned a fake pool that no one owns → leak.
+// The lock-free openedFlag is load-bearing here: a mu-guarded opened()
+// would have Close block on lazyPool.mu until step 3, deadlocking the
+// test (and stalling Close behind an in-flight dial in production).
 func TestSessionTable_Close_RacingLazyOpen_NoLeak(t *testing.T) {
 	unblockOpen := make(chan struct{})
 	openStarted := make(chan struct{})
 	var releaseCalls atomic.Int32
-	// Sentinel invoker returned by the fake openRead — proves the opener
-	// actually completed and returned a "pool" that would leak absent the
-	// post-check.
-	fakeInv := (Invoker)(nil)
 
 	tbl := newSessionTable(
 		"t",
 		func() (Invoker, error) {
 			close(openStarted)
 			<-unblockOpen
-			return fakeInv, nil
+			return &fakeInvoker{}, nil
 		},
 		nil,
 		func() error { releaseCalls.Add(1); return nil },
@@ -655,8 +702,11 @@ func TestSessionTable_Close_RacingLazyOpen_NoLeak(t *testing.T) {
 	if gotInvoker != nil {
 		t.Errorf("readPool.get() returned non-nil invoker %v, want nil", gotInvoker)
 	}
-	if got := releaseCalls.Load(); got != 2 {
-		t.Errorf("release called %d times, want 2 (once by Close, once by guardOpen post-check cleanup)", got)
+	if got := releaseCalls.Load(); got != 1 {
+		t.Errorf("release called %d times, want 1 (guardOpen post-check cleanup only; Close skipped because the pool never finished opening)", got)
+	}
+	if tbl.readPool.opened() {
+		t.Error("readPool.opened() = true after a Close-straddled open that errored; want false")
 	}
 }
 
@@ -690,7 +740,7 @@ func TestSessionTable_Close_BeforeLazyOpen_EarlyBail(t *testing.T) {
 	if openCalled.Load() != 0 {
 		t.Errorf("openRead was called %d times after Close, want 0 (early bail should short-circuit)", openCalled.Load())
 	}
-	if releaseCalls.Load() != 1 {
-		t.Errorf("release called %d times, want 1 (Close's own release only; guardOpen never entered inner)", releaseCalls.Load())
+	if releaseCalls.Load() != 0 {
+		t.Errorf("release called %d times, want 0 (pool never opened, so Close's ownership gate skips it and guardOpen never enters its inner path)", releaseCalls.Load())
 	}
 }


### PR DESCRIPTION
## The bug

On a cold-start burst, many first-touch ops for the same table race `TableCache.GetOrOpen`'s miss path. `GetOrOpen` runs `openFn` for **every** racing caller, then discards the losers with `api.Close()`. But `sessionTable.Close()` unconditionally released its read/write pools, which are keyed by resource in the shared `sessionClient.sessionPools` registry — so a loser's `Close()` tore down the pool the **winning** (cached) `sessionTable` owns. The winner's `lazyPool` has already memoized that pool, so every subsequent op for the resource serves `ErrPoolClosed` for the rest of the run — the pool never reopens.

A rarer sibling of the same class: a TTL-sweep eviction removes a handle from the cache and then closes its pool; a fresh op arriving in that window gets the still-mapped pool from `getOrCreateSessionPool` and is then stranded when the evicted handle's release closes it.

## The fix

- **Gate the releasers on `lazyPool.opened()`** in `sessionTable.Close()`, so a never-dispatched loser no longer releases the shared pool. `opened()` is monotonic and only flips true on a successful open, so this never skips a release the true owner needs.
- **Make `opened()` lock-free** via an atomic flag on `lazyPool`. `get()` holds `lazyPool.mu` for the whole `open()` (a dial that can block), so a mutex-guarded `opened()` would make `Close()`'s ownership gate stall behind — or deadlock against — an in-flight open. The flag is set under `mu` on successful open and read without it.
- **Refcount `managedSessionPool`** so a pool transiently shared by two `sessionTables` (the evict/reopen window) is torn down only when the last reference drops.
- **Make `sessionTable.Close()` idempotent** via a `closed.Swap(true)` once-guard. Each releaser now decrements the pool refcount; a second Close would decrement again with no matching open, and if a fresh pool had since been minted under the same key it would strand that pool. The guard makes a second Close a no-op.

The pieces are complementary: the `opened()` gate keeps the +1/−1 refcount balanced (only a `sessionTable` that opened a pool ever releases it), and the once-guard keeps a stale handle from decrementing a successor pool.

This keeps the current two-tier structure and every existing debug/snapshot surface intact.

## Testing

Build + vet + `internal/session` package tests (including `-race`). New coverage:

- `TestGetOrCreateSessionPool_RefcountsSharedPool` — cache-hit `+1`, release `−1`, teardown only at zero.
- `TestSessionTable_Close_SecondCloseDoesNotReleaseSuccessorPool` — a stale second Close must not tear down a pool freshly minted under the same key (fails without the once-guard).
- `TestSessionTable_Close_Idempotent`, `TestSessionTable_Close_UnopenedPoolsSkipReleasers`, and updates to the existing Close/lazy-open tests for the ownership gate.
