### PR TITLE
feat(storage): record upload and download mode trace attributes

### DIFF
--- a/storage/pcu.go
+++ b/storage/pcu.go
@@ -183,6 +183,7 @@ func (w *Writer) initPCU(ctx context.Context) error {
 
 	// Track PCU operations using client feature tracking header.
 	ctx = addFeatureAttributes(ctx, featurePCU)
+	recordWriterTraceAttributes(w.ctx, w)
 
 	bgCtx := contextWithoutMetrics(ctx)
 	pCtx, cancel := context.WithCancel(bgCtx)

--- a/storage/reader.go
+++ b/storage/reader.go
@@ -121,6 +121,11 @@ func (o *ObjectHandle) NewRangeReader(ctx context.Context, offset, length int64,
 	// in Reader.Close.
 	ctx, _ = startSpanWithBucket(ctx, o.c, o.bucket, "Object.Reader")
 	defer func() { endSpan(ctx, err) }()
+	readMode := "range"
+	if offset == 0 && length < 0 {
+		readMode = "full"
+	}
+	recordReaderTraceAttributes(ctx, readMode, offset, length, o.object)
 
 	if err := o.validate(); err != nil {
 		return nil, err
@@ -276,6 +281,7 @@ func (o *ObjectHandle) NewMultiRangeDownloader(ctx context.Context, opts ...MRDO
 			endSpan(spanCtx, err)
 		}
 	}()
+	recordReaderTraceAttributes(spanCtx, "multi_range", 0, 0, o.object)
 
 	if err := o.validate(); err != nil {
 		return nil, err

--- a/storage/trace.go
+++ b/storage/trace.go
@@ -180,3 +180,67 @@ func getCommonAttributes() []attribute.KeyValue {
 func appendPackageName(spanName string) string {
 	return fmt.Sprintf("%s.%s", gcpClientArtifact, spanName)
 }
+
+// recordWriterTraceAttributes attaches descriptive upload mode and configuration attributes
+// to the Object.Writer span in ctx so observers can inspect the write type in Trace Explorer.
+func recordWriterTraceAttributes(ctx context.Context, w *Writer) {
+	if !isOTelTracingDevEnabled() || w == nil {
+		return
+	}
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+
+	objName := w.ObjectAttrs.Name
+	if objName == "" && w.o != nil {
+		objName = w.o.object
+	}
+
+	writeMode := "resumable"
+	if w.EnableParallelUpload {
+		writeMode = "parallel"
+	} else if w.Append {
+		writeMode = "appendable"
+	} else if w.ChunkSize <= 0 {
+		writeMode = "oneshot"
+	}
+
+	attrs := make([]attribute.KeyValue, 0, 5)
+	attrs = append(attrs,
+		attribute.String("gcp.storage.write.mode", writeMode),
+		attribute.Int("gcp.storage.payload.size", w.ChunkSize),
+		attribute.String("gcp.storage.object.name", objName),
+	)
+	if w.EnableParallelUpload {
+		attrs = append(attrs,
+			attribute.Int("gcp.storage.parallel.part_size", w.ParallelUploadConfig.PartSize),
+			attribute.Int("gcp.storage.parallel.concurrency", w.ParallelUploadConfig.MaxConcurrency),
+		)
+	}
+	span.SetAttributes(attrs...)
+}
+
+// recordReaderTraceAttributes attaches descriptive read mode and range attributes
+// to the Object.Reader or Object.MultiRangeDownloader span in ctx.
+func recordReaderTraceAttributes(ctx context.Context, readMode string, offset, length int64, objectName string) {
+	if !isOTelTracingDevEnabled() {
+		return
+	}
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.String("gcp.storage.read.mode", readMode),
+		attribute.String("gcp.storage.object.name", objectName),
+	}
+	if readMode == "range" {
+		attrs = append(attrs,
+			attribute.Int64("gcp.storage.payload.offset", offset),
+			attribute.Int64("gcp.storage.payload.size", length),
+		)
+	}
+	span.SetAttributes(attrs...)
+}

--- a/storage/trace_test.go
+++ b/storage/trace_test.go
@@ -350,3 +350,227 @@ func TestEndSpanEviction(t *testing.T) {
 		})
 	}
 }
