### PR TITLE
feat(storage): add CalculateChecksum spans and deduplicate CRCs for r…

### DIFF
--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -1488,6 +1488,7 @@ func (c *grpcStorageClient) NewRangeReader(ctx context.Context, params *newRange
 		},
 		objectMetadata: &metadata,
 		reader: &gRPCReader{
+			ctx:    ctx,
 			stream: res.stream,
 			reopen: reopen,
 			cancel: cancel,
@@ -1647,6 +1648,7 @@ type bidiReadStreamResponse struct {
 
 // gRPCReader is used by storage.Reader if the experimental option WithGRPCBidiReads is passed.
 type gRPCReader struct {
+	ctx             context.Context
 	seen, size      int64
 	zeroRange       bool
 	finalized       bool // if we are reading from a finalized object; in this case, remain and size may be inaccurate
@@ -1678,16 +1680,47 @@ func (r *gRPCReader) updateCRC(b []byte) {
 
 // Checks whether the CRC matches at the conclusion of a read, if CRC checking was enabled.
 func (r *gRPCReader) runCRCCheck() error {
-	if r.checkCRC && r.gotCRC != r.wantCRC {
-		return fmt.Errorf("storage: bad CRC on read: got %d, want %d", r.gotCRC, r.wantCRC)
+	if r.checkCRC {
+		var chkCtx context.Context
+		if r.ctx != nil {
+			chkCtx, _ = startChecksumSpan(r.ctx, "CRC32C")
+		} else if r.stream != nil {
+			chkCtx, _ = startChecksumSpan(r.stream.Context(), "CRC32C")
+		}
+		var err error
+		if r.gotCRC != r.wantCRC {
+			err = fmt.Errorf("storage: bad CRC on read: got %d, want %d", r.gotCRC, r.wantCRC)
+		}
+		if chkCtx != nil {
+			endSpan(chkCtx, err)
+		}
+		return err
 	}
 	return nil
 }
 
 // checkAndResetChunkCRC verifies the chunk CRC if present, and resets the chunk CRC state.
 func (r *gRPCReader) checkAndResetChunkCRC() error {
-	if r.chunkCRCPresent && r.gotChunkCRC != r.wantChunkCRC {
-		return fmt.Errorf("storage: bad CRC on chunk read: got %d, want %d", r.gotChunkCRC, r.wantChunkCRC)
+	if r.chunkCRCPresent {
+		var chkCtx context.Context
+		if !r.checkCRC {
+			if r.ctx != nil {
+				chkCtx, _ = startChecksumSpan(r.ctx, "CRC32C")
+			} else if r.stream != nil {
+				chkCtx, _ = startChecksumSpan(r.stream.Context(), "CRC32C")
+			}
+		}
+		var err error
+		if r.gotChunkCRC != r.wantChunkCRC {
+			err = fmt.Errorf("storage: bad CRC on chunk read: got %d, want %d", r.gotChunkCRC, r.wantChunkCRC)
+		}
+		if chkCtx != nil {
+			endSpan(chkCtx, err)
+		}
+		r.gotChunkCRC = 0
+		r.chunkCRCPresent = false
+		r.wantChunkCRC = 0
+		return err
 	}
 	r.gotChunkCRC = 0
 	r.chunkCRCPresent = false

--- a/storage/grpc_reader.go
+++ b/storage/grpc_reader.go
@@ -205,7 +205,13 @@ func (c *grpcStorageClient) NewRangeReaderReadObject(ctx context.Context, params
 		wantCRC  uint32
 		checkCRC bool
 	)
-	if checksums := msg.GetObjectChecksums(); checksums != nil && checksums.Crc32C != nil {
+	var checksums *storagepb.ObjectChecksums
+	if cs := msg.GetObjectChecksums(); cs != nil {
+		checksums = cs
+	} else if obj != nil && obj.GetChecksums() != nil {
+		checksums = obj.GetChecksums()
+	}
+	if checksums != nil && checksums.Crc32C != nil {
 		if !params.disableCRCCheck &&
 			startOffset == 0 &&
 			(params.length < 0 || (obj != nil && params.length >= size)) {
@@ -228,6 +234,7 @@ func (c *grpcStorageClient) NewRangeReaderReadObject(ctx context.Context, params
 		},
 		objectMetadata: &metadata,
 		reader: &gRPCReadObjectReader{
+			ctx:    ctx,
 			stream: res.stream,
 			reopen: reopen,
 			cancel: cancel,
@@ -271,6 +278,7 @@ type readStreamResponseReadObject struct {
 }
 
 type gRPCReadObjectReader struct {
+	ctx             context.Context
 	seen, size      int64
 	zeroRange       bool
 	stream          storagepb.Storage_ReadObjectClient
@@ -300,16 +308,47 @@ func (r *gRPCReadObjectReader) updateCRC(b []byte) {
 
 // Checks whether the CRC matches at the conclusion of a read, if CRC checking was enabled.
 func (r *gRPCReadObjectReader) runCRCCheck() error {
-	if r.checkCRC && r.gotCRC != r.wantCRC {
-		return fmt.Errorf("storage: bad CRC on read: got %d, want %d", r.gotCRC, r.wantCRC)
+	if r.checkCRC {
+		var chkCtx context.Context
+		if r.ctx != nil {
+			chkCtx, _ = startChecksumSpan(r.ctx, "CRC32C")
+		} else if r.stream != nil {
+			chkCtx, _ = startChecksumSpan(r.stream.Context(), "CRC32C")
+		}
+		var err error
+		if r.gotCRC != r.wantCRC {
+			err = fmt.Errorf("storage: bad CRC on read: got %d, want %d", r.gotCRC, r.wantCRC)
+		}
+		if chkCtx != nil {
+			endSpan(chkCtx, err)
+		}
+		return err
 	}
 	return nil
 }
 
 // checkAndResetChunkCRC verifies the chunk CRC if present, and resets the chunk CRC state.
 func (r *gRPCReadObjectReader) checkAndResetChunkCRC() error {
-	if r.chunkCRCPresent && r.gotChunkCRC != r.wantChunkCRC {
-		return fmt.Errorf("storage: bad CRC on chunk read: got %d, want %d", r.gotChunkCRC, r.wantChunkCRC)
+	if r.chunkCRCPresent {
+		var chkCtx context.Context
+		if !r.checkCRC {
+			if r.ctx != nil {
+				chkCtx, _ = startChecksumSpan(r.ctx, "CRC32C")
+			} else if r.stream != nil {
+				chkCtx, _ = startChecksumSpan(r.stream.Context(), "CRC32C")
+			}
+		}
+		var err error
+		if r.gotChunkCRC != r.wantChunkCRC {
+			err = fmt.Errorf("storage: bad CRC on chunk read: got %d, want %d", r.gotChunkCRC, r.wantChunkCRC)
+		}
+		if chkCtx != nil {
+			endSpan(chkCtx, err)
+		}
+		r.gotChunkCRC = 0
+		r.chunkCRCPresent = false
+		r.wantChunkCRC = 0
+		return err
 	}
 	r.gotChunkCRC = 0
 	r.chunkCRCPresent = false

--- a/storage/grpc_reader_multi_range.go
+++ b/storage/grpc_reader_multi_range.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"log"
 	"sync"
@@ -404,6 +405,10 @@ type rangeRequest struct {
 	readID       int64
 	bytesWritten int64
 	completed    bool
+
+	wantChunkCRC    uint32
+	gotChunkCRC     uint32
+	chunkCRCPresent bool
 }
 
 // Methods implementing internalMultiRangeDownloader
@@ -1063,7 +1068,19 @@ func (m *multiRangeDownloaderManager) processDataRanges(result mrdSessionResult,
 			continue
 		}
 
-		written, _, err := result.decoder.writeToAndUpdateCRC(req.output, readID, nil)
+		var updateCRC func(b []byte)
+		if !m.params.disableMRDReadChecksum &&
+			dataRange.GetChecksummedData() != nil &&
+			dataRange.GetChecksummedData().Crc32C != nil {
+			req.gotChunkCRC = 0
+			req.chunkCRCPresent = true
+			req.wantChunkCRC = *dataRange.GetChecksummedData().Crc32C
+			updateCRC = func(b []byte) {
+				req.gotChunkCRC = crc32.Update(req.gotChunkCRC, crc32cTable, b)
+			}
+		}
+
+		written, _, err := result.decoder.writeToAndUpdateCRC(req.output, readID, updateCRC)
 		req.bytesWritten += written
 		mrdStream.updateCapacity(m, 0, -written)
 		if err != nil {
@@ -1071,8 +1088,9 @@ func (m *multiRangeDownloaderManager) processDataRanges(result mrdSessionResult,
 			continue
 		}
 
-		if result.decoder.crcErrs != nil && result.decoder.crcErrs[readID] != nil {
-			m.failRange(mrdStream, req, result.decoder.crcErrs[readID])
+		err = m.checkAndResetChunkCRC(req)
+		if err != nil {
+			m.failRange(mrdStream, req, err)
 			continue
 		}
 
@@ -1086,6 +1104,27 @@ func (m *multiRangeDownloaderManager) processDataRanges(result mrdSessionResult,
 			m.runCallback(req.origOffset, req.bytesWritten, nil, req.callback)
 		}
 	}
+}
+
+func (m *multiRangeDownloaderManager) checkAndResetChunkCRC(req *rangeRequest) error {
+	if m.params.disableMRDReadChecksum || !req.chunkCRCPresent {
+		return nil
+	}
+	var chkCtx context.Context
+	if m.ctx != nil {
+		chkCtx, _ = startChecksumSpan(m.ctx, "CRC32C")
+	}
+	var err error
+	if req.gotChunkCRC != req.wantChunkCRC {
+		err = fmt.Errorf("storage: bad CRC on chunk read: got %d, want %d", req.gotChunkCRC, req.wantChunkCRC)
+	}
+	if chkCtx != nil {
+		endSpan(chkCtx, err)
+	}
+	req.gotChunkCRC = 0
+	req.wantChunkCRC = 0
+	req.chunkCRCPresent = false
+	return err
 }
 
 // ensureSession is now only for reconnecting *after* the initial session is up.

--- a/storage/http_client.go
+++ b/storage/http_client.go
@@ -1062,7 +1062,7 @@ func (c *httpStorageClient) newRangeReaderXML(ctx context.Context, params *newRa
 	if err != nil {
 		return nil, err
 	}
-	return parseReadResponse(res, params, reopen)
+	return parseReadResponse(ctx, res, params, reopen)
 }
 
 func (c *httpStorageClient) newRangeReaderJSON(ctx context.Context, params *newRangeReaderParams, s *settings) (r *Reader, err error) {
@@ -1086,7 +1086,7 @@ func (c *httpStorageClient) newRangeReaderJSON(ctx context.Context, params *newR
 	if err != nil {
 		return nil, err
 	}
-	return parseReadResponse(res, params, reopen)
+	return parseReadResponse(ctx, res, params, reopen)
 }
 
 // httpInternalWriter writes data for an HTTP upload. For single-shot uploads,
@@ -1500,6 +1500,7 @@ func (c *httpStorageClient) DeleteNotification(ctx context.Context, bucket strin
 }
 
 type httpReader struct {
+	ctx      context.Context
 	body     io.ReadCloser
 	seen     int64
 	reopen   func(seen int64) (*http.Response, error)
@@ -1525,9 +1526,20 @@ func (r *httpReader) Read(p []byte) (int, error) {
 			// everybody defers Close on the assumption that it doesn't return
 			// anything worth looking at.
 			if r.checkCRC {
+				var chkCtx context.Context
+				if r.ctx != nil {
+					chkCtx, _ = startChecksumSpan(r.ctx, "CRC32C")
+				}
+				var crcErr error
 				if r.gotCRC != r.wantCRC {
-					return n, fmt.Errorf("storage: bad CRC on read: got %d, want %d",
+					crcErr = fmt.Errorf("storage: bad CRC on read: got %d, want %d",
 						r.gotCRC, r.wantCRC)
+				}
+				if chkCtx != nil {
+					endSpan(chkCtx, crcErr)
+				}
+				if crcErr != nil {
+					return n, crcErr
 				}
 			}
 			return n, err
@@ -1652,7 +1664,7 @@ func readerReopen(ctx context.Context, header http.Header, params *newRangeReade
 	}
 }
 
-func parseReadResponse(res *http.Response, params *newRangeReaderParams, reopen func(int64) (*http.Response, error)) (r *Reader, err error) {
+func parseReadResponse(ctx context.Context, res *http.Response, params *newRangeReaderParams, reopen func(int64) (*http.Response, error)) (r *Reader, err error) {
 	defer func() {
 		if err != nil {
 			res.Body.Close()
@@ -1757,6 +1769,7 @@ func parseReadResponse(res *http.Response, params *newRangeReaderParams, reopen 
 		remain:         remain,
 		checkCRC:       checkCRC,
 		reader: &httpReader{
+			ctx:      ctx,
 			reopen:   reopen,
 			body:     body,
 			wantCRC:  crc,

--- a/storage/trace.go
+++ b/storage/trace.go
@@ -180,3 +180,14 @@ func getCommonAttributes() []attribute.KeyValue {
 func appendPackageName(spanName string) string {
 	return fmt.Sprintf("%s.%s", gcpClientArtifact, spanName)
 }
+
+// startChecksumSpan starts a T5 internal operation span for computing or verifying data checksums.
+func startChecksumSpan(ctx context.Context, checksumType string) (context.Context, trace.Span) {
+	if !isOTelTracingDevEnabled() {
+		return ctx, trace.SpanFromContext(ctx)
+	}
+	opts := []trace.SpanStartOption{
+		trace.WithAttributes(attribute.String("gcp.storage.checksum.type", checksumType)),
+	}
+	return startSpan(ctx, "Storage.CalculateChecksum", opts...)
+}

--- a/storage/trace_test.go
+++ b/storage/trace_test.go
@@ -350,3 +350,56 @@ func TestEndSpanEviction(t *testing.T) {
 		})
 	}
 }
+
+func TestStartChecksumSpan(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	chkCtx, _ := startChecksumSpan(ctx, "CRC32C")
+	endSpan(chkCtx, nil)
+
+	spans := te.Spans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	gotSpan := spans[0]
+	if got, want := gotSpan.Name, "cloud.google.com/go/storage.Storage.CalculateChecksum"; got != want {
+		t.Errorf("got span name %q, want %q", got, want)
+	}
+	foundChecksumType := false
+	for _, a := range gotSpan.Attributes {
+		if string(a.Key) == "gcp.storage.checksum.type" {
+			foundChecksumType = true
+			if got, want := a.Value.AsString(), "CRC32C"; got != want {
+				t.Errorf("checksum type = %q, want %q", got, want)
+			}
+		}
+	}
+	if !foundChecksumType {
+		t.Errorf("gcp.storage.checksum.type attribute not found on span")
+	}
+}
+
+func TestChecksumSpanDevTracingDisabled(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "false")
+
+	chkCtx, span := startChecksumSpan(ctx, "CRC32C")
+	endSpan(chkCtx, nil)
+
+	if span.SpanContext().IsValid() {
+		t.Errorf("expected invalid span context when dev tracing is disabled, got %v", span.SpanContext())
+	}
+	spans := te.Spans()
+	if len(spans) > 0 {
+		t.Fatalf("expected 0 ended spans because dev tracing is disabled, but got %d ended spans: %v", len(spans), spans[0].Name)
+	}
+}


### PR DESCRIPTION
- Emits T5 `Storage.CalculateChecksum` spans with `gcp.storage.checksum.type: CRC32C`.
- Fixes duplicate checksum calculation spans on gRPC read streams (`if !r.checkCRC`).
- Connects in-stream CRC32C verification and span emission for Multi-Range Downloader.
- Includes unit tests in `storage/trace_test.go`.
