### PR TITLE
fix(auth): eliminate timing race conditions in grpctransport otel tests (#20175)

### DIFF
--- a/auth/grpctransport/grpctransport_otel_test.go
+++ b/auth/grpctransport/grpctransport_otel_test.go
@@ -79,18 +79,6 @@ func TestDial_OpenTelemetry_Enabled(t *testing.T) {
 			return nil, status.Error(grpccodes.Internal, "test error")
 		},
 	}
-	timeoutEchoer := &fakeEchoService{
-		Fn: func(ctx context.Context, req *echo.EchoRequest) (*echo.EchoReply, error) {
-			time.Sleep(100 * time.Millisecond)
-			return &echo.EchoReply{Message: req.Message}, nil
-		},
-	}
-	cancelEchoer := &fakeEchoService{
-		Fn: func(ctx context.Context, req *echo.EchoRequest) (*echo.EchoReply, error) {
-			time.Sleep(100 * time.Millisecond)
-			return &echo.EchoReply{Message: req.Message}, nil
-		},
-	}
 
 	tests := []struct {
 		name               string
@@ -149,7 +137,6 @@ func TestDial_OpenTelemetry_Enabled(t *testing.T) {
 		},
 		{
 			name:      "telemetry enabled client timeout",
-			echoer:    timeoutEchoer,
 			opts:      &Options{DisableAuthentication: true},
 			errorType: "timeout",
 			wantErr:   true,
@@ -173,7 +160,6 @@ func TestDial_OpenTelemetry_Enabled(t *testing.T) {
 		},
 		{
 			name:      "telemetry enabled client cancelled",
-			echoer:    cancelEchoer,
 			opts:      &Options{DisableAuthentication: true},
 			errorType: "cancel",
 			wantErr:   true,
@@ -257,12 +243,27 @@ func TestDial_OpenTelemetry_Enabled(t *testing.T) {
 			defer func(prev oteltrace.TracerProvider) { otel.SetTracerProvider(prev) }(otel.GetTracerProvider())
 			otel.SetTracerProvider(tp)
 
+			rpcStarted := make(chan struct{}, 1)
+			echoer := tt.echoer
+			if tt.errorType == "timeout" || tt.errorType == "cancel" {
+				echoer = &fakeEchoService{
+					Fn: func(ctx context.Context, req *echo.EchoRequest) (*echo.EchoReply, error) {
+						select {
+						case rpcStarted <- struct{}{}:
+						default:
+						}
+						<-ctx.Done()
+						return nil, ctx.Err()
+					},
+				}
+			}
+
 			l, err := net.Listen("tcp", "127.0.0.1:0")
 			if err != nil {
 				t.Fatalf("Failed to listen: %v", err)
 			}
 			s := grpc.NewServer()
-			echo.RegisterEchoerServer(s, tt.echoer)
+			echo.RegisterEchoerServer(s, echoer)
 			go s.Serve(l)
 			defer s.Stop()
 
@@ -278,11 +279,19 @@ func TestDial_OpenTelemetry_Enabled(t *testing.T) {
 			ctx := context.Background()
 			var cancel context.CancelFunc
 			if tt.errorType == "timeout" {
-				ctx, cancel = context.WithTimeout(ctx, 10*time.Millisecond)
+				ctx, cancel = context.WithTimeout(ctx, 50*time.Millisecond)
 				defer cancel()
 			} else if tt.errorType == "cancel" {
 				ctx, cancel = context.WithCancel(ctx)
-				time.AfterFunc(10*time.Millisecond, cancel)
+				defer cancel()
+				go func() {
+					select {
+					case <-rpcStarted:
+						cancel()
+					case <-time.After(5 * time.Second):
+						cancel()
+					}
+				}()
 			}
 
 			for k, v := range tt.telemetryCtxValues {
@@ -295,7 +304,7 @@ func TestDial_OpenTelemetry_Enabled(t *testing.T) {
 				t.Errorf("client.Echo() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			spans := exporter.GetSpans()
+			spans := getSpansWithTimeout(exporter, tt.wantSpans)
 			if len(spans) != tt.wantSpans {
 				t.Fatalf("len(spans) = %d, want %d", len(spans), tt.wantSpans)
 			}
@@ -357,18 +366,6 @@ func TestDial_OpenTelemetry_Disabled(t *testing.T) {
 			return nil, status.Error(grpccodes.Internal, "test error")
 		},
 	}
-	timeoutEchoer := &fakeEchoService{
-		Fn: func(ctx context.Context, req *echo.EchoRequest) (*echo.EchoReply, error) {
-			time.Sleep(100 * time.Millisecond)
-			return &echo.EchoReply{Message: req.Message}, nil
-		},
-	}
-	cancelEchoer := &fakeEchoService{
-		Fn: func(ctx context.Context, req *echo.EchoRequest) (*echo.EchoReply, error) {
-			time.Sleep(100 * time.Millisecond)
-			return &echo.EchoReply{Message: req.Message}, nil
-		},
-	}
 
 	tests := []struct {
 		name               string
@@ -426,7 +423,6 @@ func TestDial_OpenTelemetry_Disabled(t *testing.T) {
 		},
 		{
 			name:      "telemetry enabled client timeout (but gated off)",
-			echoer:    timeoutEchoer,
 			opts:      &Options{DisableAuthentication: true},
 			errorType: "timeout",
 			wantErr:   true,
@@ -449,7 +445,6 @@ func TestDial_OpenTelemetry_Disabled(t *testing.T) {
 		},
 		{
 			name:      "telemetry enabled client cancelled (but gated off)",
-			echoer:    cancelEchoer,
 			opts:      &Options{DisableAuthentication: true},
 			errorType: "cancel",
 			wantErr:   true,
@@ -521,12 +516,27 @@ func TestDial_OpenTelemetry_Disabled(t *testing.T) {
 			defer func(prev oteltrace.TracerProvider) { otel.SetTracerProvider(prev) }(otel.GetTracerProvider())
 			otel.SetTracerProvider(tp)
 
+			rpcStarted := make(chan struct{}, 1)
+			echoer := tt.echoer
+			if tt.errorType == "timeout" || tt.errorType == "cancel" {
+				echoer = &fakeEchoService{
+					Fn: func(ctx context.Context, req *echo.EchoRequest) (*echo.EchoReply, error) {
+						select {
+						case rpcStarted <- struct{}{}:
+						default:
+						}
+						<-ctx.Done()
+						return nil, ctx.Err()
+					},
+				}
+			}
+
 			l, err := net.Listen("tcp", "127.0.0.1:0")
 			if err != nil {
 				t.Fatalf("Failed to listen: %v", err)
 			}
 			s := grpc.NewServer()
-			echo.RegisterEchoerServer(s, tt.echoer)
+			echo.RegisterEchoerServer(s, echoer)
 			go s.Serve(l)
 			defer s.Stop()
 
@@ -542,11 +552,19 @@ func TestDial_OpenTelemetry_Disabled(t *testing.T) {
 			ctx := context.Background()
 			var cancel context.CancelFunc
 			if tt.errorType == "timeout" {
-				ctx, cancel = context.WithTimeout(ctx, 10*time.Millisecond)
+				ctx, cancel = context.WithTimeout(ctx, 50*time.Millisecond)
 				defer cancel()
 			} else if tt.errorType == "cancel" {
 				ctx, cancel = context.WithCancel(ctx)
-				time.AfterFunc(10*time.Millisecond, cancel)
+				defer cancel()
+				go func() {
+					select {
+					case <-rpcStarted:
+						cancel()
+					case <-time.After(5 * time.Second):
+						cancel()
+					}
+				}()
 			}
 
 			for k, v := range tt.telemetryCtxValues {
@@ -559,7 +577,7 @@ func TestDial_OpenTelemetry_Disabled(t *testing.T) {
 				t.Errorf("client.Echo() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			spans := exporter.GetSpans()
+			spans := getSpansWithTimeout(exporter, tt.wantSpans)
 			if len(spans) != tt.wantSpans {
 				t.Fatalf("len(spans) = %d, want %d", len(spans), tt.wantSpans)
 			}
@@ -1060,5 +1078,20 @@ func TestExtractHostPort(t *testing.T) {
 				t.Errorf("extractHostPort(%q) port = %v, want %v", tt.target, gotPort, tt.wantPort)
 			}
 		})
+	}
+}
+
+func getSpansWithTimeout(exporter *tracetest.InMemoryExporter, wantSpans int) tracetest.SpanStubs {
+	if wantSpans == 0 {
+		time.Sleep(10 * time.Millisecond)
+		return exporter.GetSpans()
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		spans := exporter.GetSpans()
+		if len(spans) >= wantSpans || time.Now().After(deadline) {
+			return spans
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
### Description
Fixes remaining race conditions and timing flakes in `TestDial_OpenTelemetry_Disabled` and `TestDial_OpenTelemetry_Enabled` in `grpctransport_otel_test.go` (fixes #20175).

### Root Causes
1. **Connection handshake vs. timeout/cancellation race**:
   `Dial` connects asynchronously. In client cancellation and client timeout tests, a 10ms timer could fire before the TCP connection handshake finished under CI CPU load. When the RPC was cancelled before binding to a connected peer socket, the resulting span lacked `server.address` and `server.port`, failing the attribute assertions.
2. **Server sleep vs. client cancellation race**:
   The echoer previously used `time.Sleep(100ms)` while the client used `time.AfterFunc(10ms, cancel)`. If thread scheduling delayed the client timer past 100ms, the echoer returned success, failing the `wantErr: true` assertion and recording an `OK` span.
3. **Asynchronous stats recording race**:
   `client.Echo` can return on error before gRPC background stream cleanup finishes invoking `stats.Handler.HandleRPC` and ending the span, causing `exporter.GetSpans()` to temporarily return 0 spans.

### The Fix
1. Synchronize the client cancellation with the echoer via channels (`rpcStarted`) so the RPC is actively in flight on the server before `cancel()` is triggered.
2. Have `timeoutEchoer` and `cancelEchoer` wait on `<-ctx.Done()` instead of arbitrary sleeps.
3. Add a `getSpansWithTimeout` helper to poll `exporter.GetSpans()` with a short deadline to handle asynchronous stream teardown gracefully.

### Evidence of Fix
Ran 500 iterations of all `auth/grpctransport` tests with `-race` locally without failure:
```
$ go test -v -race -count 500 .
PASS
ok  	cloud.google.com/go/auth/grpctransport	144.011s
```