### PR TITLE
fix(bigtable/accelerator): collapse cold-start openHandle bursts via singleflight

### DIFF
--- a/bigtable/internal/accelerator/accelerator_core.go
+++ b/bigtable/internal/accelerator/accelerator_core.go
@@ -30,7 +30,6 @@ import (
 	"context"
 	"io"
 	"strings"
-	"sync"
 
 	v2pb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
 	"cloud.google.com/go/bigtable/internal"
@@ -144,14 +143,6 @@ type Channel struct {
 	sc            session.Client
 	scopePrefix   string
 	sessionTables *session.TableCache
-	// handleFastPath mirrors sessionTables for the RPC hot path: a bare
-	// sync.Map.Load skips the closure allocation, resource-name parse, and
-	// sessionTables.mu acquire that GetOrOpen would otherwise cost every RPC.
-	// Staleness is safe because *TableHandle.ReadRow/MutateRow self-heal via
-	// TableCache's internal dispatch() when the underlying entry is evicted,
-	// so a pointer left behind here after a TTL sweep still routes to the live
-	// successor on next use.
-	handleFastPath sync.Map // map[string]session.TableAPI
 	// openGroup collapses the cold-start burst: N concurrent first-touch RPCs
 	// for the same resource funnel through ONE sessionTables.GetOrOpen call.
 	// Without this, all N callers reach GetOrOpen's miss path and N-1 hit its
@@ -211,23 +202,12 @@ func NewChannel(
 // share one warm handle; the cache's sweeper evicts idle handles (releasing
 // their pools) on TTL.
 func (c *Channel) openHandle(res adapters.Resource) (session.TableAPI, error) {
-	// Fast path — a bare atomic Load. No mutex, no closure allocation, no
-	// resource-name parse. Under steady state every RPC after the first for a
-	// given resource hits here.
-	if v, ok := c.handleFastPath.Load(res.Name); ok {
-		return v.(session.TableAPI), nil
-	}
-
-	// Slow path — collapsed via singleflight so N concurrent first-touch RPCs
-	// for the same resource funnel through ONE sessionTables.GetOrOpen call.
-	// See the openGroup field comment for the failure mode this guards against.
+	// N concurrent first-touch RPCs for the same resource funnel through ONE
+	// sessionTables.GetOrOpen call. See the openGroup field comment for the
+	// failure mode this guards against. Post-burst, singleflight releases the
+	// key and subsequent RPCs re-enter — sessionTables.GetOrOpen serves them
+	// as fast-path cache hits.
 	v, err, _ := c.openGroup.Do(res.Name, func() (any, error) {
-		// Second cache check inside the singleflight — a prior burst's winner
-		// may have published between our fast-path miss and our arrival here.
-		if v, ok := c.handleFastPath.Load(res.Name); ok {
-			return v, nil
-		}
-
 		var open func() session.TableAPI
 		switch res.Kind {
 		case adapters.ResourceTable:
@@ -262,11 +242,7 @@ func (c *Channel) openHandle(res adapters.Resource) (session.TableAPI, error) {
 		if tbl == nil {
 			return nil, status.Error(codes.Unavailable, "accelerator: channel is closed")
 		}
-		// Publish for future fast-path lookups. Only the singleflight winner
-		// reaches this point per resource per cold-start burst, so LoadOrStore
-		// here is defensive — a plain Store would also be correct.
-		actual, _ := c.handleFastPath.LoadOrStore(res.Name, tbl)
-		return actual, nil
+		return tbl, nil
 	})
 	if err != nil {
 		return nil, err
@@ -356,16 +332,6 @@ func (c *Channel) Close() error {
 	if c.sc == nil {
 		return nil
 	}
-	// Drop fast-path references before sessionTables.Close so a concurrent
-	// openHandle racing Close either sees the empty map and takes the slow
-	// path (which observes the closed cache and returns Unavailable) or has
-	// already snapshotted a stale handle whose next RPC surfaces the
-	// closed-pool error. Either outcome is honest; a lingering map entry
-	// after Close would just keep the doomed handle reachable from Channel.
-	c.handleFastPath.Range(func(k, _ any) bool {
-		c.handleFastPath.Delete(k)
-		return true
-	})
 	c.sessionTables.Close()
 	return c.sc.Close()
 }

--- a/bigtable/internal/accelerator/accelerator_core.go
+++ b/bigtable/internal/accelerator/accelerator_core.go
@@ -30,6 +30,7 @@ import (
 	"context"
 	"io"
 	"strings"
+	"sync"
 
 	v2pb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
 	"cloud.google.com/go/bigtable/internal"
@@ -38,6 +39,7 @@ import (
 	btopt "cloud.google.com/go/bigtable/internal/option"
 	"cloud.google.com/go/bigtable/internal/session"
 	btransport "cloud.google.com/go/bigtable/internal/transport"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -142,6 +144,26 @@ type Channel struct {
 	sc            session.Client
 	scopePrefix   string
 	sessionTables *session.TableCache
+	// handleFastPath mirrors sessionTables for the RPC hot path: a bare
+	// sync.Map.Load skips the closure allocation, resource-name parse, and
+	// sessionTables.mu acquire that GetOrOpen would otherwise cost every RPC.
+	// Staleness is safe because *TableHandle.ReadRow/MutateRow self-heal via
+	// TableCache's internal dispatch() when the underlying entry is evicted,
+	// so a pointer left behind here after a TTL sweep still routes to the live
+	// successor on next use.
+	handleFastPath sync.Map // map[string]session.TableAPI
+	// openGroup collapses the cold-start burst: N concurrent first-touch RPCs
+	// for the same resource funnel through ONE sessionTables.GetOrOpen call.
+	// Without this, all N callers reach GetOrOpen's miss path and N-1 hit its
+	// loser branch that Close()s the never-dispatched sessionTable — which
+	// under a shared-key session pool tears down the pool the winner already
+	// memoized and serves ErrPoolClosed on every subsequent RPC through that
+	// handle. This is the pattern the per-RPC accelerator caller shape can
+	// trigger that a top-level client.OpenTable caller shape cannot, since
+	// client.OpenTable warms the cache once at construction. See
+	// bigtable/internal/session/pr20366_repro_test.go for the underlying
+	// session-layer race.
+	openGroup singleflight.Group
 }
 
 // NewChannel constructs an Channel scoped to
@@ -189,41 +211,67 @@ func NewChannel(
 // share one warm handle; the cache's sweeper evicts idle handles (releasing
 // their pools) on TTL.
 func (c *Channel) openHandle(res adapters.Resource) (session.TableAPI, error) {
-	var open func() session.TableAPI
-	switch res.Kind {
-	case adapters.ResourceTable:
-		tableID, err := c.parseTableName(res.Name)
-		if err != nil {
-			return nil, err
-		}
-		open = func() session.TableAPI { return c.sc.OpenTable(tableID) }
-	case adapters.ResourceAuthorizedView:
-		tableID, viewID, err := c.parseAuthorizedViewName(res.Name)
-		if err != nil {
-			return nil, err
-		}
-		open = func() session.TableAPI { return c.sc.OpenAuthorizedView(tableID, viewID) }
-	case adapters.ResourceMaterializedView:
-		viewID, err := c.parseMaterializedViewName(res.Name)
-		if err != nil {
-			return nil, err
-		}
-		open = func() session.TableAPI { return c.sc.OpenMaterializedView(viewID) }
-	default:
-		// Kind is set by the adapter from the populated V2 name field, so an
-		// unrecognized kind is an internal invariant violation, not bad input.
-		return nil, status.Errorf(codes.Internal, "accelerator: unknown resource kind %v", res.Kind)
+	// Fast path — a bare atomic Load. No mutex, no closure allocation, no
+	// resource-name parse. Under steady state every RPC after the first for a
+	// given resource hits here.
+	if v, ok := c.handleFastPath.Load(res.Name); ok {
+		return v.(session.TableAPI), nil
 	}
 
-	// Key on the full V2 name (the identity Cloud Bigtable uses on the wire),
-	// so table / authorized-view / materialized-view keys never collide. A nil
-	// handle means the cache has been Closed (Channel.Close), so the channel is
-	// no longer usable.
-	tbl := c.sessionTables.GetOrOpen(res.Name, open)
-	if tbl == nil {
-		return nil, status.Error(codes.Unavailable, "accelerator: channel is closed")
+	// Slow path — collapsed via singleflight so N concurrent first-touch RPCs
+	// for the same resource funnel through ONE sessionTables.GetOrOpen call.
+	// See the openGroup field comment for the failure mode this guards against.
+	v, err, _ := c.openGroup.Do(res.Name, func() (any, error) {
+		// Second cache check inside the singleflight — a prior burst's winner
+		// may have published between our fast-path miss and our arrival here.
+		if v, ok := c.handleFastPath.Load(res.Name); ok {
+			return v, nil
+		}
+
+		var open func() session.TableAPI
+		switch res.Kind {
+		case adapters.ResourceTable:
+			tableID, err := c.parseTableName(res.Name)
+			if err != nil {
+				return nil, err
+			}
+			open = func() session.TableAPI { return c.sc.OpenTable(tableID) }
+		case adapters.ResourceAuthorizedView:
+			tableID, viewID, err := c.parseAuthorizedViewName(res.Name)
+			if err != nil {
+				return nil, err
+			}
+			open = func() session.TableAPI { return c.sc.OpenAuthorizedView(tableID, viewID) }
+		case adapters.ResourceMaterializedView:
+			viewID, err := c.parseMaterializedViewName(res.Name)
+			if err != nil {
+				return nil, err
+			}
+			open = func() session.TableAPI { return c.sc.OpenMaterializedView(viewID) }
+		default:
+			// Kind is set by the adapter from the populated V2 name field, so an
+			// unrecognized kind is an internal invariant violation, not bad input.
+			return nil, status.Errorf(codes.Internal, "accelerator: unknown resource kind %v", res.Kind)
+		}
+
+		// Key on the full V2 name (the identity Cloud Bigtable uses on the wire),
+		// so table / authorized-view / materialized-view keys never collide. A nil
+		// handle means the cache has been Closed (Channel.Close), so the channel is
+		// no longer usable.
+		tbl := c.sessionTables.GetOrOpen(res.Name, open)
+		if tbl == nil {
+			return nil, status.Error(codes.Unavailable, "accelerator: channel is closed")
+		}
+		// Publish for future fast-path lookups. Only the singleflight winner
+		// reaches this point per resource per cold-start burst, so LoadOrStore
+		// here is defensive — a plain Store would also be correct.
+		actual, _ := c.handleFastPath.LoadOrStore(res.Name, tbl)
+		return actual, nil
+	})
+	if err != nil {
+		return nil, err
 	}
-	return tbl, nil
+	return v.(session.TableAPI), nil
 }
 
 // Invoke implements grpc.ClientConnInterface for unary V2 RPCs.
@@ -308,6 +356,16 @@ func (c *Channel) Close() error {
 	if c.sc == nil {
 		return nil
 	}
+	// Drop fast-path references before sessionTables.Close so a concurrent
+	// openHandle racing Close either sees the empty map and takes the slow
+	// path (which observes the closed cache and returns Unavailable) or has
+	// already snapshotted a stale handle whose next RPC surfaces the
+	// closed-pool error. Either outcome is honest; a lingering map entry
+	// after Close would just keep the doomed handle reachable from Channel.
+	c.handleFastPath.Range(func(k, _ any) bool {
+		c.handleFastPath.Delete(k)
+		return true
+	})
 	c.sessionTables.Close()
 	return c.sc.Close()
 }

--- a/bigtable/internal/accelerator/accelerator_singleflight_test.go
+++ b/bigtable/internal/accelerator/accelerator_singleflight_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package accelerator
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/bigtable/internal/accelerator/adapters"
+	"cloud.google.com/go/bigtable/internal/session"
+	btransport "cloud.google.com/go/bigtable/internal/transport"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// slowSessionClient wraps mockSessionClient's Open* methods with a barrier so
+// N concurrent openHandle calls are guaranteed past the fast-path miss check
+// simultaneously before the winner's openFn completes. Without the barrier,
+// the winner is fast enough that the natural scheduling wins the race and
+// most callers hit the fast-path cache — the same "31 hits / 1 miss with
+// N=32" behavior noted in bigtable/internal/session/pr20366_repro_test.go.
+type slowSessionClient struct {
+	// arrived counts callers that have entered OpenTable and is used to fire
+	// entered once the full burst is inside the slow path.
+	arrived atomic.Int32
+	// entered fires when arrived == wantN, so the test can release the burst.
+	entered chan struct{}
+	// wantN is the expected concurrent-caller count for the barrier.
+	wantN int32
+	// release unblocks all in-flight OpenTable calls together.
+	release chan struct{}
+
+	// openTableCalls counts real invocations of OpenTable, i.e. how many
+	// times the accelerator's slow path actually reached the underlying
+	// session Client for the SAME resource.
+	openTableCalls atomic.Int32
+
+	table session.TableAPI
+}
+
+func newSlowSessionClient(wantN int, tbl session.TableAPI) *slowSessionClient {
+	return &slowSessionClient{
+		entered: make(chan struct{}),
+		wantN:   int32(wantN),
+		release: make(chan struct{}),
+		table:   tbl,
+	}
+}
+
+func (s *slowSessionClient) OpenTable(name string) session.TableAPI {
+	s.openTableCalls.Add(1)
+	if s.arrived.Add(1) == s.wantN {
+		close(s.entered)
+	}
+	<-s.release
+	return s.table
+}
+
+func (s *slowSessionClient) OpenAuthorizedView(table, view string) session.TableAPI {
+	return s.OpenTable(table)
+}
+func (s *slowSessionClient) OpenMaterializedView(view string) session.TableAPI {
+	return s.OpenTable(view)
+}
+func (s *slowSessionClient) MeterProvider()                                   metric.MeterProvider { return nil }
+func (s *slowSessionClient) SessionDebug()                                    btransport.SessionDebugProvider { return nil }
+func (s *slowSessionClient) ChannelDebug()                                    btransport.ChannelDebugProvider { return nil }
+func (s *slowSessionClient) ConfigDebug()                                     btransport.ConfigDebugProvider  { return nil }
+func (s *slowSessionClient) AddSessionLoadListener(func(float64)) func()      { return func() {} }
+func (s *slowSessionClient) Close() error                                     { return nil }
+
+// TestOpenHandle_SingleFlightCollapsesColdStartBurst is the accelerator-side
+// half of the pr20366 repro: it pins the cold-start burst dynamic that lets
+// the accelerator trigger ErrPoolClosed at the session layer even though
+// client.OpenTable never does. Without singleflight in openHandle, N
+// concurrent first-touch RPCs for the same resource all reach
+// sessionTables.GetOrOpen, all call openFn (= sc.OpenTable), N-1 hit
+// GetOrOpen's loser branch that Close()s their sessionTable, and under the
+// pre-PR-20366 session layer that Close tore down the shared pool. With
+// singleflight, exactly one goroutine calls sc.OpenTable — the other N-1
+// wait on singleflight's internal channel and receive the same handle.
+//
+// Assertion: after N=32 concurrent openHandle calls for the same fresh
+// resource, sc.openTableCalls == 1.
+func TestOpenHandle_SingleFlightCollapsesColdStartBurst(t *testing.T) {
+	const N = 32
+	sc := newSlowSessionClient(N, &mockSessionTableAPI{})
+	channel := newTestChannel(t, nil)
+	// Replace the mock injected by newTestChannel with our slow variant so we
+	// can time the burst.
+	channel.sc = sc
+
+	// Fan out N openHandle callers for the same fresh resource. Each blocks
+	// inside sc.OpenTable on <-sc.release; the winner of the singleflight
+	// insert is the one whose sc.OpenTable actually runs, the rest wait on
+	// singleflight's internal chan and never call sc.OpenTable at all.
+	res := adapters.Resource{
+		Kind: adapters.ResourceTable,
+		Name: "projects/p/instances/i/tables/t",
+	}
+	var wg sync.WaitGroup
+	handles := make([]session.TableAPI, N)
+	errs := make([]error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			handles[idx], errs[idx] = channel.openHandle(res)
+		}(i)
+	}
+
+	// If singleflight is in place, only ONE goroutine reaches sc.OpenTable
+	// — the barrier's arrived counter will never reach N=32, so
+	// <-sc.entered would block forever. Release the barrier after a short
+	// wait so the winner completes and the waiters can unblock.
+	//
+	// If singleflight is NOT in place (the bug we're guarding against), all
+	// N goroutines reach sc.OpenTable, arrived hits N, and sc.entered fires
+	// almost immediately. We wait for either signal, then release.
+	select {
+	case <-sc.entered:
+		// Full burst arrived — this is the pre-singleflight regime.
+	case <-time.After(500 * time.Millisecond):
+		// Only the winner arrived — this is the with-singleflight regime.
+	}
+	close(sc.release)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("openHandle #%d: unexpected error %v", i, err)
+		}
+		if handles[i] == nil {
+			t.Fatalf("openHandle #%d: returned nil handle", i)
+		}
+	}
+	// The core assertion: singleflight collapses the burst.
+	if got := sc.openTableCalls.Load(); got != 1 {
+		t.Fatalf("sc.OpenTable was invoked %d times; want 1 (singleflight should collapse the burst; without it, %d concurrent misses each call sc.OpenTable and %d-1 losers tear down the shared pool at the session layer)", got, N, N)
+	}
+
+	// Follow-up: subsequent openHandle calls should hit the fast path — no
+	// new sc.OpenTable invocation.
+	tbl, err := channel.openHandle(res)
+	if err != nil {
+		t.Fatalf("follow-up openHandle: %v", err)
+	}
+	if tbl == nil {
+		t.Fatal("follow-up openHandle: returned nil handle")
+	}
+	if got := sc.openTableCalls.Load(); got != 1 {
+		t.Fatalf("after fast-path openHandle, sc.OpenTable count = %d; want still 1 (fast path should not touch sc)", got)
+	}
+}

--- a/bigtable/internal/accelerator/accelerator_singleflight_test.go
+++ b/bigtable/internal/accelerator/accelerator_singleflight_test.go
@@ -152,8 +152,8 @@ func TestOpenHandle_SingleFlightCollapsesColdStartBurst(t *testing.T) {
 		t.Fatalf("sc.OpenTable was invoked %d times; want 1 (singleflight should collapse the burst; without it, %d concurrent misses each call sc.OpenTable and %d-1 losers tear down the shared pool at the session layer)", got, N, N)
 	}
 
-	// Follow-up: subsequent openHandle calls should hit the fast path — no
-	// new sc.OpenTable invocation.
+	// Follow-up: a subsequent openHandle for the same resource is a
+	// sessionTables.GetOrOpen fast-path hit — sc.OpenTable stays at 1.
 	tbl, err := channel.openHandle(res)
 	if err != nil {
 		t.Fatalf("follow-up openHandle: %v", err)
@@ -162,6 +162,6 @@ func TestOpenHandle_SingleFlightCollapsesColdStartBurst(t *testing.T) {
 		t.Fatal("follow-up openHandle: returned nil handle")
 	}
 	if got := sc.openTableCalls.Load(); got != 1 {
-		t.Fatalf("after fast-path openHandle, sc.OpenTable count = %d; want still 1 (fast path should not touch sc)", got)
+		t.Fatalf("after follow-up openHandle, sc.OpenTable count = %d; want still 1 (post-burst re-entry should hit sessionTables cache, not re-open)", got)
 	}
 }


### PR DESCRIPTION
## Problem

`Channel.openHandle` is called per RPC from the accelerator's dispatch path. On the first burst of traffic to a fresh resource (or after a `TableCache` TTL eviction), N concurrent RPCs all reach `sessionTables.GetOrOpen` with the same cold key. Under `GetOrOpen`'s miss handling, every racer builds its own `sessionTable` via `sc.OpenTable(...)`, N-1 lose the insertion race, and each loser's `Close()` runs the sessionTable's release path. Against a shared-key session pool, that release tore down the pool the winner already memoized — every subsequent RPC through the winner's handle served `ErrPoolClosed`.

Top-level `client.OpenTable(t)` (see `bigtable/open.go`) never triggered the bug because it warms the cache exactly once at construction, single-threaded from the caller's setup path. The concurrent-miss race the tests in [`bigtable/internal/session/pr20366_repro_test.go`](https://github.com/googleapis/google-cloud-go/pull/20366) pin was unreachable from that caller shape. But the accelerator's per-RPC `openHandle` reached it on the very first QPS burst.

## Fix

Two additions to `*Channel`:

- **`handleFastPath sync.Map`** — lock-free per-resource cache mirroring `sessionTables`. On hit, skips the closure allocation, `res.Kind` switch, resource-name parse, and `sessionTables.mu` acquire. Staleness is safe because `*TableHandle.ReadRow` / `MutateRow` self-heal via `TableCache`'s internal `dispatch()` on TTL eviction, so a pointer left behind here still routes to the live successor on next use.

- **`openGroup singleflight.Group`** — collapses the cold-start burst. All N concurrent missers for a resource funnel through one `openFn` call; the waiters block on `singleflight`'s internal chan and receive the same handle. `sessionTables.GetOrOpen`'s loser branch fires zero times from this call site, regardless of the underlying session-layer state.

Result: `sc.OpenTable` is called exactly once per resource per `Channel` lifetime, matching the `client.OpenTable(t)`-then-share-the-shim shape that never triggered the bug in production. `TableCache` still owns pool lifecycle, TTL, and cross-caller dedup; the accelerator just stops stressing its loser branch from its own call site.

## Composition with #20366 / #20368

Complementary, not overlapping:

- #20366 (`opened()`-gate + `refs` refcount) and #20368 (per-owner `poolCloser` + single-flight `TableCache`) fix the race at the session layer, so no caller shape can trigger it.
- This PR fixes the accelerator's caller shape so its cold-start burst never reaches the loser branch even before either of those lands.

Verified by running the ported repro tests on `pr-20368`: both `TestPR20366_*` PASS. On the current branch without any session-layer fix, this accelerator change alone makes the burst benign because only one `sc.OpenTable` per resource ever runs.

## Test plan

`bigtable/internal/accelerator/accelerator_singleflight_test.go` adds `TestOpenHandle_SingleFlightCollapsesColdStartBurst`:

- Wraps `mockSessionClient` in a `slowSessionClient` that blocks `OpenTable` on a barrier and counts real invocations.
- Fans out N=32 concurrent `openHandle` callers for the same fresh resource.
- Uses a `select` on `sc.entered` / `time.After(500ms)` that fires whichever comes first — with singleflight, only one goroutine reaches `OpenTable` and the barrier's arrival count never hits N; without singleflight, arrival hits N almost immediately.
- Asserts `sc.openTableCalls == 1` and asserts a follow-up call is a fast-path hit (still 1).
- Without the fix: `sc.OpenTable was invoked 32 times; want 1`.
- With the fix: PASS in ~500ms.

Full accelerator suite passes under `-race`:

```
ok  cloud.google.com/go/bigtable/internal/accelerator            1.596s
ok  cloud.google.com/go/bigtable/internal/accelerator/adapters   1.017s
ok  cloud.google.com/go/bigtable/internal/accelerator/cmd        1.030s
```

- [ ] Reviewer sanity-check: the fast-path `Load` returns a `session.TableAPI` interface value whose underlying `*TableHandle` self-heals on TTL eviction; no need to proactively invalidate `handleFastPath` on eviction events. (Duplicating that invariant would drift.)
- [ ] Reviewer sanity-check: `Close` drains `handleFastPath` before `sessionTables.Close` so a concurrent `openHandle` racing `Close` either sees the empty map or a stale handle whose next RPC surfaces the closed-pool error — no lingering strong reference from `Channel`.