### PR TITLE
feat(storage): add CalculateChecksum spans for upload writers

### DIFF
--- a/storage/grpc_writer.go
+++ b/storage/grpc_writer.go
@@ -60,7 +60,14 @@ func (w *gRPCWriter) Write(p []byte) (n int, err error) {
 			!w.sendCRC32C &&
 			!md5Provided &&
 			!w.append {
+			var chkCtx context.Context
+			if w.preRunCtx != nil && len(p) > 0 {
+				chkCtx, _ = startChecksumSpan(w.preRunCtx, "CRC32C")
+			}
 			w.fullObjectChecksum = crc32.Update(w.fullObjectChecksum, crc32cTable, p)
+			if chkCtx != nil {
+				endSpan(chkCtx, nil)
+			}
 		}
 		// write command successfully delivered to sender. We no longer own cmd.
 		break

--- a/storage/http_client.go
+++ b/storage/http_client.go
@@ -1094,6 +1094,7 @@ func (c *httpStorageClient) newRangeReaderJSON(ctx context.Context, params *newR
 // the checksum returned by the server.
 type httpInternalWriter struct {
 	*io.PipeWriter
+	ctx                context.Context
 	chunkSize          int
 	checksumDisabled   bool
 	fullObjectChecksum uint32
@@ -1115,7 +1116,14 @@ func (hiw *httpInternalWriter) validateChecksumFromServer() error {
 
 func (hiw *httpInternalWriter) Write(data []byte) (n int, err error) {
 	if !hiw.checksumDisabled && hiw.chunkSize == 0 {
+		var chkCtx context.Context
+		if hiw.ctx != nil && len(data) > 0 {
+			chkCtx, _ = startChecksumSpan(hiw.ctx, "CRC32C")
+		}
 		hiw.fullObjectChecksum = crc32.Update(hiw.fullObjectChecksum, crc32cTable, data)
+		if chkCtx != nil {
+			endSpan(chkCtx, nil)
+		}
 	}
 	return hiw.PipeWriter.Write(data)
 }
@@ -1250,6 +1258,7 @@ func (c *httpStorageClient) OpenWriter(params *openWriterParams, opts ...storage
 	}()
 	return &httpInternalWriter{
 		PipeWriter:         pw,
+		ctx:                params.ctx,
 		chunkSize:          params.chunkSize,
 		serverChecksumChan: serverChecksumChan,
 		checksumDisabled:   checksumDisabled,

--- a/storage/trace.go
+++ b/storage/trace.go
@@ -180,3 +180,14 @@ func getCommonAttributes() []attribute.KeyValue {
 func appendPackageName(spanName string) string {
 	return fmt.Sprintf("%s.%s", gcpClientArtifact, spanName)
 }
+
+// startChecksumSpan starts a T5 internal operation span for computing or verifying data checksums.
+func startChecksumSpan(ctx context.Context, checksumType string) (context.Context, trace.Span) {
+	if !isOTelTracingDevEnabled() {
+		return ctx, trace.SpanFromContext(ctx)
+	}
+	opts := []trace.SpanStartOption{
+		trace.WithAttributes(attribute.String("gcp.storage.checksum.type", checksumType)),
+	}
+	return startSpan(ctx, "Storage.CalculateChecksum", opts...)
+}

--- a/storage/trace_test.go
+++ b/storage/trace_test.go
@@ -17,7 +17,9 @@ package storage
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -349,4 +351,132 @@ func TestEndSpanEviction(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStartChecksumSpan(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	chkCtx, _ := startChecksumSpan(ctx, "CRC32C")
+	endSpan(chkCtx, nil)
+
+	spans := te.Spans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	gotSpan := spans[0]
+	if got, want := gotSpan.Name, "cloud.google.com/go/storage.Storage.CalculateChecksum"; got != want {
+		t.Errorf("got span name %q, want %q", got, want)
+	}
+	foundChecksumType := false
+	for _, a := range gotSpan.Attributes {
+		if string(a.Key) == "gcp.storage.checksum.type" {
+			foundChecksumType = true
+			if got, want := a.Value.AsString(), "CRC32C"; got != want {
+				t.Errorf("checksum type = %q, want %q", got, want)
+			}
+		}
+	}
+	if !foundChecksumType {
+		t.Errorf("gcp.storage.checksum.type attribute not found on span")
+	}
+}
+
+func TestChecksumSpanDevTracingDisabled(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "false")
+
+	chkCtx, span := startChecksumSpan(ctx, "CRC32C")
+	endSpan(chkCtx, nil)
+
+	if span.SpanContext().IsValid() {
+		t.Errorf("expected invalid span context when dev tracing is disabled, got %v", span.SpanContext())
+	}
+	spans := te.Spans()
+	if len(spans) > 0 {
+		t.Fatalf("expected 0 ended spans because dev tracing is disabled, but got %d ended spans: %v", len(spans), spans[0].Name)
+	}
+}
+
+func TestHTTPInternalWriterChecksumming(t *testing.T) {
+	t.Run("single-shot emits checksum span", func(t *testing.T) {
+		ctx := context.Background()
+		te := testutil.NewOpenTelemetryTestExporter()
+		t.Cleanup(func() {
+			te.Unregister(ctx)
+		})
+		t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+		pr, pw := io.Pipe()
+		defer pr.Close()
+		serverChecksumChan := make(chan uint32, 1)
+		close(serverChecksumChan)
+		hiw := &httpInternalWriter{
+			PipeWriter:         pw,
+			ctx:                ctx,
+			chunkSize:          0,
+			serverChecksumChan: serverChecksumChan,
+		}
+		go io.ReadAll(pr)
+
+		hiw.Write([]byte("some data"))
+		hiw.Close()
+
+		var foundChecksumSpan bool
+		for _, s := range te.Spans() {
+			if strings.HasSuffix(s.Name, "Storage.CalculateChecksum") {
+				foundChecksumSpan = true
+				foundChecksumType := false
+				for _, a := range s.Attributes {
+					if string(a.Key) == "gcp.storage.checksum.type" && a.Value.AsString() == "CRC32C" {
+						foundChecksumType = true
+					}
+				}
+				if !foundChecksumType {
+					t.Errorf("gcp.storage.checksum.type attribute missing or incorrect on span")
+				}
+			}
+		}
+		if !foundChecksumSpan {
+			t.Errorf("expected CalculateChecksum span for single-shot HTTP upload, got none")
+		}
+	})
+
+	t.Run("chunked skips checksum span", func(t *testing.T) {
+		ctx := context.Background()
+		te := testutil.NewOpenTelemetryTestExporter()
+		t.Cleanup(func() {
+			te.Unregister(ctx)
+		})
+		t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+		pr, pw := io.Pipe()
+		defer pr.Close()
+		serverChecksumChan := make(chan uint32, 1)
+		close(serverChecksumChan)
+		hiw := &httpInternalWriter{
+			PipeWriter:         pw,
+			ctx:                ctx,
+			chunkSize:          8 * 1024 * 1024,
+			serverChecksumChan: serverChecksumChan,
+		}
+		go io.ReadAll(pr)
+
+		hiw.Write([]byte("some data"))
+		hiw.Close()
+
+		for _, s := range te.Spans() {
+			if strings.HasSuffix(s.Name, "CalculateChecksum") {
+				t.Errorf("expected no CalculateChecksum span for chunked HTTP upload, got %s", s.Name)
+			}
+		}
+	})
 }


### PR DESCRIPTION
- Emits T5 `Storage.CalculateChecksum` spans during single-shot HTTP uploads when verifying client-side CRC against the server-returned CRC.
- Emits chunk `Storage.CalculateChecksum` spans during one-shot and resumable gRPC chunk writes.
- Includes unit test in `storage/trace_test.go`.
