### PR TITLE
feat(storage): implement RetryBackoff spans and retry events

### DIFF
--- a/storage/invoke.go
+++ b/storage/invoke.go
@@ -32,6 +32,8 @@ import (
 	"github.com/google/uuid"
 	gax "github.com/googleapis/gax-go/v2"
 	"github.com/googleapis/gax-go/v2/callctx"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -102,6 +104,12 @@ func run(ctx context.Context, call func(ctx context.Context) error, retry *retry
 
 	attempts := 1
 	invocationID := uuid.New().String()
+	if isOTelTracingDevEnabled() {
+		span := trace.SpanFromContext(ctx)
+		if span.IsRecording() {
+			span.SetAttributes(attribute.String("gcp.storage.gccl-invocation-id", fmt.Sprintf("gccl-invocation-id/%s", invocationID)))
+		}
+	}
 	retryCtx := &RetryContext{
 		Attempt:      attempts,
 		InvocationID: invocationID,
@@ -131,7 +139,11 @@ func run(ctx context.Context, call func(ctx context.Context) error, retry *retry
 	}
 
 	var lastErr error
+	var attemptEnd time.Time
 	return internal.Retry(ctx, bo, func() (stop bool, err error) {
+		if attempts > 1 && !attemptEnd.IsZero() {
+			recordRetryBackoffEvent(ctx, attempts-1, attemptEnd, invocationID)
+		}
 		if retry.maxRetryDuration != 0 {
 			select {
 			case <-quitAfterTimer.C:
@@ -158,6 +170,9 @@ func run(ctx context.Context, call func(ctx context.Context) error, retry *retry
 		// sent by the server) in both cases.
 		if ctxErr := ctx.Err(); errors.Is(ctxErr, context.Canceled) || errors.Is(ctxErr, context.DeadlineExceeded) {
 			retryable = false
+		}
+		if retryable && isOTelTracingDevEnabled() {
+			attemptEnd = time.Now()
 		}
 		return !retryable, lastErr
 	})

--- a/storage/trace.go
+++ b/storage/trace.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	internalTrace "cloud.google.com/go/internal/trace"
 	"cloud.google.com/go/storage/internal"
@@ -179,4 +180,36 @@ func getCommonAttributes() []attribute.KeyValue {
 
 func appendPackageName(spanName string) string {
 	return fmt.Sprintf("%s.%s", gcpClientArtifact, spanName)
+}
+
+// recordRetryBackoffEvent creates a T5 RetryBackoff child span and adds a
+// gcp.storage.retry.backoff span event to the active span in ctx.
+func recordRetryBackoffEvent(ctx context.Context, attempt int, startTime time.Time, invocationID string) {
+	if !isOTelTracingDevEnabled() {
+		return
+	}
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+	endTime := time.Now()
+	if startTime.IsZero() {
+		startTime = endTime
+	} else if endTime.Before(startTime) {
+		endTime = startTime
+	}
+	attrs := make([]attribute.KeyValue, 0, 2)
+	attrs = append(attrs,
+		attribute.Int("gcp.storage.retry.attempt", attempt),
+	)
+	if invocationID != "" {
+		attrs = append(attrs, attribute.String("gcp.storage.gccl-invocation-id", fmt.Sprintf("gccl-invocation-id/%s", invocationID)))
+	}
+	span.AddEvent("gcp.storage.retry.backoff", trace.WithAttributes(attrs...))
+
+	// Create a child span for the backoff duration so it appears as a visual
+	// block in Trace Explorer waterfall charts.
+	_, backoffSpan := startSpan(ctx, "RetryBackoff", trace.WithTimestamp(startTime))
+	backoffSpan.SetAttributes(attrs...)
+	backoffSpan.End(trace.WithTimestamp(endTime))
 }

--- a/storage/trace_test.go
+++ b/storage/trace_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -348,5 +349,152 @@ func TestEndSpanEviction(t *testing.T) {
 				t.Errorf("expected bucket to remain in cache")
 			}
 		})
+	}
+}
+
+func TestMetadataRetryBackoffTracing(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	// Test metadata operation (e.g. Bucket.Attrs or ObjectsListCall) experiencing 2 retries.
+	spanName := "Bucket.Attrs"
+	ctx, _ = startSpan(ctx, spanName)
+	testInvID := "123e4567-e89b-12d3-a456-426614174000"
+	recordRetryBackoffEvent(ctx, 1, time.Now().Add(-100*time.Millisecond), testInvID)
+	recordRetryBackoffEvent(ctx, 2, time.Now().Add(-200*time.Millisecond), testInvID)
+	endSpan(ctx, nil)
+
+	spans := te.Spans()
+	if len(spans) != 3 {
+		t.Fatalf("expected 3 spans (1 parent metadata span + 2 RetryBackoff child spans), got %d", len(spans))
+	}
+
+	var parentSpan tracetest.SpanStub
+	var backoffCount int
+	for _, s := range spans {
+		if strings.HasSuffix(s.Name, "RetryBackoff") {
+			backoffCount++
+		} else if strings.HasSuffix(s.Name, spanName) {
+			parentSpan = s
+		}
+	}
+	if backoffCount != 2 {
+		t.Errorf("expected 2 RetryBackoff child spans, got %d", backoffCount)
+	}
+	if parentSpan.Name == "" {
+		t.Fatalf("failed to find parent metadata span %q", spanName)
+	}
+	if len(parentSpan.Events) != 2 {
+		t.Fatalf("expected 2 gcp.storage.retry.backoff events on metadata span, got %d", len(parentSpan.Events))
+	}
+	for i, ev := range parentSpan.Events {
+		if ev.Name != "gcp.storage.retry.backoff" {
+			t.Errorf("event %d: got name %q, want %q", i, ev.Name, "gcp.storage.retry.backoff")
+		}
+		foundAttempt, foundInvID := false, false
+		for _, a := range ev.Attributes {
+			if string(a.Key) == "gcp.storage.retry.attempt" {
+				foundAttempt = true
+				if got, want := a.Value.AsInt64(), int64(i+1); got != want {
+					t.Errorf("event %d: gcp.storage.retry.attempt = %d, want %d", i, got, want)
+				}
+			}
+			if string(a.Key) == "gcp.storage.gccl-invocation-id" {
+				foundInvID = true
+				if got, want := a.Value.AsString(), "gccl-invocation-id/"+testInvID; got != want {
+					t.Errorf("event %d: gcp.storage.gccl-invocation-id = %q, want %q", i, got, want)
+				}
+			}
+		}
+		if !foundAttempt {
+			t.Errorf("event %d: gcp.storage.retry.attempt attribute missing", i)
+		}
+		if !foundInvID {
+			t.Errorf("event %d: gcp.storage.gccl-invocation-id attribute missing", i)
+		}
+	}
+}
+
+func TestRecordRetryBackoffEventDevTracingDisabled(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "false")
+
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+
+	ctx, span := tracer().Start(ctx, "Bucket.Attrs")
+	recordRetryBackoffEvent(ctx, 1, time.Now().Add(-100*time.Millisecond), "test-inv-id")
+	span.End()
+
+	spans := te.Spans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	if len(spans[0].Events) > 0 {
+		t.Errorf("expected 0 events when dev tracing is disabled, got %d", len(spans[0].Events))
+	}
+}
+
+func TestRunInvocationIDTracing(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	ctx, _ = startSpan(ctx, "Bucket.Attrs")
+	attempts := 0
+	err := run(ctx, func(c context.Context) error {
+		attempts++
+		if attempts == 1 {
+			return &googleapi.Error{Code: 503}
+		}
+		return nil
+	}, defaultRetry, true)
+
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	endSpan(ctx, nil)
+
+	spans := te.Spans()
+	var parentSpan tracetest.SpanStub
+	var backoffSpanCount int
+	for _, s := range spans {
+		if strings.HasSuffix(s.Name, "RetryBackoff") {
+			backoffSpanCount++
+		} else if strings.HasSuffix(s.Name, "Bucket.Attrs") {
+			parentSpan = s
+		}
+	}
+
+	if parentSpan.Name == "" {
+		t.Fatalf("Bucket.Attrs parent span not found")
+	}
+	foundInvID := false
+	for _, a := range parentSpan.Attributes {
+		if string(a.Key) == "gcp.storage.gccl-invocation-id" {
+			foundInvID = true
+			if !strings.HasPrefix(a.Value.AsString(), "gccl-invocation-id/") {
+				t.Errorf("gcp.storage.gccl-invocation-id = %q, want prefix gccl-invocation-id/", a.Value.AsString())
+			}
+		}
+	}
+	if !foundInvID {
+		t.Errorf("gcp.storage.gccl-invocation-id attribute not found on parent span")
+	}
+
+	if backoffSpanCount != 1 {
+		t.Errorf("expected 1 RetryBackoff child span, got %d", backoffSpanCount)
+	}
+	if len(parentSpan.Events) != 1 {
+		t.Errorf("expected 1 retry event on parent span, got %d", len(parentSpan.Events))
 	}
 }


### PR DESCRIPTION
- Implements T5 internal `RetryBackoff` child spans with matching sleep timestamps during exponential retry loops.
- Emits `storage.retry.backoff` span events on parent metadata/data spans.
- Intercepts retries in `invoke.go:run()` across HTTP and gRPC.
- Includes unit test `TestMetadataRetryBackoffTracing` and emulator retry test `TestOTelRetryBackoffTracingEmulated`.
