### PR TITLE
feat(storage): add OpenTelemetry tracing for OAuth2 token source

### DIFF
--- a/storage/trace.go
+++ b/storage/trace.go
@@ -28,6 +28,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	otelcodes "go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/oauth2"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -179,4 +180,29 @@ func getCommonAttributes() []attribute.KeyValue {
 
 func appendPackageName(spanName string) string {
 	return fmt.Sprintf("%s.%s", gcpClientArtifact, spanName)
+}
+
+// TracedTokenSource wraps an oauth2.TokenSource to record T5 Auth.RefreshAccessToken
+// internal operation spans whenever an access token is fetched or refreshed.
+type TracedTokenSource struct {
+	base oauth2.TokenSource
+}
+
+// NewTracedTokenSource wraps an existing oauth2.TokenSource with OpenTelemetry T5 Auth tracing.
+func NewTracedTokenSource(base oauth2.TokenSource) oauth2.TokenSource {
+	if base == nil {
+		return nil
+	}
+	return &TracedTokenSource{base: base}
+}
+
+// Token fetches or refreshes an access token while recording a T5 Auth.RefreshAccessToken span.
+func (t *TracedTokenSource) Token() (*oauth2.Token, error) {
+	if !isOTelTracingDevEnabled() {
+		return t.base.Token()
+	}
+	ctx, _ := startSpan(context.Background(), "Auth.RefreshAccessToken")
+	tok, err := t.base.Token()
+	endSpan(ctx, err)
+	return tok, err
 }

--- a/storage/trace_test.go
+++ b/storage/trace_test.go
@@ -29,6 +29,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/oauth2"
 	"google.golang.org/api/googleapi"
 )
 
@@ -348,5 +349,99 @@ func TestEndSpanEviction(t *testing.T) {
 				t.Errorf("expected bucket to remain in cache")
 			}
 		})
+	}
+}
+
+type staticTokenSource struct {
+	token *oauth2.Token
+	err   error
+}
+
+func (s *staticTokenSource) Token() (*oauth2.Token, error) {
+	return s.token, s.err
+}
+
+func TestTracedTokenSourceSpan(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	rawTS := &staticTokenSource{token: &oauth2.Token{AccessToken: "fake-token"}}
+	tts := NewTracedTokenSource(rawTS)
+
+	tok, err := tts.Token()
+	if err != nil {
+		t.Fatalf("tts.Token: %v", err)
+	}
+	if tok.AccessToken != "fake-token" {
+		t.Fatalf("got access token %q, want %q", tok.AccessToken, "fake-token")
+	}
+
+	spans := te.Spans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	if got, want := spans[0].Name, "cloud.google.com/go/storage.Auth.RefreshAccessToken"; got != want {
+		t.Errorf("got span name %q, want %q", got, want)
+	}
+}
+
+func TestTracedTokenSourceNilBase(t *testing.T) {
+	if got := NewTracedTokenSource(nil); got != nil {
+		t.Errorf("NewTracedTokenSource(nil) = %v, want nil", got)
+	}
+}
+
+func TestTracedTokenSourceError(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	testErr := fmt.Errorf("oauth2: token expired")
+	rawTS := &staticTokenSource{err: testErr}
+	tts := NewTracedTokenSource(rawTS)
+
+	_, err := tts.Token()
+	if err == nil {
+		t.Fatalf("expected error from tts.Token, got nil")
+	}
+
+	spans := te.Spans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	if spans[0].Status.Code != otcodes.Error {
+		t.Errorf("got span status code %v, want %v", spans[0].Status.Code, otcodes.Error)
+	}
+}
+
+func TestTracedTokenSourceDevTracingDisabled(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "false")
+
+	rawTS := &staticTokenSource{token: &oauth2.Token{AccessToken: "fake-token"}}
+	tts := NewTracedTokenSource(rawTS)
+
+	tok, err := tts.Token()
+	if err != nil {
+		t.Fatalf("tts.Token: %v", err)
+	}
+	if tok.AccessToken != "fake-token" {
+		t.Fatalf("got access token %q, want %q", tok.AccessToken, "fake-token")
+	}
+
+	spans := te.Spans()
+	if len(spans) > 0 {
+		t.Fatalf("expected 0 spans when dev tracing is disabled, got %d", len(spans))
 	}
 }


### PR DESCRIPTION
## Description

This PR introduces OpenTelemetry tracing support for authentication token refreshes (`Auth.RefreshAccessToken`) to fulfill the T5 internal operations telemetry specification for the Google Cloud Storage Go client.

### Background & Architectural Context
In the Go Cloud SDKs, default credential resolution (Application Default Credentials) and background token lifecycle management are handled deep within the shared transport layer (`google.golang.org/api/transport` and `cloud.google.com/go/auth`).

To provide `Auth.RefreshAccessToken` span recording within the `storage` module without modifying upstream shared transport dependencies, this PR introduces `TracedTokenSource` as a non-intrusive decorator around `oauth2.TokenSource`.

### Includes unit test `TestTracedTokenSourceSpan` in `storage/trace_test.go`.

### Usage Example
Callers or integrations supplying a custom `oauth2.TokenSource` can wrap it with `NewTracedTokenSource`:

```go
ts := storage.NewTracedTokenSource(customTokenSource)
client, err := storage.NewClient(ctx, option.WithTokenSource(ts))


