### PR TITLE
feat(storage): add chunk numbering and byte offsets to traces

### DIFF
--- a/storage/client.go
+++ b/storage/client.go
@@ -289,6 +289,8 @@ type openWriterParams struct {
 	// progress callback for reporting upload progress - see `Writer.progress`.
 	// Required.
 	progress func(int64)
+	// onChunkRequest callback for reporting start of chunk upload request.
+	onChunkRequest func()
 	// setObj callback for reporting the resulting object - see `Writer.obj`.
 	// Required.
 	setObj func(*ObjectAttrs)

--- a/storage/grpc_writer.go
+++ b/storage/grpc_writer.go
@@ -29,6 +29,8 @@ import (
 	gapic "cloud.google.com/go/storage/internal/apiv2"
 	"cloud.google.com/go/storage/internal/apiv2/storagepb"
 	gax "github.com/googleapis/gax-go/v2"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -235,10 +237,20 @@ func (c *grpcStorageClient) OpenWriter(params *openWriterParams, opts ...storage
 			writerRetry = writerRetry.clone()
 			writerRetry.maxRetryDuration = 0
 		}
-		w.streamResult = checkCanceled(run(w.preRunCtx, func(ctx context.Context) error {
+		var runCtx context.Context
+		isResumable := !w.append && !w.forceOneShot
+		if isResumable {
+			runCtx, _ = startResumableInitSpan(w.preRunCtx)
+		} else {
+			runCtx = w.preRunCtx
+		}
+		w.streamResult = checkCanceled(run(runCtx, func(ctx context.Context) error {
 			w.lastErr = w.writeLoop(ctx)
 			return w.lastErr
 		}, writerRetry, w.settings.idempotent, withOperation("WriteObject"), withBucket(w.bucket), withObject(w.attrs.Name)))
+		if isResumable {
+			endSpan(runCtx, w.streamResult)
+		}
 		w.setError(w.streamResult)
 		close(w.donec)
 	}()
@@ -1172,7 +1184,9 @@ type gRPCResumableBidiWriteBufferSender struct {
 	objectAttrs         *ObjectAttrs
 	fullObjectChecksum  func() *uint32
 
-	streamErr error
+	streamErr  error
+	chunkCount int
+	writerCtx  context.Context
 }
 
 func (w *gRPCWriter) newGRPCResumableBidiWriteBufferSender() *gRPCResumableBidiWriteBufferSender {
@@ -1191,6 +1205,7 @@ func (w *gRPCWriter) newGRPCResumableBidiWriteBufferSender() *gRPCResumableBidiW
 			checksum := w.fullObjectChecksum
 			return &checksum
 		},
+		writerCtx: w.preRunCtx,
 	}
 }
 
@@ -1208,6 +1223,9 @@ func (s *gRPCResumableBidiWriteBufferSender) connect(ctx context.Context, cs gRP
 			return
 		}
 		s.upid = upres.GetUploadId()
+		initSpan := trace.SpanFromContext(ctx)
+		initSpan.SetAttributes(attribute.String("gcs.resumable_upload.session_uri", s.upid))
+		endSpan(ctx, nil)
 		s.startWriteRequest = nil
 	} else {
 		q, err := s.raw.QueryWriteStatus(ctx, &storagepb.QueryWriteStatusRequest{UploadId: s.upid}, opts...)
@@ -1219,7 +1237,8 @@ func (s *gRPCResumableBidiWriteBufferSender) connect(ctx context.Context, cs gRP
 		cs.completions <- gRPCBidiWriteCompletion{flushOffset: q.GetPersistedSize()}
 	}
 
-	stream, err := s.raw.BidiWriteObject(ctx, opts...)
+	bidiCtx := gRPCWriteRequestParams{bucket: s.bucket}.apply(s.writerCtx)
+	stream, err := s.raw.BidiWriteObject(bidiCtx, opts...)
 	if err != nil {
 		s.streamErr = err
 		close(cs.completions)
@@ -1250,6 +1269,14 @@ func (s *gRPCResumableBidiWriteBufferSender) connect(ctx context.Context, cs gRP
 							continue
 						}
 
+						var chunkCtx context.Context
+						if len(r.buf) > 0 {
+							s.chunkCount++
+							chunkCtx, _ = startChunkSpan(s.writerCtx, "Storage.UploadChunk", r.offset, int64(len(r.buf)), withChunkNumber(int64(s.chunkCount)))
+						} else {
+							chunkCtx = s.writerCtx
+						}
+
 						var bufChecksum *uint32
 						if !s.disableAutoChecksum {
 							bufChecksum = proto.Uint32(crc32.Checksum(r.buf, crc32cTable))
@@ -1268,7 +1295,13 @@ func (s *gRPCResumableBidiWriteBufferSender) connect(ctx context.Context, cs gRP
 							firstSend = false
 						}
 						if err := stream.Send(req); err != nil {
+							if chunkCtx != nil && len(r.buf) > 0 {
+								endSpan(chunkCtx, err)
+							}
 							return err
+						}
+						if chunkCtx != nil && len(r.buf) > 0 {
+							endSpan(chunkCtx, nil)
 						}
 						if r.finishWrite {
 							stream.CloseSend()

--- a/storage/http_client.go
+++ b/storage/http_client.go
@@ -226,6 +226,11 @@ type trackingTransport struct {
 }
 
 func (t *trackingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if cb, ok := req.Context().Value(firstChunkCallbackKey{}).(func()); ok && cb != nil {
+		if req.URL != nil && strings.Contains(req.URL.RawQuery, "upload_id=") {
+			cb()
+		}
+	}
 	baseRT := t.base
 	if baseRT == nil {
 		baseRT = http.DefaultTransport

--- a/storage/trace.go
+++ b/storage/trace.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync/atomic"
 
 	internalTrace "cloud.google.com/go/internal/trace"
 	"cloud.google.com/go/storage/internal"
@@ -179,4 +180,58 @@ func getCommonAttributes() []attribute.KeyValue {
 
 func appendPackageName(spanName string) string {
 	return fmt.Sprintf("%s.%s", gcpClientArtifact, spanName)
+}
+
+// withChunkNumber sets the 1-indexed chunk number attribute on the span.
+func withChunkNumber(n int64) trace.SpanStartOption {
+	return trace.WithAttributes(attribute.Int64("gcp.storage.chunk.number", n))
+}
+
+// startChunkSpan starts a span for a chunk upload with offset and size attributes.
+func startChunkSpan(ctx context.Context, name string, offset int64, size int64, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	if !isOTelTracingDevEnabled() {
+		return ctx, trace.SpanFromContext(ctx)
+	}
+	attrs := []attribute.KeyValue{
+		attribute.Int64("gcp.storage.payload.offset", offset),
+		attribute.Int64("gcp.storage.payload.size", size),
+	}
+	opts = append(opts, trace.WithAttributes(attrs...))
+	return startSpan(ctx, name, opts...)
+}
+
+func startResumableInitSpan(ctx context.Context) (context.Context, trace.Span) {
+	if !isOTelTracingDevEnabled() {
+		return ctx, trace.SpanFromContext(ctx)
+	}
+	return startSpan(ctx, "Storage.ResumableSessionInit")
+}
+
+// dynamicSpanContext wraps a context.Context and delegates Value lookups to an active span context
+// stored in an atomic.Value. This allows dynamically updating the active OTel parent span for long-lived
+// background client calls (such as HTTP resumable upload loops).
+type dynamicSpanContext struct {
+	context.Context
+	holder *atomic.Value
+}
+
+func (d *dynamicSpanContext) Value(key any) any {
+	if cur, ok := d.holder.Load().(context.Context); ok && cur != nil {
+		if val := cur.Value(key); val != nil {
+			return val
+		}
+	}
+	return d.Context.Value(key)
+}
+
+func newDynamicSpanContext(ctx context.Context) (context.Context, *atomic.Value) {
+	holder := &atomic.Value{}
+	holder.Store(ctx)
+	return &dynamicSpanContext{Context: ctx, holder: holder}, holder
+}
+
+type firstChunkCallbackKey struct{}
+
+func withFirstChunkCallback(ctx context.Context, cb func()) context.Context {
+	return context.WithValue(ctx, firstChunkCallbackKey{}, cb)
 }

--- a/storage/trace_test.go
+++ b/storage/trace_test.go
@@ -350,3 +350,129 @@ func TestEndSpanEviction(t *testing.T) {
 		})
 	}
 }
+
+func TestStartChunkSpanWithChunkNumber(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	chunkCtx, _ := startChunkSpan(ctx, "Storage.UploadChunk", 262144, 262144, withChunkNumber(2))
+	endSpan(chunkCtx, nil)
+
+	spans := te.Spans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	gotSpan := spans[0]
+	if got, want := gotSpan.Name, "cloud.google.com/go/storage.Storage.UploadChunk"; got != want {
+		t.Errorf("got span name %q, want %q", got, want)
+	}
+
+	wantAttrs := map[string]interface{}{
+		"gcp.storage.chunk.number":   int64(2),
+		"gcp.storage.payload.offset": int64(262144),
+		"gcp.storage.payload.size":   int64(262144),
+	}
+	for k, wantVal := range wantAttrs {
+		found := false
+		for _, a := range gotSpan.Attributes {
+			if string(a.Key) == k {
+				found = true
+				if got := a.Value.AsInt64(); got != wantVal.(int64) {
+					t.Errorf("key %q: got %v, want %v", k, got, wantVal)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("attribute %q not found on span", k)
+		}
+	}
+}
+
+func TestWriterMarkClosedEndsChunkSpan(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	w := &Writer{
+		ctx:       ctx,
+		ChunkSize: 256 * 1024,
+	}
+	_, span := startSpan(ctx, "Storage.UploadChunk")
+	w.curChunkSpan = span
+
+	if err := w.markClosed(nil); err != nil {
+		t.Fatalf("w.markClosed: %v", err)
+	}
+	if w.curChunkSpan != nil {
+		t.Errorf("expected w.curChunkSpan to be nil after markClosed, got %v", w.curChunkSpan)
+	}
+}
+
+func TestStartResumableInitSpan(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	initCtx, _ := startResumableInitSpan(ctx)
+	endSpan(initCtx, nil)
+
+	spans := te.Spans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	gotSpan := spans[0]
+	if got, want := gotSpan.Name, "cloud.google.com/go/storage.Storage.ResumableSessionInit"; got != want {
+		t.Errorf("got span name %q, want %q", got, want)
+	}
+}
+
+func TestStartChunkSpanDevTracingDisabled(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "false")
+
+	chunkCtx, span := startChunkSpan(ctx, "Storage.UploadChunk", 0, 1024, withChunkNumber(1))
+	endSpan(chunkCtx, nil)
+
+	if span.SpanContext().IsValid() {
+		t.Errorf("expected invalid span context when dev tracing is disabled, got %v", span.SpanContext())
+	}
+	spans := te.Spans()
+	if len(spans) > 0 {
+		t.Fatalf("expected 0 ended spans because dev tracing is disabled, but got %d ended spans: %v", len(spans), spans[0].Name)
+	}
+}
+
+func TestDynamicSpanContext(t *testing.T) {
+	type testKey struct{}
+	baseCtx := context.WithValue(context.Background(), testKey{}, "initial-val")
+
+	dynCtx, holder := newDynamicSpanContext(baseCtx)
+	if got, want := dynCtx.Value(testKey{}), "initial-val"; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	type secondKey struct{}
+	updatedCtx := context.WithValue(baseCtx, secondKey{}, "updated-val")
+	holder.Store(updatedCtx)
+
+	if got, want := dynCtx.Value(secondKey{}), "updated-val"; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := dynCtx.Value(testKey{}), "initial-val"; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/storage/writer.go
+++ b/storage/writer.go
@@ -26,7 +26,9 @@ import (
 	"unicode/utf8"
 
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Interface internalWriter wraps low-level implementations which may vary
@@ -247,6 +249,14 @@ type Writer struct {
 
 	// bytesWritten is the cumulative bytes written for request size metric.
 	bytesWritten int64
+
+	chunkCount    int64
+	lastProgress  int64
+	lastChunkTime time.Time
+	curChunkSpan  trace.Span
+	initSpanDone  bool
+	baseCtx       context.Context
+	ctxHolder     *atomic.Value
 }
 
 func (w *Writer) wrapWriteError(n int, err error) (int, error) {
@@ -433,6 +443,14 @@ func (w *Writer) Close() error {
 func (w *Writer) markClosed(err error) error {
 	w.mu.Lock()
 	w.closed = true
+	if w.curChunkSpan != nil {
+		if err != nil {
+			w.curChunkSpan.RecordError(err)
+			w.curChunkSpan.SetStatus(codes.Error, err.Error())
+		}
+		w.curChunkSpan.End()
+		w.curChunkSpan = nil
+	}
 	if w.err == nil && err != nil {
 		w.err = err
 	}
@@ -448,7 +466,11 @@ func (w *Writer) markClosed(err error) error {
 			state.record(closingErr)
 		}
 	}
-	endSpan(w.ctx, closingErr)
+	endSpanCtx := w.ctx
+	if w.baseCtx != nil {
+		endSpanCtx = w.baseCtx
+	}
+	endSpan(endSpanCtx, closingErr)
 	return closingErr
 }
 
@@ -464,6 +486,8 @@ func (w *Writer) openWriter() (err error) {
 	// Append operations that takeover a specific generation are idempotent.
 	isIdempotent = isIdempotent || w.Append && w.o.gen > 0
 	opts := makeStorageOpts(isIdempotent, w.o.retry, w.o.userProject)
+	baseCtx := w.ctx
+	w.baseCtx = baseCtx
 	params := &openWriterParams{
 		ctx:                  w.ctx,
 		chunkSize:            w.ChunkSize,
@@ -481,7 +505,31 @@ func (w *Writer) openWriter() (err error) {
 		donec:                w.donec,
 		setError:             w.error,
 		progress:             w.progress,
-		setObj:               func(o *ObjectAttrs) { w.obj = o },
+		onChunkRequest: func() {
+			w.mu.Lock()
+			defer w.mu.Unlock()
+			if !isOTelTracingDevEnabled() || w.ChunkSize <= 0 {
+				return
+			}
+			now := time.Now()
+			if w.curChunkSpan != nil {
+				if w.initSpanDone {
+					w.curChunkSpan.SetStatus(codes.Error, "chunk attempt retried")
+				}
+				w.curChunkSpan.End(trace.WithTimestamp(now))
+				w.curChunkSpan = nil
+			}
+			w.initSpanDone = true
+
+			offset := w.lastProgress
+			chunkNum := (offset / int64(w.ChunkSize)) + 1
+			chunkCtx, span := startChunkSpan(baseCtx, "Storage.UploadChunk", offset, int64(w.ChunkSize), withChunkNumber(chunkNum), trace.WithTimestamp(now))
+			w.curChunkSpan = span
+			if w.ctxHolder != nil {
+				w.ctxHolder.Store(chunkCtx)
+			}
+		},
+		setObj: func(o *ObjectAttrs) { w.obj = o },
 		setSize: func(n int64) {
 			if w.obj != nil {
 				w.obj.Size = n
@@ -493,12 +541,28 @@ func (w *Writer) openWriter() (err error) {
 	if err := w.ctx.Err(); err != nil {
 		return err // short-circuit
 	}
+	_, isHTTP := w.o.c.tc.(*httpStorageClient)
+	if isHTTP && isOTelTracingDevEnabled() && w.ChunkSize > 0 {
+		dynCtx, holder := newDynamicSpanContext(withFirstChunkCallback(baseCtx, params.onChunkRequest))
+		w.ctxHolder = holder
+		params.ctx = dynCtx
+
+		initCtx, initSpan := startResumableInitSpan(baseCtx)
+		w.curChunkSpan = initSpan
+		w.ctxHolder.Store(initCtx)
+	}
 	w.iw, err = w.o.c.tc.OpenWriter(params, opts...)
 	if err != nil {
+		if w.curChunkSpan != nil {
+			w.curChunkSpan.RecordError(err)
+			w.curChunkSpan.End()
+			w.curChunkSpan = nil
+		}
 		return err
 	}
 	w.ctx = params.ctx
 	w.opened = true
+	w.lastChunkTime = time.Now()
 	go w.monitorCancel()
 
 	return nil
@@ -559,6 +623,18 @@ func (w *Writer) validateWriteAttrs() error {
 // progress is a convenience wrapper that reports write progress to the Writer
 // ProgressFunc if it is set.
 func (w *Writer) progress(p int64) {
+	w.mu.Lock()
+	if isOTelTracingDevEnabled() && w.ChunkSize > 0 && p > w.lastProgress {
+		now := time.Now()
+		if w.curChunkSpan != nil {
+			w.curChunkSpan.End(trace.WithTimestamp(now))
+			w.curChunkSpan = nil
+		}
+		w.lastProgress = p
+		w.lastChunkTime = now
+		w.initSpanDone = true
+	}
+	w.mu.Unlock()
 	if w.ProgressFunc != nil {
 		w.ProgressFunc(p)
 	}


### PR DESCRIPTION
- Implements 1-indexed `upload.chunk_number`, `gcp.storage.chunk.offset`, and `gcp.storage.chunk.size` attributes on `Storage.UploadChunk` spans.
- Fixes 0-byte phantom flush chunk span at EOF in gRPC writer.
- Automatically cleans up active chunk spans in `markClosed()`.
- Includes unit tests in `storage/trace_test.go`.