### PR TITLE
fix(storage): prevent panic when MultiRangeDownloader callback is nil

### DIFF
--- a/storage/grpc_reader_multi_range.go
+++ b/storage/grpc_reader_multi_range.go
@@ -519,6 +519,9 @@ func (m *multiRangeDownloaderManager) getSpanCtx() context.Context {
 }
 
 func (m *multiRangeDownloaderManager) runCallback(origOffset, numBytes int64, err error, cb func(int64, int64, error)) {
+	if cb == nil {
+		return
+	}
 	m.callbackWg.Add(1)
 	go func() {
 		defer m.callbackWg.Done()

--- a/storage/reader_test.go
+++ b/storage/reader_test.go
@@ -852,3 +852,10 @@ func TestHTTPReaderMidStreamRetryCRC(t *testing.T) {
 		}
 	}, option.WithHTTPClient(hc))
 }
+
+func TestMRDRunCallbackNilGuard(t *testing.T) {
+	m := &multiRangeDownloaderManager{}
+	// Calling runCallback with a nil callback should safely return without panicking.
+	m.runCallback(0, 100, nil, nil)
+	m.callbackWg.Wait()
+}


### PR DESCRIPTION
- Adds nil callback check in `multiRangeDownloaderManager.runCallback()` to prevent SIGSEGV panics when callers invoke `mrd.Add()` without providing a callback.
- Includes unit test `TestMRDRunCallbackNilGuard` in `storage/reader_test.go`.