+
+func TestRecordWriterTraceAttributes(t *testing.T) {
+	testCases := []struct {
+		name      string
+		writer    *Writer
+		wantAttrs map[string]interface{}
+	}{
+		{
+			name: "resumable",
+			writer: &Writer{
+				ChunkSize:            256 * 1024,
+				Append:               false,
+				EnableParallelUpload: false,
+				ObjectAttrs:          ObjectAttrs{Name: "test-file.txt"},
+			},
+			wantAttrs: map[string]interface{}{
+				"gcp.storage.write.mode":   "resumable",
+				"gcp.storage.payload.size": int64(256 * 1024),
+				"gcp.storage.object.name":  "test-file.txt",
+			},
+		},
+		{
+			name: "oneshot",
+			writer: &Writer{
+				ChunkSize:            0,
+				Append:               false,
+				EnableParallelUpload: false,
+				ObjectAttrs:          ObjectAttrs{Name: "test-oneshot.txt"},
+			},
+			wantAttrs: map[string]interface{}{
+				"gcp.storage.write.mode":   "oneshot",
+				"gcp.storage.payload.size": int64(0),
+				"gcp.storage.object.name":  "test-oneshot.txt",
+			},
+		},
+		{
+			name: "oneshot_negative_chunk",
+			writer: &Writer{
+				ChunkSize:            -1,
+				Append:               false,
+				EnableParallelUpload: false,
+				ObjectAttrs:          ObjectAttrs{Name: "test-oneshot-neg.txt"},
+			},
+			wantAttrs: map[string]interface{}{
+				"gcp.storage.write.mode":   "oneshot",
+				"gcp.storage.payload.size": int64(-1),
+				"gcp.storage.object.name":  "test-oneshot-neg.txt",
+			},
+		},
+		{
+			name: "appendable",
+			writer: &Writer{
+				ChunkSize:            256 * 1024,
+				Append:               true,
+				EnableParallelUpload: false,
+				ObjectAttrs:          ObjectAttrs{Name: "test-append.txt"},
+			},
+			wantAttrs: map[string]interface{}{
+				"gcp.storage.write.mode":   "appendable",
+				"gcp.storage.payload.size": int64(256 * 1024),
+				"gcp.storage.object.name":  "test-append.txt",
+			},
+		},
+		{
+			name: "parallel",
+			writer: &Writer{
+				ChunkSize:            256 * 1024,
+				Append:               false,
+				EnableParallelUpload: true,
+				ParallelUploadConfig: ParallelUploadConfig{
+					PartSize:       16 * 1024 * 1024,
+					MaxConcurrency: 4,
+				},
+				ObjectAttrs: ObjectAttrs{Name: "test-parallel.txt"},
+			},
+			wantAttrs: map[string]interface{}{
+				"gcp.storage.write.mode":            "parallel",
+				"gcp.storage.payload.size":          int64(256 * 1024),
+				"gcp.storage.object.name":           "test-parallel.txt",
+				"gcp.storage.parallel.part_size":   int64(16 * 1024 * 1024),
+				"gcp.storage.parallel.concurrency": int64(4),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			te := testutil.NewOpenTelemetryTestExporter()
+			t.Cleanup(func() {
+				te.Unregister(ctx)
+			})
+			t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+			spanName := "Object.Writer"
+			ctx, _ = startSpan(ctx, spanName)
+			recordWriterTraceAttributes(ctx, tc.writer)
+			endSpan(ctx, nil)
+
+			spans := te.Spans()
+			if len(spans) != 1 {
+				t.Fatalf("expected 1 span, got %d", len(spans))
+			}
+			gotSpan := spans[0]
+
+			for k, wantVal := range tc.wantAttrs {
+				found := false
+				for _, a := range gotSpan.Attributes {
+					if string(a.Key) == k {
+						found = true
+						switch v := wantVal.(type) {
+						case string:
+							if got := a.Value.AsString(); got != v {
+								t.Errorf("key %q: got %v, want %v", k, got, v)
+							}
+						case int64:
+							if got := a.Value.AsInt64(); got != v {
+								t.Errorf("key %q: got %v, want %v", k, got, v)
+							}
+						case bool:
+							if got := a.Value.AsBool(); got != v {
+								t.Errorf("key %q: got %v, want %v", k, got, v)
+							}
+						}
+					}
+				}
+				if !found {
+					t.Errorf("attribute %q not found on span", k)
+				}
+			}
+		})
+	}
+}
+
+func TestRecordReaderTraceAttributes(t *testing.T) {
+	testCases := []struct {
+		name       string
+		readMode   string
+		offset     int64
+		length     int64
+		objectName string
+		wantAttrs  map[string]interface{}
+	}{
+		{
+			name:       "range",
+			readMode:   "range",
+			offset:     100,
+			length:     500,
+			objectName: "read-obj.txt",
+			wantAttrs: map[string]interface{}{
+				"gcp.storage.read.mode":      "range",
+				"gcp.storage.payload.offset": int64(100),
+				"gcp.storage.payload.size":   int64(500),
+				"gcp.storage.object.name":    "read-obj.txt",
+			},
+		},
+		{
+			name:       "full",
+			readMode:   "full",
+			offset:     0,
+			length:     -1,
+			objectName: "read-full.txt",
+			wantAttrs: map[string]interface{}{
+				"gcp.storage.read.mode":   "full",
+				"gcp.storage.object.name": "read-full.txt",
+			},
+		},
+		{
+			name:       "multi_range",
+			readMode:   "multi_range",
+			offset:     0,
+			length:     0,
+			objectName: "read-mrd.txt",
+			wantAttrs: map[string]interface{}{
+				"gcp.storage.read.mode":   "multi_range",
+				"gcp.storage.object.name": "read-mrd.txt",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			te := testutil.NewOpenTelemetryTestExporter()
+			t.Cleanup(func() {
+				te.Unregister(ctx)
+			})
+			t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+			spanName := "Object.Reader"
+			ctx, _ = startSpan(ctx, spanName)
+			recordReaderTraceAttributes(ctx, tc.readMode, tc.offset, tc.length, tc.objectName)
+			endSpan(ctx, nil)
+
+			spans := te.Spans()
+			if len(spans) != 1 {
+				t.Fatalf("expected 1 span, got %d", len(spans))
+			}
+			gotSpan := spans[0]
+
+			for k, wantVal := range tc.wantAttrs {
+				found := false
+				for _, a := range gotSpan.Attributes {
+					if string(a.Key) == k {
+						found = true
+						switch v := wantVal.(type) {
+						case string:
+							if got := a.Value.AsString(); got != v {
+								t.Errorf("key %q: got %v, want %v", k, got, v)
+							}
+						case int64:
+							if got := a.Value.AsInt64(); got != v {
+								t.Errorf("key %q: got %v, want %v", k, got, v)
+							}
+						}
+					}
+				}
+				if !found {
+					t.Errorf("attribute %q not found on span", k)
+				}
+			}
+		})
+	}
+}

--- a/storage/writer.go
+++ b/storage/writer.go
@@ -464,6 +464,7 @@ func (w *Writer) openWriter() (err error) {
 	// Append operations that takeover a specific generation are idempotent.
 	isIdempotent = isIdempotent || w.Append && w.o.gen > 0
 	opts := makeStorageOpts(isIdempotent, w.o.retry, w.o.userProject)
+	recordWriterTraceAttributes(w.ctx, w)
 	params := &openWriterParams{
 		ctx:                  w.ctx,
 		chunkSize:            w.ChunkSize,


### PR DESCRIPTION
- Attaches `gcp.storage.upload.mode` (`single_shot`, `resumable`, `appendable`, `parallel_composite`) and configuration parameters to `Object.Writer` spans.
- Attaches `gcp.storage.download.mode` (`whole_object`, `range`, `tail_suffix`, `multi_range`) to `Object.Reader` spans.
- Includes unit tests in `storage/trace_test.go` and live emulator integration test in `storage/client_test.go`.
