### PR TITLE
fix(bigtable): session client — single ownership + single-flight pool loading

### DIFF
--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -16,6 +16,7 @@ package session
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"sort"
@@ -141,12 +142,10 @@ type managedSessionPool struct {
 // runs it exactly once. Close() before set() (opener never ran — the
 // resource was never touched) or after a prior Close() is a no-op.
 //
-// This is the single-ownership core of the Java-shape refactor: each
-// sessionTable closes exactly the pool its OWN opener created, by
-// captured identity, never a shared-key sibling's pool. It replaces the
-// old key-based releaseSessionPool, which could close a pool a live
-// sibling sessionTable was still memoizing — the shared-pool
-// close-forever bug this refactor fixes.
+// This gives each sessionTable single ownership of its pool: a table
+// closes exactly the pool its OWN opener created, by captured identity,
+// never a sibling's pool that happens to share a poolKey. That prevents
+// closing a pool a live sibling sessionTable is still memoizing.
 type poolCloser struct {
 	mu      sync.Mutex
 	release func() error
@@ -653,9 +652,10 @@ func (sc *sessionClient) buildLazyOpener(
 		// Hand the pool's teardown to the owner. If the sessionTable was
 		// closed while we were dialing, set() tears the fresh pool down
 		// immediately (it would otherwise leak, since owner.Close already
-		// fired against an empty owner) and we surface client-closed.
-		if closed, _ := owner.set(release); closed {
-			return nil, ErrClientClosed
+		// fired against an empty owner) and we surface client-closed —
+		// joining any teardown error so a failed drain isn't swallowed.
+		if closed, err := owner.set(release); closed {
+			return nil, errors.Join(ErrClientClosed, err)
 		}
 		return pool, nil
 	}

--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -123,14 +123,71 @@ type Config struct {
 }
 
 // managedSessionPool bundles a pool with its config-listener unregister
-// thunk so the listener can be detached before pool teardown.
+// thunk so the listener can be detached before pool teardown. id and key
+// are carried only for the observational index (sessionz snapshots,
+// stable ordering, config-listener fanout) — the pool's lifetime is
+// owned by the poolCloser handed back to the sessionTable that created
+// it, NOT by its presence in this map.
 type managedSessionPool struct {
+	id         uint64
+	key        poolKey
 	pool       *btransport.SessionPoolImpl
 	unregister func()
 }
 
+// poolCloser owns the teardown of the single pool instance created by
+// one buildLazyOpener invocation. The opener calls set() with an
+// identity-scoped release thunk once the pool is constructed; Close()
+// runs it exactly once. Close() before set() (opener never ran — the
+// resource was never touched) or after a prior Close() is a no-op.
+//
+// This is the single-ownership core of the Java-shape refactor: each
+// sessionTable closes exactly the pool its OWN opener created, by
+// captured identity, never a shared-key sibling's pool. It replaces the
+// old key-based releaseSessionPool, which could close a pool a live
+// sibling sessionTable was still memoizing — the shared-pool
+// close-forever bug this refactor fixes.
+type poolCloser struct {
+	mu      sync.Mutex
+	release func() error
+	done    bool
+}
+
+// set records the identity-scoped release thunk for the pool the opener
+// just created. If Close() already ran (the sessionTable was torn down
+// while the opener was mid-flight), set tears the just-created pool down
+// immediately so it doesn't leak, and reports that the owner is closed.
+func (c *poolCloser) set(release func() error) (closed bool, err error) {
+	c.mu.Lock()
+	if c.done {
+		c.mu.Unlock()
+		return true, release()
+	}
+	c.release = release
+	c.mu.Unlock()
+	return false, nil
+}
+
+// Close runs the captured release thunk exactly once. No-op when the
+// opener never ran (release nil) or Close already fired.
+func (c *poolCloser) Close() error {
+	c.mu.Lock()
+	if c.done {
+		c.mu.Unlock()
+		return nil
+	}
+	c.done = true
+	release := c.release
+	c.release = nil
+	c.mu.Unlock()
+	if release == nil {
+		return nil
+	}
+	return release()
+}
+
 // permission is the read/write axis of a pool's identity. Kept as a
-// typed enum (not a string suffix on the map key) so getOrCreateSessionPool
+// typed enum (not a string suffix on the map key) so createSessionPool
 // doesn't have to reverse-parse the key to label the pool.
 type permission int
 
@@ -150,11 +207,18 @@ func (p permission) display() string {
 	return ""
 }
 
-// poolKey identifies one pool inside sessionClient.pools. Resource is
-// the caller-supplied short name ("table:foo", "av:t:v", "mv:v");
-// permission separates the read pool from the write pool for the same
-// resource. Struct keys let the map dedup on both axes without string
-// concatenation.
+// poolKey names a pool for display + ordering only. Resource is the
+// caller-supplied short name ("table:foo", "av:t:v", "mv:v"); permission
+// separates the read pool from the write pool for the same resource.
+//
+// poolKey is deliberately NOT the ownership key: pools are owned by the
+// poolCloser handed to the creating sessionTable and indexed in
+// sessionClient.sessionPools by a monotonic uint64 id. Two live
+// sessionTables for the same resource therefore each own a private pool
+// that happens to share a poolKey — which is exactly the property that
+// fixes the shared-pool close-forever bug. The key survives only to label
+// the OTel `session_name` metric (displayName) and to order snapshots
+// (less).
 type poolKey struct {
 	resourceName string
 	perm         permission
@@ -186,11 +250,13 @@ func (k poolKey) less(other poolKey) bool {
 // `session_name` timeseries and distinct sessionz rows — otherwise they
 // would silently aggregate on the label.
 //
-// (Resource, permission) is already unique per pool, so the numeric
-// pool id is intentionally left out of the display name. The pool id
-// remains on SessionPoolImpl (as poolID) and gets baked into per-session
-// log names via createSession — `session_name` label cardinality stays
-// bounded by (resource × permission).
+// The numeric pool id is intentionally left out of the display name so
+// `session_name` label cardinality stays bounded by (resource ×
+// permission) even though several short-lived pools may share a
+// (resource, permission) across successive Open* calls. Those pools
+// aggregate onto one `session_name` timeseries by design; the numeric id
+// still lives on SessionPoolImpl (as poolID) for the sessionz ↔ channelz
+// reverse link and per-session log names.
 func (k poolKey) displayName() string {
 	r := k.resourceName
 	switch {
@@ -246,8 +312,15 @@ type sessionClient struct {
 	// disagree on session-mode flags.
 	featureFlagsProto *btpb.FeatureFlags
 
+	// sessionPools is an observational index of live pools keyed by a
+	// monotonic id (nextPoolID). It backs sessionz/PoolSnapshots, the
+	// config-listener fanout, and Client.Close's close-all — NOT
+	// ownership: each pool's lifetime is owned by the poolCloser handed
+	// to the sessionTable that created it (see poolCloser). Entries are
+	// added by createSessionPool and removed by the id-scoped releaser it
+	// returns.
 	sessionPoolsMu sync.Mutex
-	sessionPools   map[poolKey]*managedSessionPool
+	sessionPools   map[uint64]*managedSessionPool
 	nextPoolID     atomic.Uint64
 }
 
@@ -392,7 +465,7 @@ func newSessionClientFromParts(channelPool ChannelPool, stub btpb.BigtableClient
 		metricsFactory:    metricsFactory,
 		enableDebug:       cfg.EnableDebug,
 		featureFlagsProto: cfg.FeatureFlagsProto,
-		sessionPools:      make(map[poolKey]*managedSessionPool),
+		sessionPools:      make(map[uint64]*managedSessionPool),
 	}
 	// stub == nil only happens on the test-only newSessionClientFromParts
 	// path (unit tests wiring a fake ChannelPool without a real gRPC stub).
@@ -442,17 +515,15 @@ func (sc *sessionClient) OpenTable(tableID string) TableAPI {
 	fullName := sc.fullTableName(tableID)
 	streamFactory := func(ctx context.Context) (btransport.Stream, error) { return sc.stub.OpenTable(ctx) }
 	resource := "table:" + tableID
-	readKey := poolKey{resource, permissionRead}
-	writeKey := poolKey{resource, permissionWrite}
+	readOwner := &poolCloser{}
+	writeOwner := &poolCloser{}
 	openRead := sc.buildLazyOpener(fullName, btransport.TABLE_SESSION, streamFactory,
 		&btpb.OpenTableRequest{TableName: fullName, AppProfileId: sc.cfg.AppProfile, Permission: btpb.OpenTableRequest_PERMISSION_READ},
-		readKey)
+		poolKey{resource, permissionRead}, readOwner)
 	openWrite := sc.buildLazyOpener(fullName, btransport.TABLE_SESSION, streamFactory,
 		&btpb.OpenTableRequest{TableName: fullName, AppProfileId: sc.cfg.AppProfile, Permission: btpb.OpenTableRequest_PERMISSION_WRITE},
-		writeKey)
-	closeRead := sc.buildLazyReleaser(readKey)
-	closeWrite := sc.buildLazyReleaser(writeKey)
-	return newSessionTable(tableID, openRead, openWrite, closeRead, closeWrite, btransport.READ_ROW, btransport.MUTATE_ROW, sc.perResourceMetadata(fullName, "table_name", fullName), sc.metricsFactory)
+		poolKey{resource, permissionWrite}, writeOwner)
+	return newSessionTable(tableID, openRead, openWrite, readOwner.Close, writeOwner.Close, btransport.READ_ROW, btransport.MUTATE_ROW, sc.perResourceMetadata(fullName, "table_name", fullName), sc.metricsFactory)
 }
 
 // OpenAuthorizedView returns a TableAPI for an authorized view.
@@ -460,17 +531,15 @@ func (sc *sessionClient) OpenAuthorizedView(table, view string) TableAPI {
 	fullName := sc.fullAuthorizedViewName(table, view)
 	streamFactory := func(ctx context.Context) (btransport.Stream, error) { return sc.stub.OpenAuthorizedView(ctx) }
 	resource := fmt.Sprintf("av:%s:%s", table, view)
-	readKey := poolKey{resource, permissionRead}
-	writeKey := poolKey{resource, permissionWrite}
+	readOwner := &poolCloser{}
+	writeOwner := &poolCloser{}
 	openRead := sc.buildLazyOpener(fullName, btransport.AUTHORIZED_VIEW_SESSION, streamFactory,
 		&btpb.OpenAuthorizedViewRequest{AuthorizedViewName: fullName, AppProfileId: sc.cfg.AppProfile, Permission: btpb.OpenAuthorizedViewRequest_PERMISSION_READ},
-		readKey)
+		poolKey{resource, permissionRead}, readOwner)
 	openWrite := sc.buildLazyOpener(fullName, btransport.AUTHORIZED_VIEW_SESSION, streamFactory,
 		&btpb.OpenAuthorizedViewRequest{AuthorizedViewName: fullName, AppProfileId: sc.cfg.AppProfile, Permission: btpb.OpenAuthorizedViewRequest_PERMISSION_WRITE},
-		writeKey)
-	closeRead := sc.buildLazyReleaser(readKey)
-	closeWrite := sc.buildLazyReleaser(writeKey)
-	return newSessionTable(table, openRead, openWrite, closeRead, closeWrite, btransport.READ_ROW_AUTH_VIEW, btransport.MUTATE_ROW_AUTH_VIEW, sc.perResourceMetadata(fullName, "authorized_view_name", fullName), sc.metricsFactory)
+		poolKey{resource, permissionWrite}, writeOwner)
+	return newSessionTable(table, openRead, openWrite, readOwner.Close, writeOwner.Close, btransport.READ_ROW_AUTH_VIEW, btransport.MUTATE_ROW_AUTH_VIEW, sc.perResourceMetadata(fullName, "authorized_view_name", fullName), sc.metricsFactory)
 }
 
 // OpenMaterializedView returns a read-only TableAPI for a
@@ -478,7 +547,7 @@ func (sc *sessionClient) OpenAuthorizedView(table, view string) TableAPI {
 // cleanly via the nil openWrite passed to newSessionTable.
 func (sc *sessionClient) OpenMaterializedView(view string) TableAPI {
 	fullName := sc.fullMaterializedViewName(view)
-	readKey := poolKey{"mv:" + view, permissionRead}
+	readOwner := &poolCloser{}
 	openRead := sc.buildLazyOpener(fullName, btransport.MATERIALIZED_VIEW_SESSION,
 		func(ctx context.Context) (btransport.Stream, error) { return sc.stub.OpenMaterializedView(ctx) },
 		&btpb.OpenMaterializedViewRequest{
@@ -486,9 +555,8 @@ func (sc *sessionClient) OpenMaterializedView(view string) TableAPI {
 			AppProfileId:         sc.cfg.AppProfile,
 			Permission:           btpb.OpenMaterializedViewRequest_PERMISSION_READ,
 		},
-		readKey)
-	closeRead := sc.buildLazyReleaser(readKey)
-	return newSessionTable("", openRead, nil, closeRead, nil, btransport.READ_ROW_MAT_VIEW, nil, sc.perResourceMetadata(fullName, "materialized_view_name", fullName), sc.metricsFactory)
+		poolKey{"mv:" + view, permissionRead}, readOwner)
+	return newSessionTable("", openRead, nil, readOwner.Close, nil, btransport.READ_ROW_MAT_VIEW, nil, sc.perResourceMetadata(fullName, "materialized_view_name", fullName), sc.metricsFactory)
 }
 
 // Close tears down in a phased order that keeps late callbacks from
@@ -512,7 +580,7 @@ func (sc *sessionClient) Close() error {
 	// through the teardown.
 	sc.sessionPoolsMu.Lock()
 	pools := sc.sessionPools
-	sc.sessionPools = nil // refuse subsequent Opens; getOrCreateSessionPool nil-checks
+	sc.sessionPools = nil // refuse subsequent Opens; createSessionPool nil-checks
 	mgr := sc.configManager
 	chp := sc.channelPool
 	managed := sc.managedChannelPool
@@ -547,108 +615,70 @@ func (sc *sessionClient) Close() error {
 	return err
 }
 
-// buildLazyOpener returns a closure that, on first invocation,
-// creates (or reuses via the keyed cache) the pool for the given
-// payload/key. Returns nil when payload is nil (materialized-view
+// buildLazyOpener returns a closure that, on first invocation, creates a
+// fresh pool for the given payload/key and hands its identity-scoped
+// closer to owner. Returns nil when payload is nil (materialized-view
 // write side).
+//
+// Each invocation mints its OWN pool (no keyed dedup) and records the
+// teardown thunk on owner via set(). owner.Close — wired as the
+// sessionTable's closeRead/closeWrite — then closes exactly that pool,
+// by identity. This is the single-ownership contract: a sibling
+// sessionTable sharing the same poolKey holds a different owner and a
+// different pool, so its teardown can never close ours.
 func (sc *sessionClient) buildLazyOpener(
 	resourceName string,
 	sessionDesc *btransport.SessionDescriptor,
 	streamFactory func(ctx context.Context) (btransport.Stream, error),
 	payload proto.Message,
 	key poolKey,
+	owner *poolCloser,
 ) func() (Invoker, error) {
 	if payload == nil {
 		return nil
 	}
 	return func() (Invoker, error) {
-		pool, err := sc.createSessionPoolForPayload(resourceName, sessionDesc, streamFactory, payload, key)
+		pool, release, err := sc.createSessionPoolForPayload(resourceName, sessionDesc, streamFactory, payload, key)
 		if err != nil {
 			return nil, err
 		}
 		if pool == nil {
-			// getOrCreateSessionPool returns nil ONLY when Close() has already
+			// createSessionPool returns nil ONLY when Close() has already
 			// snapshotted the pool set. Surface a distinct sentinel so
 			// callers can tell "client closed" apart from "resource has
 			// no write pool" (ErrWriteNotSupported) or "bookkeeping
 			// drift" (errReadPoolNil).
 			return nil, ErrClientClosed
 		}
+		// Hand the pool's teardown to the owner. If the sessionTable was
+		// closed while we were dialing, set() tears the fresh pool down
+		// immediately (it would otherwise leak, since owner.Close already
+		// fired against an empty owner) and we surface client-closed.
+		if closed, _ := owner.set(release); closed {
+			return nil, ErrClientClosed
+		}
 		return pool, nil
 	}
-}
-
-// buildLazyReleaser returns a closure that releases the pool entry
-// for the given key from sessionPools + closes the underlying pool.
-// Returned closure is idempotent (second call finds entry absent and
-// no-ops) and nil-safe when key is the zero value (the caller can
-// pass nil for resources without a write side — e.g. materialized
-// views — mirroring buildLazyOpener's payload==nil convention).
-//
-// Symmetric with buildLazyOpener so sessionTable can drive real
-// per-resource teardown from its Close() without needing back-refs
-// or knowing about poolKey / sessionPools internals.
-func (sc *sessionClient) buildLazyReleaser(key poolKey) func() error {
-	return func() error {
-		return sc.releaseSessionPool(key)
-	}
-}
-
-// releaseSessionPool removes key from sessionPools and closes the
-// underlying pool. No-op when:
-//   - the client has already Closed (sessionPools == nil), so any late
-//     release from a cache handle draining on the way out doesn't
-//     racily double-close a pool that Client.Close is already
-//     tearing down.
-//   - the entry is absent (already released — makes second calls safe).
-//
-// Assumes the caller (currently bigtable.Client via session.TableCache)
-// guarantees at-most-one sessionTable per resource at any moment. That
-// invariant means no co-owner can be relying on the pool we're closing.
-// If session.Client is ever exposed to callers that bypass that cache,
-// this must gain a refcount.
-//
-// Teardown runs OUTSIDE sessionPoolsMu so a graceful pool drain (which
-// can block on in-flight vRPCs) doesn't deadlock any snapshotter
-// waiting on the lock. Matches the snapshot-under-lock / teardown-
-// outside pattern in Client.Close.
-func (sc *sessionClient) releaseSessionPool(key poolKey) error {
-	sc.sessionPoolsMu.Lock()
-	if sc.sessionPools == nil {
-		sc.sessionPoolsMu.Unlock()
-		return nil
-	}
-	mp, ok := sc.sessionPools[key]
-	if !ok {
-		sc.sessionPoolsMu.Unlock()
-		return nil
-	}
-	delete(sc.sessionPools, key)
-	sc.sessionPoolsMu.Unlock()
-
-	if mp.unregister != nil {
-		mp.unregister()
-	}
-	return mp.pool.Close()
 }
 
 // createSessionPoolForPayload marshals the resource-typed OpenXxxRequest
 // into the transport-level OpenSessionRequest envelope, builds routing
 // metadata via the descriptor's MetadataFn, and delegates to
-// getOrCreateSessionPool for cache-hit-or-construct.
+// createSessionPool. Returns the pool plus its identity-scoped release
+// thunk (nil pool+release when Close already snapshotted the pool set).
 func (sc *sessionClient) createSessionPoolForPayload(
 	resourceName string,
 	sessionDesc *btransport.SessionDescriptor,
 	streamFactory func(ctx context.Context) (btransport.Stream, error),
 	payload proto.Message,
 	key poolKey,
-) (*btransport.SessionPoolImpl, error) {
+) (*btransport.SessionPoolImpl, func() error, error) {
 	if payload == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 	payloadBytes, err := proto.Marshal(payload)
 	if err != nil {
-		return nil, fmt.Errorf("proto.Marshal session payload: %w", err)
+		return nil, nil, fmt.Errorf("proto.Marshal session payload: %w", err)
 	}
 	handshake := &btpb.OpenSessionRequest{
 		ProtocolVersion: sessionProtocolVersion,
@@ -673,59 +703,61 @@ func (sc *sessionClient) createSessionPoolForPayload(
 		requestParamsHeader, paramsVal,
 	), sc.cfg.FeatureFlagsMD)
 
-	return sc.getOrCreateSessionPool(key, streamFactory, handshake, md, sessionDesc.Type), nil
+	pool, release := sc.createSessionPool(key, streamFactory, handshake, md, sessionDesc.Type)
+	return pool, release, nil
 }
 
-// getOrCreateSessionPool ports SessionManager.GetOrCreateSessionPool:
-// dedups on key, mints a display name, constructs the pool, wires
-// the config listener + background loops.
-func (sc *sessionClient) getOrCreateSessionPool(
+// createSessionPool constructs a fresh pool, registers it in the
+// observational index under a monotonic id, wires the config listener +
+// background loops, and returns the pool along with an id-scoped release
+// thunk that removes it from the index and closes it.
+//
+// Unlike the old getOrCreateSessionPool this NEVER dedups on key: every
+// Open* call that reaches its opener gets its own pool. Ownership is
+// carried by the returned closer (captured on a poolCloser by
+// buildLazyOpener), so a TableCache loser discarding its handle, or an
+// evicted-then-reopened handle, only ever closes the pool IT created —
+// never a live sibling's. Returns (nil, nil) when Close() has already
+// snapshotted+nil'd the pool set.
+func (sc *sessionClient) createSessionPool(
 	key poolKey,
 	streamFactory func(ctx context.Context) (btransport.Stream, error),
 	openSessionRequest *btpb.OpenSessionRequest,
 	md metadata.MD,
 	sessionType btransport.SessionType,
-) *btransport.SessionPoolImpl {
+) (*btransport.SessionPoolImpl, func() error) {
 	sc.sessionPoolsMu.Lock()
 	// Close() sets pools=nil to refuse subsequent Opens; a nil map here
 	// means teardown has already snapshotted the pool set.
 	if sc.sessionPools == nil {
 		sc.sessionPoolsMu.Unlock()
-		return nil
-	}
-	if mp, ok := sc.sessionPools[key]; ok {
-		sc.sessionPoolsMu.Unlock()
-		return mp.pool
+		return nil, nil
 	}
 	id := sc.nextPoolID.Add(1)
 	// poolName is stamped as the `session_name` OTel metric label and
 	// surfaces in sessionz — "<resource-id>-<PERM>" (see poolKey.displayName).
-	// Numeric pool id lives on SessionPoolImpl.poolID for the sessionz
-	// ↔ channelz reverse link and per-session log names; we don't need
-	// it in the human-readable label because (resource, permission)
-	// already uniquely identifies the pool.
+	// Several pools may share a name across successive Open* calls; the
+	// numeric id (on SessionPoolImpl.poolID and this index) disambiguates
+	// them for the sessionz ↔ channelz reverse link and per-session log
+	// names while `session_name` cardinality stays bounded.
 	poolName := key.displayName()
 	pool := btransport.NewSessionPoolImpl(
 		id,
 		poolName, streamFactory, openSessionRequest, md, sessionType,
 		sc.enableDebug,
 	)
-	mp := &managedSessionPool{pool: pool}
-	sc.sessionPools[key] = mp
+	mp := &managedSessionPool{id: id, key: key, pool: pool}
+	sc.sessionPools[id] = mp
 	configManager := sc.configManager
 	backgroundCtx := sc.cfg.BackgroundCtx
 	sc.sessionPoolsMu.Unlock()
-	// TODO(sushanb): publish-before-Start race — a concurrent second Open
-	// on the same key sees mp in the map before pool.Start(backgroundCtx)
-	// runs below and can Invoke on an unstarted pool. Fix in follow-up by
-	// gating each managedSessionPool with a sync.Once + <-ready channel.
 
 	if configManager != nil {
 		unregister := configManager.AddSessionPoolListener(func(config *btpb.SessionClientConfiguration_SessionPoolConfiguration) {
 			pool.UpdateConfig(config)
 		})
 		sc.sessionPoolsMu.Lock()
-		if cur, stillThere := sc.sessionPools[key]; stillThere && cur == mp {
+		if cur, stillThere := sc.sessionPools[id]; stillThere && cur == mp {
 			mp.unregister = unregister
 			sc.sessionPoolsMu.Unlock()
 		} else {
@@ -735,7 +767,42 @@ func (sc *sessionClient) getOrCreateSessionPool(
 	}
 
 	pool.Start(backgroundCtx)
-	return pool
+	return pool, sc.releasePoolByID(id)
+}
+
+// releasePoolByID returns the identity-scoped teardown thunk for the
+// pool registered under id. The thunk removes the pool from the
+// observational index and closes it, and is a no-op when:
+//   - the client has already Closed (sessionPools == nil), so a late
+//     release draining out of a TableCache handle doesn't double-close a
+//     pool Client.Close is already tearing down; or
+//   - the id is absent (already released — makes the poolCloser's
+//     single-shot Close doubly safe).
+//
+// Teardown runs OUTSIDE sessionPoolsMu so a graceful pool drain (which
+// can block on in-flight vRPCs) doesn't deadlock a snapshotter waiting
+// on the lock — the snapshot-under-lock / teardown-outside pattern also
+// used by Client.Close.
+func (sc *sessionClient) releasePoolByID(id uint64) func() error {
+	return func() error {
+		sc.sessionPoolsMu.Lock()
+		if sc.sessionPools == nil {
+			sc.sessionPoolsMu.Unlock()
+			return nil
+		}
+		mp, ok := sc.sessionPools[id]
+		if !ok {
+			sc.sessionPoolsMu.Unlock()
+			return nil
+		}
+		delete(sc.sessionPools, id)
+		sc.sessionPoolsMu.Unlock()
+
+		if mp.unregister != nil {
+			mp.unregister()
+		}
+		return mp.pool.Close()
+	}
 }
 
 // featureFlags returns the FeatureFlags proto stamped onto every
@@ -811,26 +878,34 @@ func (sc *sessionClient) LoadBalancingSnapshots() []btransport.LoadBalancingSnap
 	return out
 }
 
-// poolEntry is the internal (key, pool) tuple used by snapshot methods
-// so they can sort by poolKey without duplicating the collection loop.
+// poolEntry is the internal (id, key, pool) tuple used by snapshot
+// methods so they can sort by poolKey without duplicating the collection
+// loop. id breaks ties when two live pools share a poolKey (successive
+// Open* calls for the same resource) so ordering stays stable.
 type poolEntry struct {
+	id   uint64
 	key  poolKey
 	pool *btransport.SessionPoolImpl
 }
 
 // orderedPoolEntries snapshots the pools map under lock and returns
-// its non-nil entries sorted by poolKey.
+// its non-nil entries sorted by poolKey, then id.
 func (sc *sessionClient) orderedPoolEntries() []poolEntry {
 	sc.sessionPoolsMu.Lock()
 	entries := make([]poolEntry, 0, len(sc.sessionPools))
-	for k, mp := range sc.sessionPools {
+	for _, mp := range sc.sessionPools {
 		if mp == nil || mp.pool == nil {
 			continue
 		}
-		entries = append(entries, poolEntry{key: k, pool: mp.pool})
+		entries = append(entries, poolEntry{id: mp.id, key: mp.key, pool: mp.pool})
 	}
 	sc.sessionPoolsMu.Unlock()
-	sort.Slice(entries, func(i, j int) bool { return entries[i].key.less(entries[j].key) })
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].key != entries[j].key {
+			return entries[i].key.less(entries[j].key)
+		}
+		return entries[i].id < entries[j].id
+	})
 	return entries
 }
 

--- a/bigtable/internal/session/client_test.go
+++ b/bigtable/internal/session/client_test.go
@@ -241,7 +241,7 @@ func TestSessionClient_BuildLazyOpener_NilPayloadReturnsNil(t *testing.T) {
 	sc := newTestClient(t, nil, Config{})
 	defer sc.Close()
 
-	got := sc.buildLazyOpener("projects/p/instances/i/materializedViews/v", nil, nil, nil, poolKey{"mv:v", permissionWrite})
+	got := sc.buildLazyOpener("projects/p/instances/i/materializedViews/v", nil, nil, nil, poolKey{resourceName: "mv:v", perm: permissionWrite}, &poolCloser{})
 	if got != nil {
 		t.Errorf("buildLazyOpener(payload=nil) = non-nil, want nil (MV write side)")
 	}
@@ -440,26 +440,26 @@ func TestPoolKey_DisplayName(t *testing.T) {
 		key  poolKey
 		want string
 	}{
-		{"table read", poolKey{"table:my-table", permissionRead}, "my-table-READ"},
-		{"table write", poolKey{"table:my-table", permissionWrite}, "my-table-WRITE"},
-		{"authorized view read", poolKey{"av:my-table:my-view", permissionRead}, "my-table/my-view-READ"},
-		{"authorized view write", poolKey{"av:my-table:my-view", permissionWrite}, "my-table/my-view-WRITE"},
+		{"table read", poolKey{resourceName: "table:my-table", perm: permissionRead}, "my-table-READ"},
+		{"table write", poolKey{resourceName: "table:my-table", perm: permissionWrite}, "my-table-WRITE"},
+		{"authorized view read", poolKey{resourceName: "av:my-table:my-view", perm: permissionRead}, "my-table/my-view-READ"},
+		{"authorized view write", poolKey{resourceName: "av:my-table:my-view", perm: permissionWrite}, "my-table/my-view-WRITE"},
 		{"authorized view — same view id, different tables must not collide",
-			poolKey{"av:other-table:my-view", permissionRead}, "other-table/my-view-READ"},
-		{"materialized view read", poolKey{"mv:my-mat-view", permissionRead}, "my-mat-view-READ"},
-		{"table id with dashes and dots", poolKey{"table:tbl-1.foo", permissionRead}, "tbl-1.foo-READ"},
+			poolKey{resourceName: "av:other-table:my-view", perm: permissionRead}, "other-table/my-view-READ"},
+		{"materialized view read", poolKey{resourceName: "mv:my-mat-view", perm: permissionRead}, "my-mat-view-READ"},
+		{"table id with dashes and dots", poolKey{resourceName: "table:tbl-1.foo", perm: permissionRead}, "tbl-1.foo-READ"},
 		// Unknown prefix falls through to the raw resource string so
 		// operators still get a legible label even if a future resource
 		// kind hasn't been wired into displayResource yet.
-		{"unknown prefix falls through", poolKey{"future-kind:xyz", permissionRead}, "future-kind:xyz-READ"},
+		{"unknown prefix falls through", poolKey{resourceName: "future-kind:xyz", perm: permissionRead}, "future-kind:xyz-READ"},
 		// Malformed inputs: pin current fallback behavior so nobody
 		// silently changes to a panic. In practice these can't be
 		// produced by any of the Open* call sites; the assertions are
 		// defensive-programming contracts on displayResource.
-		{"empty resource", poolKey{"", permissionRead}, "-READ"},
-		{"empty table id after prefix", poolKey{"table:", permissionRead}, "-READ"},
-		{"empty view id after av prefix", poolKey{"av:t:", permissionRead}, "t/-READ"},
-		{"empty view id after mv prefix", poolKey{"mv:", permissionRead}, "-READ"},
+		{"empty resource", poolKey{resourceName: "", perm: permissionRead}, "-READ"},
+		{"empty table id after prefix", poolKey{resourceName: "table:", perm: permissionRead}, "-READ"},
+		{"empty view id after av prefix", poolKey{resourceName: "av:t:", perm: permissionRead}, "t/-READ"},
+		{"empty view id after mv prefix", poolKey{resourceName: "mv:", perm: permissionRead}, "-READ"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -470,64 +470,69 @@ func TestPoolKey_DisplayName(t *testing.T) {
 	}
 }
 
-// --- releaseSessionPool ------------------------------------------------------
+// --- releasePoolByID ---------------------------------------------------------
 
-// TestReleaseSessionPool_AfterClientClose_NoOp: once Close nils out
-// sessionPools, any late release from a cache handle draining on the
-// way out must be a benign no-op rather than a nil-map panic.
-func TestReleaseSessionPool_AfterClientClose_NoOp(t *testing.T) {
+// TestReleasePoolByID_AfterClientClose_NoOp: once Close nils out
+// sessionPools, any late release from a poolCloser draining on the way
+// out must be a benign no-op rather than a nil-map panic.
+func TestReleasePoolByID_AfterClientClose_NoOp(t *testing.T) {
 	sc := newTestClient(t, &fakeChannelPool{}, Config{})
+	release := sc.releasePoolByID(1)
 	sc.sessionPools = nil // simulate Close having snapshotted+nil'd
-	if err := sc.releaseSessionPool(poolKey{"table:foo", permissionRead}); err != nil {
-		t.Errorf("releaseSessionPool on nil map = %v, want nil (post-Close no-op)", err)
+	if err := release(); err != nil {
+		t.Errorf("releasePoolByID on nil map = %v, want nil (post-Close no-op)", err)
 	}
 }
 
-// TestReleaseSessionPool_MissingKeyNoOp: releasing a key that isn't in
-// the map returns nil and leaves other entries untouched. This is what
-// makes double-release safe (winner deletes; loser sees absent).
-func TestReleaseSessionPool_MissingKeyNoOp(t *testing.T) {
+// TestReleasePoolByID_MissingIDNoOp: releasing an id that isn't in the
+// map returns nil and leaves other entries untouched. This is what makes
+// double-release safe (winner deletes; loser sees absent).
+func TestReleasePoolByID_MissingIDNoOp(t *testing.T) {
 	sc := newTestClient(t, &fakeChannelPool{}, Config{})
-	present := poolKey{"table:present", permissionRead}
-	sc.sessionPools[present] = &managedSessionPool{} // sentinel, not touched
-	if err := sc.releaseSessionPool(poolKey{"table:absent", permissionRead}); err != nil {
-		t.Errorf("releaseSessionPool on absent key = %v, want nil", err)
+	const presentID = 7
+	sc.sessionPools[presentID] = &managedSessionPool{id: presentID} // sentinel, not touched
+	if err := sc.releasePoolByID(99)(); err != nil {
+		t.Errorf("releasePoolByID on absent id = %v, want nil", err)
 	}
-	if _, still := sc.sessionPools[present]; !still {
-		t.Error("releaseSessionPool on absent key deleted a different entry")
+	if _, still := sc.sessionPools[presentID]; !still {
+		t.Error("releasePoolByID on absent id deleted a different entry")
 	}
 }
 
-// TestReleaseSessionPool_RemovesEntryAndInvokesUnregister covers the
-// happy path with a real (unstarted) SessionPoolImpl. The pool never
-// dialed a stream so Close returns cleanly; we assert the map entry
-// is gone AND the config-listener unregister thunk fired.
-func TestReleaseSessionPool_RemovesEntryAndInvokesUnregister(t *testing.T) {
+// TestReleasePoolByID_RemovesEntryAndInvokesUnregister covers the happy
+// path with a real (unstarted) SessionPoolImpl. The pool never dialed a
+// stream so Close returns cleanly; we assert the map entry is gone AND
+// the config-listener unregister thunk fired, and that the returned
+// closer is idempotent.
+func TestReleasePoolByID_RemovesEntryAndInvokesUnregister(t *testing.T) {
 	sc := newTestClient(t, &fakeChannelPool{}, Config{})
-	key := poolKey{"table:foo", permissionRead}
+	const id = 3
 	pool := btransport.NewSessionPoolImpl(
-		1, "test-pool",
+		id, "test-pool",
 		func(ctx context.Context) (btransport.Stream, error) { return nil, errors.New("test never dials") },
 		&btpb.OpenSessionRequest{}, nil,
 		btransport.SessionTypeTable, false,
 	)
 	var unregistered int
-	sc.sessionPools[key] = &managedSessionPool{
+	sc.sessionPools[id] = &managedSessionPool{
+		id:         id,
+		key:        poolKey{resourceName: "table:foo", perm: permissionRead},
 		pool:       pool,
 		unregister: func() { unregistered++ },
 	}
-	if err := sc.releaseSessionPool(key); err != nil {
-		t.Fatalf("releaseSessionPool = %v, want nil", err)
+	release := sc.releasePoolByID(id)
+	if err := release(); err != nil {
+		t.Fatalf("releasePoolByID = %v, want nil", err)
 	}
-	if _, still := sc.sessionPools[key]; still {
-		t.Error("sessionPools still holds the released key")
+	if _, still := sc.sessionPools[id]; still {
+		t.Error("sessionPools still holds the released id")
 	}
 	if unregistered != 1 {
 		t.Errorf("unregister fired %d times, want 1", unregistered)
 	}
 	// Second release is a clean no-op (winner deleted, loser sees absent).
-	if err := sc.releaseSessionPool(key); err != nil {
-		t.Errorf("second releaseSessionPool = %v, want nil", err)
+	if err := release(); err != nil {
+		t.Errorf("second releasePoolByID = %v, want nil", err)
 	}
 	if unregistered != 1 {
 		t.Errorf("unregister fired %d times after second release, want still 1", unregistered)

--- a/bigtable/internal/session/client_test.go
+++ b/bigtable/internal/session/client_test.go
@@ -538,3 +538,64 @@ func TestReleasePoolByID_RemovesEntryAndInvokesUnregister(t *testing.T) {
 		t.Errorf("unregister fired %d times after second release, want still 1", unregistered)
 	}
 }
+
+// --- single ownership --------------------------------------------------------
+
+// TestCreateSessionPool_SingleOwnership_SameKeyDistinctPools pins the
+// heart of the fix: two Open* calls that resolve the SAME poolKey each
+// get their OWN pool, registered under a distinct id — createSessionPool
+// NEVER dedups on key. Releasing one pool's id-scoped closer tears down
+// only that pool and leaves the sibling registered and open, so a
+// discarded-loser or evicted-then-reopened handle can no longer close a
+// pool a live sibling is still using.
+func TestCreateSessionPool_SingleOwnership_SameKeyDistinctPools(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel) // stops the pools' background loops on test exit
+	sc := newTestClient(t, &fakeChannelPool{}, Config{BackgroundCtx: ctx})
+
+	key := poolKey{resourceName: "table:foo", perm: permissionRead}
+	neverDial := func(context.Context) (btransport.Stream, error) {
+		return nil, errors.New("test never dials")
+	}
+	newPool := func() (*btransport.SessionPoolImpl, func() error) {
+		return sc.createSessionPool(key, neverDial, &btpb.OpenSessionRequest{}, nil, btransport.SessionTypeTable)
+	}
+
+	poolA, releaseA := newPool()
+	poolB, releaseB := newPool()
+
+	if poolA == nil || poolB == nil {
+		t.Fatalf("createSessionPool returned nil pool: A=%v B=%v", poolA, poolB)
+	}
+	if poolA == poolB {
+		t.Fatal("same poolKey returned the SAME pool instance — createSessionPool deduped on key (regressed to shared-pool ownership)")
+	}
+	if got := len(sc.sessionPools); got != 2 {
+		t.Fatalf("sessionPools has %d entries, want 2 (both siblings registered under distinct ids)", got)
+	}
+
+	// Releasing A removes ONLY A; B stays registered and points at the
+	// same live pool it created. This is the assertion the old shared-key
+	// releaseSessionPool could not satisfy.
+	if err := releaseA(); err != nil {
+		t.Fatalf("releaseA: %v", err)
+	}
+	if got := len(sc.sessionPools); got != 1 {
+		t.Fatalf("after releaseA, sessionPools has %d entries, want 1 (sibling survives)", got)
+	}
+	var survivor *managedSessionPool
+	for _, mp := range sc.sessionPools {
+		survivor = mp
+	}
+	if survivor == nil || survivor.pool != poolB {
+		t.Fatalf("releaseA tore down the sibling: survivor=%v, want B's pool", survivor)
+	}
+
+	// B's closer is independent and still fires cleanly.
+	if err := releaseB(); err != nil {
+		t.Fatalf("releaseB: %v", err)
+	}
+	if got := len(sc.sessionPools); got != 0 {
+		t.Errorf("after releaseB, sessionPools has %d entries, want 0", got)
+	}
+}

--- a/bigtable/internal/session/table.go
+++ b/bigtable/internal/session/table.go
@@ -65,11 +65,14 @@ type sessionTable struct {
 	writeVRpcDesc  btransport.VRpcDescriptor
 	md             metadata.MD
 	metricsFactory *metrics.Factory
-	// closeRead / closeWrite release the per-resource pool entries on
-	// this sessionTable's Close(). Both are supplied by sessionClient
-	// via buildLazyReleaser and no-op cleanly when the pool was never
-	// opened or the client already tore itself down. closeWrite is nil
-	// for materialized views (read-only resources), mirroring the nil
+	// closeRead / closeWrite tear down the specific pools this
+	// sessionTable's openers created, on its Close(). Both are supplied by
+	// sessionClient as a per-owner poolCloser.Close (see client.go's
+	// poolCloser): they close exactly the pool the matching opener minted,
+	// by captured identity — never a sibling sessionTable's pool that
+	// happens to share a poolKey — and no-op cleanly when the pool was
+	// never opened or the client already tore itself down. closeWrite is
+	// nil for materialized views (read-only resources), mirroring the nil
 	// write side of the openRead/openWrite pair.
 	closeRead  func() error
 	closeWrite func() error
@@ -120,12 +123,14 @@ func newSessionTable(
 //   - Close ran first: early check trips, opener never runs. No leak.
 //   - Close runs while opener's slow path holds sessionPoolsMu: post-check
 //     trips after opener returns; guardOpen invokes release itself to tear
-//     down the pool the opener just inserted. releaseSessionPool is
-//     idempotent, so Close's parallel call to release harmlessly no-ops.
+//     down the pool the opener just inserted. The poolCloser behind
+//     release is single-shot, so Close's parallel call harmlessly no-ops
+//     (and the opener's own poolCloser.set already handles the case where
+//     Close fully preceded set, closing the fresh pool on the spot).
 //   - Close runs after guardOpen returns: normal path — Close's releaser
-//     finds the pool in sessionPools and closes it. In-flight Invoke on
-//     the returned pool may fail with a "pool closed" error; the client
-//     was concurrently being torn down, so that's expected.
+//     closes the pool the opener created. In-flight Invoke on the returned
+//     pool may fail with a "pool closed" error; the client was
+//     concurrently being torn down, so that's expected.
 //
 // A nil opener passes through as nil so the MV write side (no write pool)
 // stays a lazyPool-with-nil-open ("no session support"), not a

--- a/bigtable/internal/session/table_cache.go
+++ b/bigtable/internal/session/table_cache.go
@@ -263,9 +263,8 @@ type TableCache struct {
 	// runs openFn; concurrent callers for the same key block on the
 	// loadState's ready channel and re-check the map once it closes,
 	// finding the winner's handle instead of each dialing their own
-	// pool. This is the LoadingCache single-load contract — no losers,
-	// so a storm of post-eviction RPCs mints exactly one successor pool
-	// rather than N-1 throwaways.
+	// pool. With no losers, a storm of post-eviction RPCs mints exactly
+	// one successor pool rather than N-1 throwaways.
 	loading map[string]*loadState
 	// closed is flipped by Close() under mu. GetOrOpen's slow path
 	// re-checks it before inserting the freshly-opened handle so a
@@ -321,9 +320,8 @@ func NewTableCache(ttl, sweepInterval time.Duration, now func() time.Time) *Tabl
 // own locks — avoids lock inversion), then installs the handle. Any
 // concurrent caller for the same key finds the loadState and blocks on
 // its ready channel, then loops to re-check the map — it never dials a
-// throwaway pool. This mirrors Guava LoadingCache's atomic single-load
-// contract, so a post-eviction RPC storm mints exactly one successor
-// pool rather than N and discarding N-1.
+// throwaway pool. A post-eviction RPC storm therefore mints exactly one
+// successor pool rather than dialing N and discarding N-1.
 func (c *TableCache) GetOrOpen(key string, openFn func() TableAPI) TableAPI {
 	if c == nil {
 		return nil
@@ -356,11 +354,24 @@ func (c *TableCache) GetOrOpen(key string, openFn func() TableAPI) TableAPI {
 		c.loading[key] = ls
 		c.mu.Unlock()
 
+		// Clear the loading slot and wake waiters in a defer so a panic in
+		// openFn (deep in buildLazyOpener → createSessionPoolForPayload →
+		// pool construction) can't leave the slot wedged forever — that
+		// would block every subsequent GetOrOpen(key), and since every RPC
+		// routes through here, wedge the process on that resource. The
+		// loader path always returns in this iteration, so the defer fires
+		// exactly once. Waiters re-check entries after ready closes, so the
+		// handle (happy path) is already installed by the time they wake.
+		defer func() {
+			c.mu.Lock()
+			delete(c.loading, key)
+			c.mu.Unlock()
+			close(ls.ready)
+		}()
+
 		api := openFn()
 
 		c.mu.Lock()
-		delete(c.loading, key)
-		close(ls.ready)
 		if api == nil {
 			c.mu.Unlock()
 			return nil

--- a/bigtable/internal/session/table_cache.go
+++ b/bigtable/internal/session/table_cache.go
@@ -103,8 +103,8 @@ type TableHandle struct {
 	// on the next observation.
 	//
 	// Store races are safe: two concurrent dispatches that both call
-	// resolveSuccessor race into GetOrOpen, which is at-most-one-per-key
-	// (loser closes its local api and returns the winner's handle), so
+	// resolveSuccessor race into GetOrOpen, which is single-flight per
+	// key (one loads, the other blocks and observes the same handle), so
 	// both racers see the same `next` — the Store is idempotent. A
 	// divergent-`next` race (successor itself gets evicted between one
 	// dispatch's resolveSuccessor and another's Store) writes a stale
@@ -258,6 +258,15 @@ type TableCache struct {
 
 	mu      sync.Mutex
 	entries map[string]*TableHandle
+	// loading tracks the in-flight openFn call per key so GetOrOpen is
+	// single-flight: the first miss for a key installs a loadState and
+	// runs openFn; concurrent callers for the same key block on the
+	// loadState's ready channel and re-check the map once it closes,
+	// finding the winner's handle instead of each dialing their own
+	// pool. This is the LoadingCache single-load contract — no losers,
+	// so a storm of post-eviction RPCs mints exactly one successor pool
+	// rather than N-1 throwaways.
+	loading map[string]*loadState
 	// closed is flipped by Close() under mu. GetOrOpen's slow path
 	// re-checks it before inserting the freshly-opened handle so a
 	// slow-path insert straddling Close() can't orphan a live
@@ -274,6 +283,14 @@ type TableCache struct {
 	now func() time.Time
 }
 
+// loadState is the single-flight token for one in-flight openFn call.
+// The loader installs it in TableCache.loading under mu, runs openFn
+// outside the lock, then deletes it and closes ready. Waiters for the
+// same key block on ready and retry the cache lookup.
+type loadState struct {
+	ready chan struct{}
+}
+
 // NewTableCache constructs a cache and starts its background sweeper.
 // Production callers pass nil for now (→ time.Now); tests inject a
 // controllable clock.
@@ -285,6 +302,7 @@ func NewTableCache(ttl, sweepInterval time.Duration, now func() time.Time) *Tabl
 		ttl:           ttl,
 		sweepInterval: sweepInterval,
 		entries:       make(map[string]*TableHandle),
+		loading:       make(map[string]*loadState),
 		stop:          make(chan struct{}),
 		now:           now,
 	}
@@ -294,59 +312,80 @@ func NewTableCache(ttl, sweepInterval time.Duration, now func() time.Time) *Tabl
 }
 
 // GetOrOpen returns the cached handle for key, opening a fresh one
-// via openFn on cache miss. Returns nil when openFn returns nil.
+// via openFn on cache miss. Returns nil when openFn returns nil or the
+// cache is closed.
 //
-// openFn is invoked OUTSIDE the cache mutex — safe for callers whose
-// open path may itself take locks (avoids lock inversion). If two
-// callers race to open the same key concurrently, both may invoke
-// their openFn; the loser's api gets Close()d and the winner's is
-// returned to both callers.
+// Single-flight: at most one openFn runs per key at a time. The first
+// caller to miss becomes the loader — it installs a loadState, runs
+// openFn OUTSIDE the cache mutex (safe for open paths that take their
+// own locks — avoids lock inversion), then installs the handle. Any
+// concurrent caller for the same key finds the loadState and blocks on
+// its ready channel, then loops to re-check the map — it never dials a
+// throwaway pool. This mirrors Guava LoadingCache's atomic single-load
+// contract, so a post-eviction RPC storm mints exactly one successor
+// pool rather than N and discarding N-1.
 func (c *TableCache) GetOrOpen(key string, openFn func() TableAPI) TableAPI {
 	if c == nil {
 		return nil
 	}
 
-	// Fast path — cache hit.
-	c.mu.Lock()
-	if h, ok := c.entries[key]; ok {
+	for {
+		c.mu.Lock()
+		// Fast path — cache hit.
+		if h, ok := c.entries[key]; ok {
+			c.mu.Unlock()
+			h.touch()
+			return h
+		}
+		if c.closed {
+			c.mu.Unlock()
+			return nil
+		}
+		// Another caller is already loading this key. Release the lock,
+		// wait for it to finish, then loop to re-check: it either
+		// installed a handle (fast-path hit next iteration) or failed
+		// (openFn returned nil / cache closed), in which case we become
+		// the next loader.
+		if ls, ok := c.loading[key]; ok {
+			c.mu.Unlock()
+			<-ls.ready
+			continue
+		}
+		// Become the loader for this key.
+		ls := &loadState{ready: make(chan struct{})}
+		c.loading[key] = ls
 		c.mu.Unlock()
-		h.touch()
+
+		api := openFn()
+
+		c.mu.Lock()
+		delete(c.loading, key)
+		close(ls.ready)
+		if api == nil {
+			c.mu.Unlock()
+			return nil
+		}
+		if c.closed {
+			// Close() ran between the slow-path openFn and our re-lock.
+			// If we inserted this handle now, nothing would ever call
+			// its Close (sweeper stopped, Close() already snapshotted an
+			// empty map, cache-Close is stopOnce-guarded). Release the
+			// freshly-opened api ourselves and return nil so the caller
+			// falls back to classic (TableShim treats nil session-side
+			// as classic-only).
+			c.mu.Unlock()
+			_ = api.Close()
+			return nil
+		}
+		// Single-flight guarantees no concurrent loader installed a
+		// handle for this key while we held the loading slot, so this is
+		// always a fresh install.
+		h := &TableHandle{api: api, openFn: openFn, key: key, cache: c}
+		h.lastAccessNano.Store(c.now().UnixNano())
+		c.entries[key] = h
+		c.mu.Unlock()
 		return h
 	}
-	c.mu.Unlock()
-
-	// Slow path — miss. Open outside the mutex; another goroutine may
-	// win the race and insert first, in which case we discard our api
-	// and return theirs.
-	api := openFn()
-	if api == nil {
-		return nil
-	}
-
-	c.mu.Lock()
-	if c.closed {
-		// Close() ran between the slow-path openFn and our re-lock.
-		// If we inserted this handle now, nothing would ever call
-		// its Close (sweeper stopped, Close() already snapshotted an
-		// empty map, cache-Close is stopOnce-guarded). Release the
-		// freshly-opened api ourselves and return nil so the caller
-		// falls back to classic (TableShim treats nil session-side
-		// as classic-only).
-		c.mu.Unlock()
-		_ = api.Close()
-		return nil
-	}
-	if h, ok := c.entries[key]; ok {
-		c.mu.Unlock()
-		_ = api.Close() // duplicate opened concurrently; release its resources
-		h.touch()
-		return h
-	}
-	h := &TableHandle{api: api, openFn: openFn, key: key, cache: c}
-	h.lastAccessNano.Store(c.now().UnixNano())
-	c.entries[key] = h
-	c.mu.Unlock()
-	return h
 }
 
 // removeEntry deletes key from the map iff the current entry is

--- a/bigtable/internal/session/table_cache_test.go
+++ b/bigtable/internal/session/table_cache_test.go
@@ -601,3 +601,47 @@ func TestTableHandle_EvictionStormConvergesOnSingleInstalled(t *testing.T) {
 		t.Errorf("closes = %d, want %d (opens=%d, one installed live)", closesLoaded, wantCloses, opensLoaded)
 	}
 }
+
+// TestTableCache_LoaderPanic_DoesNotWedgeKey proves the loader's defer
+// clears the loading slot and wakes waiters even when openFn panics deep
+// in pool construction. Without the defer the slot stays populated with
+// an unclosed ready channel, so every later GetOrOpen(key) blocks on it
+// forever — and since every RPC routes through GetOrOpen, the resource
+// wedges until process restart.
+func TestTableCache_LoaderPanic_DoesNotWedgeKey(t *testing.T) {
+	clock := newFakeClock(time.Unix(1_700_000_000, 0))
+	c := NewTableCache(1*time.Hour, 1*time.Hour, clock.now)
+	t.Cleanup(c.Close)
+
+	// First load panics inside openFn (stands in for a nil deref /
+	// malformed proto anywhere in the buildLazyOpener chain).
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("expected openFn panic to propagate out of GetOrOpen")
+			}
+		}()
+		c.GetOrOpen("tbl:t", func() TableAPI { panic("boom in pool construction") })
+	}()
+
+	// The loading slot must be cleared, otherwise the next caller deadlocks.
+	c.mu.Lock()
+	nLoading := len(c.loading)
+	c.mu.Unlock()
+	if nLoading != 0 {
+		t.Fatalf("loading map has %d entries after panic, want 0 (leaked slot wedges future GetOrOpen)", nLoading)
+	}
+
+	// A subsequent open for the same key must succeed rather than block
+	// on the dead loadState's ready channel.
+	done := make(chan TableAPI, 1)
+	go func() { done <- c.GetOrOpen("tbl:t", openNoop("tbl:t")) }()
+	select {
+	case got := <-done:
+		if got == nil {
+			t.Fatal("GetOrOpen after panic returned nil, want a live handle")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetOrOpen after panic deadlocked — loader slot was not cleaned up")
+	}
+}

--- a/bigtable/internal/session/table_cache_test.go
+++ b/bigtable/internal/session/table_cache_test.go
@@ -539,16 +539,15 @@ func TestTableHandle_ConcurrentEvictAndReadRace(t *testing.T) {
 }
 
 // TestTableHandle_EvictionStormConvergesOnSingleInstalled pins the
-// invariant GetOrOpen actually guarantees: N concurrent post-eviction
-// RPCs may each invoke openFn (GetOrOpen is NOT single-flight on
-// openFn per line 205-207's doc), but the cache converges on EXACTLY
-// ONE installed successor, and every loser api gets Close()d. This is
-// the leak-avoidance invariant — without it, a storm would leak N-1
-// session pools under a single key.
-//
-// (Making openFn genuinely single-flight would be a real perf win but
-// is a separate feature — this test would need to tighten if that
-// ever lands.)
+// single-flight invariant GetOrOpen guarantees: N concurrent
+// post-eviction RPCs collapse onto ONE openFn call for the key (the
+// loader), every waiter blocks and observes that one installed
+// successor, and no throwaway pools are dialed. Without single-flight a
+// storm would dial N pools and Close N-1; with it the storm dials
+// exactly one successor. opens climbs above the initial only if a
+// successor is itself evicted mid-flight (not the case here), so we
+// assert the loose opens>=2 / closes==opens-1 shape that holds in both
+// the steady and the evicted-mid-flight cases.
 func TestTableHandle_EvictionStormConvergesOnSingleInstalled(t *testing.T) {
 	clock := newFakeClock(time.Unix(1_700_000_000, 0))
 	c := NewTableCache(1*time.Hour, 1*time.Hour, clock.now)
@@ -588,10 +587,11 @@ func TestTableHandle_EvictionStormConvergesOnSingleInstalled(t *testing.T) {
 		t.Errorf("cache.entries len = %d after storm, want 1 (one installed successor)", n)
 	}
 
-	// Every openFn call except the winner must have had its api closed
-	// by GetOrOpen's loser-close path. The initial h was also closed
-	// (the h.Close() above), so total closes == opens - 1 (one live
-	// installed successor).
+	// With single-flight, the only Close in a quiescent storm is the
+	// initial h (the h.Close() above); every successor open installs
+	// and stays live. If a successor were evicted mid-flight an extra
+	// open+close pair would appear, keeping closes == opens - 1 (one
+	// live installed successor) either way.
 	opensLoaded := opens.Load()
 	closesLoaded := closes.Load()
 	if opensLoaded < 2 {

--- a/bigtable/internal/session/table_test.go
+++ b/bigtable/internal/session/table_test.go
@@ -324,8 +324,8 @@ func TestMutationsAreRetryable_SessionHelper(t *testing.T) {
 // TestSessionTableMutateRow_IdempotencyFlowsToRetry verifies the
 // end-to-end plumbing from mutationsAreRetryable(req.GetMutations()) →
 // RetryingOptions.Idempotent → shouldRetryDefault at table.go:119,176.
-// The retry interceptor is configured with MaxAttempts=3 in dispatch
-// (Java parity), so an idempotent TransportFailure runs the full budget
+// The retry interceptor is configured with MaxAttempts=3 in dispatch,
+// so an idempotent TransportFailure runs the full budget
 // while a non-idempotent one fails after exactly one attempt. A regression that
 // hard-wired Idempotent: true (or broke mutationsAreRetryable) would
 // silently allow double-apply on non-idempotent Apply.
@@ -341,7 +341,7 @@ func TestSessionTableMutateRow_IdempotencyFlowsToRetry(t *testing.T) {
 		{
 			name:           "explicit_timestamp_idempotent_retries_full_budget",
 			muts:           []*btpb.Mutation{mutationSetCell(1_000_000)},
-			wantAttemptCap: 3, // MaxAttempts in session/table.go dispatch (Java parity)
+			wantAttemptCap: 3, // MaxAttempts in session/table.go dispatch
 		},
 		{
 			name:           "server_time_non_idempotent_stops_at_one_attempt",

--- a/bigtable/internal/session/table_test.go
+++ b/bigtable/internal/session/table_test.go
@@ -83,7 +83,7 @@ func newTestTable(t *testing.T, readInv, writeInv Invoker) (*sessionTable, *sdkm
 		"test-table",
 		openRead,
 		openWrite,
-		nil, // closeRead — fake pools don't back real releaseSessionPool
+		nil, // closeRead — fake pools don't back a real poolCloser
 		nil, // closeWrite
 		&btransport.VRpcDescriptorImpl{MethodName: "test.ReadRow"},
 		&btransport.VRpcDescriptorImpl{MethodName: "test.MutateRow"},
@@ -560,8 +560,8 @@ func TestSessionTable_Close_JoinsErrors(t *testing.T) {
 
 // TestSessionTable_Close_ReleasersIdempotent verifies a second Close
 // call still runs the release closures (they're idempotent at the
-// sessionClient layer — second releaseSessionPool call finds the
-// entry absent and no-ops). The point is that sessionTable.Close
+// sessionClient layer — the poolCloser behind each is single-shot, so a
+// second call no-ops). The point is that sessionTable.Close
 // itself does not gate on a once — the underlying release is where
 // idempotency lives.
 func TestSessionTable_Close_ReleasersIdempotent(t *testing.T) {


### PR DESCRIPTION
## Approach 2 of 2 — Java-shape single ownership + single-flight loading

Second of two alternative fixes for the cold-start burst bug where a session pool is `Close()`d and never reopens, leaving every op for the run returning `ErrPoolClosed`. (Approach 1, the localized `opened()`-gate + refcount patch, is #20366.)

### The bug

A pool was keyed only by `(resource, permission)`, so every `sessionTable` for the same resource shared one entry in `sessionPools`. Two independent races then closed a pool a live sibling still referenced:

- **Burst / loser-discard:** `TableCache.GetOrOpen` runs `openFn` for all concurrent missers and discards the losers via `api.Close()`. The loser's release closed the shared pool the winner had already memoized in its `lazyPool`.
- **Evict-then-reopen:** a TTL-evicted handle's self-heal resolves a fresh `sessionTable` that picks up the still-mapped pool during the delete-then-close window; the old handle's release then closes it out from under the new one.

Either way `lazyPool` memoizes the closed Invoker forever and there is no path to reopen → `ErrPoolClosed` for the rest of the run.

### The fix

Mirror the java-bigtable shape faithfully: the cache value solely owns its pool, and loads are single-flight. Two structural changes replace the shared-key registry.

**1. Single ownership.** Each `buildLazyOpener` invocation mints its OWN pool (no keyed dedup) and hands the pool's teardown to a per-owner `poolCloser`. `sessionTable.closeRead`/`closeWrite` are that owner's single-shot `Close`, so a table only ever closes the pool ITS opener created — by captured identity — never a sibling `sessionTable`'s pool that happens to share a `(resource, permission)`.

- `getOrCreateSessionPool`/`releaseSessionPool`/`buildLazyReleaser` are gone; `createSessionPool` always creates and returns an id-scoped releaser, and `releasePoolByID` tears down by id.
- `sessionPools` becomes an **id-keyed observational index** (sessionz snapshots, config-listener fanout, `Client.Close` close-all) rather than the ownership/dedup key. `poolKey` loses its nonce and survives only to label the OTel `session_name` metric and order snapshots.
- `poolCloser` also handles the Close-straddles-open race: if the table is torn down before the opener finishes wiring, `set()` closes the fresh pool on the spot instead of leaking it.

**2. Single-flight loading.** `TableCache.GetOrOpen` is now single-flight per key via a `loading` map + ready channel, matching Guava `LoadingCache`'s atomic single-load contract. A post-eviction RPC storm collapses onto one `openFn` call and installs exactly one successor pool instead of dialing N and discarding N-1. The closed-gate still releases a handle whose open straddled `cache.Close` (the interleaving that previously deadlocked a naive single-flight is handled by keeping the `loadState` separate from the always-complete `TableHandle`).

### Notes

- Supersedes the earlier nonce bolt-on, which kept the shared-key registry and left a dead dedup lookup — [@mutianf flagged](https://github.com/googleapis/google-cloud-go/pull/20368) that it wasn't the Java shape originally proposed.
- Test changes are in scope for this refactor: `releaseSessionPool` tests → id-based `releasePoolByID` tests; `buildLazyOpener` test gains the owner arg; the eviction-storm test's assertions are unchanged (they already tolerated single-flight) but its stale "NOT single-flight" / "loser-close" comments are corrected.
- `newSessionTable` / `lazyPool` signatures are unchanged. Full session suite passes under `-race`.
