### PR TITLE
fix(bigtable): use composed user agent as CSM client_name

### DIFF
--- a/bigtable/client.go
+++ b/bigtable/client.go
@@ -158,7 +158,7 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 	}
 
 	// Create a OpenTelemetry metrics configuration
-	metricsTracerFactory, err := metrics.NewFactory(ctx, project, instance, config.AppProfile, metricsProvider, opts...)
+	metricsTracerFactory, err := metrics.NewFactory(ctx, project, instance, config.AppProfile, "", metricsProvider, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -313,7 +313,7 @@ func NewClientWithConfig(ctx context.Context, project, instance string, config C
 		// in (endpoint, scopes, user-agent, interceptors) — passing
 		// bare opts leaves the resolver target empty and the dial
 		// aborts with "passthrough: received empty target in Build()".
-		sc, sessionErr := session.NewClient(ctx, project, instance, config.AppProfile, metricsProvider, featureFlagsProto, o...)
+		sc, sessionErr := session.NewClient(ctx, project, instance, config.AppProfile, "", metricsProvider, featureFlagsProto, o...)
 		if sessionErr != nil {
 			// Best-effort cleanup of the classic pool since we won't
 			// return c to the caller. Go through the ManagedChannelPool

--- a/bigtable/internal/accelerator/accelerator_core.go
+++ b/bigtable/internal/accelerator/accelerator_core.go
@@ -85,7 +85,7 @@ var _ grpc.ClientConnInterface = (*Channel)(nil)
 // mock; package-level state mutation is not parallel-safe.
 var newSessionClient = func(
 	ctx context.Context,
-	project, instance, appProfile string,
+	project, instance, appProfile, clientName string,
 	opts ...option.ClientOption,
 ) (session.Client, error) {
 	// Phase 1 keeps built-in client-side metrics on: a nil MetricsProvider is
@@ -102,7 +102,7 @@ var newSessionClient = func(
 	// this instance exists only to read .Enabled, so shut it down immediately.
 	// The accelerator has no separate classic data path that would use a second
 	// factory, and leaving it running would double-export session's metrics.
-	factory, err := metrics.NewFactory(ctx, project, instance, appProfile, metricsProvider, opts...)
+	factory, err := metrics.NewFactory(ctx, project, instance, appProfile, clientName, metricsProvider, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ var newSessionClient = func(
 		EnableDirectAccess: true,
 	})
 
-	return session.NewClient(ctx, project, instance, appProfile, metricsProvider, featureFlags, opts...)
+	return session.NewClient(ctx, project, instance, appProfile, clientName, metricsProvider, featureFlags, opts...)
 }
 
 // Channel is an in-process grpc.ClientConnInterface backed by
@@ -147,9 +147,15 @@ type Channel struct {
 // NewChannel constructs an Channel scoped to
 // (project, instance, appProfile). It dials the underlying session.Client,
 // which the Channel owns and closes via Close (below).
+//
+// clientName is stamped as the client_name attribute on exported client-side
+// metrics. The daemon passes its composed user agent here (see ComposeUserAgent),
+// e.g. "python-bigtable/2.1.0 go-acc/v1.38.0", so CSM attributes the metrics to
+// both the calling client library and the daemon build; an empty string keeps
+// the default "go-bigtable/<version>" token.
 func NewChannel(
 	ctx context.Context,
-	project, instance, appProfile string,
+	project, instance, appProfile, clientName string,
 	opts ...option.ClientOption,
 ) (*Channel, error) {
 	// session.NewClient forwards opts straight to gtransport.Dial
@@ -164,7 +170,7 @@ func NewChannel(
 	}
 	opts = append(defaultOpts, opts...)
 
-	sc, err := newSessionClient(ctx, project, instance, appProfile, opts...)
+	sc, err := newSessionClient(ctx, project, instance, appProfile, clientName, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/bigtable/internal/accelerator/accelerator_core_test.go
+++ b/bigtable/internal/accelerator/accelerator_core_test.go
@@ -104,7 +104,7 @@ func stubSessionClient(t *testing.T, sc *mockSessionClient) {
 	orig := newSessionClient
 	newSessionClient = func(
 		_ context.Context,
-		_, _, _ string,
+		_, _, _, _ string,
 		_ ...option.ClientOption,
 	) (session.Client, error) {
 		return sc, nil
@@ -117,7 +117,7 @@ func stubSessionClient(t *testing.T, sc *mockSessionClient) {
 func newTestChannel(t *testing.T, sc *mockSessionClient) *Channel {
 	t.Helper()
 	stubSessionClient(t, sc)
-	channel, err := NewChannel(context.Background(), "p", "i", "ap")
+	channel, err := NewChannel(context.Background(), "p", "i", "ap", "")
 	if err != nil {
 		t.Fatalf("NewChannel error: %v", err)
 	}
@@ -754,6 +754,34 @@ func TestNewStream_UnknownMethod_ReturnsUnimplemented(t *testing.T) {
 	_, err := channel.NewStream(context.Background(), nil, "/google.bigtable.v2.Bigtable/SampleRowKeys")
 	if status.Code(err) != codes.Unimplemented {
 		t.Errorf("NewStream(unknown) code = %v; want Unimplemented", status.Code(err))
+	}
+}
+
+// TestNewChannel_ForwardsClientName asserts NewChannel hands the client_name it
+// receives (the daemon's --user-agent flag) to the session-client seam, where it
+// becomes the CSM client_name attribute via metrics.NewFactory.
+func TestNewChannel_ForwardsClientName(t *testing.T) {
+	orig := newSessionClient
+	var got string
+	newSessionClient = func(
+		_ context.Context,
+		_, _, _, clientName string,
+		_ ...option.ClientOption,
+	) (session.Client, error) {
+		got = clientName
+		return &mockSessionClient{table: &mockSessionTableAPI{}}, nil
+	}
+	t.Cleanup(func() { newSessionClient = orig })
+
+	const want = "python-bigtable/2.1.0"
+	channel, err := NewChannel(context.Background(), "p", "i", "ap", want)
+	if err != nil {
+		t.Fatalf("NewChannel error: %v", err)
+	}
+	t.Cleanup(func() { _ = channel.Close() })
+
+	if got != want {
+		t.Errorf("newSessionClient clientName = %q; want %q", got, want)
 	}
 }
 

--- a/bigtable/internal/accelerator/cmd/main.go
+++ b/bigtable/internal/accelerator/cmd/main.go
@@ -116,7 +116,11 @@ func main() {
 	// publish in identity.json.
 	opts = append(opts, option.WithCredentials(creds))
 
-	channel, err := accelerator.NewChannel(ctx, *project, *instance, *appProfile, opts...)
+	// Pass the composed user agent as the CSM client_name so client-side
+	// metrics are attributed to both the calling client library and the daemon
+	// build, e.g. "python-bigtable/2.1.0 go-acc/v1.38.0". A blank --user-agent
+	// yields the daemon token alone ("go-acc/v1.38.0").
+	channel, err := accelerator.NewChannel(ctx, *project, *instance, *appProfile, accelerator.ComposeUserAgent(*userAgent), opts...)
 	if err != nil {
 		log.Fatalf("failed to construct accelerator channel: %v", err)
 	}

--- a/bigtable/internal/accelerator/integration_roundtrip_test.go
+++ b/bigtable/internal/accelerator/integration_roundtrip_test.go
@@ -142,7 +142,7 @@ func TestReadRows_MutateReadRoundTrip_Prod(t *testing.T) {
 	// request; the daemon itself is scoped to (project, instance, appProfile).
 	fullTableName := fmt.Sprintf("projects/%s/instances/%s/tables/%s", project, instance, tableName)
 
-	channel, err := NewChannel(ctx, project, instance, appProfile, channelOpts...)
+	channel, err := NewChannel(ctx, project, instance, appProfile, "", channelOpts...)
 	if err != nil {
 		t.Fatalf("NewChannel: %v", err)
 	}

--- a/bigtable/internal/metrics/factory.go
+++ b/bigtable/internal/metrics/factory.go
@@ -132,7 +132,12 @@ type Factory struct {
 // (client-UID / exporter / instrument creation) are swallowed and the
 // disabled factory is returned instead, since metrics are not critical
 // to client creation.
-func NewFactory(ctx context.Context, project, instance, appProfile string, metricsProvider MetricsProvider, opts ...option.ClientOption) (*Factory, error) {
+//
+// clientNameOverride sets the client_name attribute stamped on every exported
+// metric. An empty string keeps the default "go-bigtable/<version>" token; the
+// accelerator daemon passes its --user-agent flag here so CSM attributes the
+// metrics to the calling client library rather than the daemon build.
+func NewFactory(ctx context.Context, project, instance, appProfile, clientNameOverride string, metricsProvider MetricsProvider, opts ...option.ClientOption) (*Factory, error) {
 	switch metricsProvider.(type) {
 	case nil, DefaultMetricsProvider:
 		// fall through to the enabled path
@@ -149,6 +154,11 @@ func NewFactory(ctx context.Context, project, instance, appProfile string, metri
 		return disabledMetricsTracerFactory, nil
 	}
 
+	effectiveClientName := clientName
+	if clientNameOverride != "" {
+		effectiveClientName = clientNameOverride
+	}
+
 	tracerFactory := &Factory{
 		Enabled: true,
 		clientAttributes: []attribute.KeyValue{
@@ -156,7 +166,7 @@ func NewFactory(ctx context.Context, project, instance, appProfile string, metri
 			attribute.String(MetricLabelKeyInstance, instance),
 			attribute.String(MetricLabelKeyAppProfile, appProfile),
 			attribute.String(MetricLabelKeyClientUID, clientUID),
-			attribute.String(MetricLabelKeyClientName, clientName),
+			attribute.String(MetricLabelKeyClientName, effectiveClientName),
 		},
 		Shutdown: func() {},
 	}
@@ -173,7 +183,7 @@ func NewFactory(ctx context.Context, project, instance, appProfile string, metri
 		project:    project,
 		instance:   instance,
 		appProfile: appProfile,
-		clientName: clientName,
+		clientName: effectiveClientName,
 		clientUID:  clientUID,
 		interval:   DefaultSamplePeriod,
 	})

--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -268,14 +268,19 @@ type sessionClient struct {
 // The load-balancing hook for a mixed-mode setup lives at
 // AddSessionLoadListener — call it after construction if you're
 // composing this Client with a bigtable.Client Diverter.
+//
+// clientName sets the client_name attribute on exported client-side metrics.
+// An empty string keeps the default "go-bigtable/<version>" token; the
+// accelerator daemon passes its --user-agent flag so CSM attributes the metrics
+// to the calling client library rather than the daemon build.
 func NewClient(
 	ctx context.Context,
-	project, instance, appProfile string,
+	project, instance, appProfile, clientName string,
 	metricsProvider metrics.MetricsProvider,
 	featureFlagsProto *btpb.FeatureFlags,
 	opts ...option.ClientOption,
 ) (Client, error) {
-	factory, err := metrics.NewFactory(ctx, project, instance, appProfile, metricsProvider)
+	factory, err := metrics.NewFactory(ctx, project, instance, appProfile, clientName, metricsProvider)
 	if err != nil {
 		return nil, fmt.Errorf("session.NewClient: metrics.NewFactory: %w", err)
 	}


### PR DESCRIPTION
Plumb a clientName through NewChannel -> session.NewClient -> metrics.NewFactory so the accelerator daemon stamps its composed user agent (e.g. "python-bigtable/2.1.0 go-acc/v1.38.0") as the client-side metrics client_name attribute, attributing metrics to both the calling client library and the daemon build.

An empty clientName keeps the default "go-bigtable/<version>" token, so the native Go client is unchanged.