### PR TITLE
feat(storage): promote WithGRPCBidiReads and WithGRPCAppendableUploads out of experimental

### DIFF
--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -1758,7 +1758,7 @@ func TestNewRangeReaderUnfinalizedEmulated(t *testing.T) {
 			return clientStream, err
 		})
 
-	client, err := NewGRPCClient(ctx, option.WithGRPCDialOption(streamInterceptor), experimental.WithGRPCBidiReads())
+	client, err := NewGRPCClient(ctx, option.WithGRPCDialOption(streamInterceptor), WithGRPCBidiReads())
 	if err != nil {
 		t.Fatalf("NewGRPCClient: %v", err)
 	}
@@ -1949,7 +1949,7 @@ func TestReadObjectWrongChunkChecksumEmulated(t *testing.T) {
 				var clientOpts []option.ClientOption
 				clientOpts = append(clientOpts, option.WithGRPCDialOption(streamInterceptor))
 				if bidiReads {
-					clientOpts = append(clientOpts, experimental.WithGRPCBidiReads())
+					clientOpts = append(clientOpts, WithGRPCBidiReads())
 				}
 
 				client, err := NewGRPCClient(ctx, clientOpts...)
@@ -2092,7 +2092,7 @@ func TestReadObjectWrongChecksumWholeObjectSizeEmulated(t *testing.T) {
 					var clientOpts []option.ClientOption
 					clientOpts = append(clientOpts, option.WithGRPCDialOption(streamInterceptor))
 					if bidiReads {
-						clientOpts = append(clientOpts, experimental.WithGRPCBidiReads())
+						clientOpts = append(clientOpts, WithGRPCBidiReads())
 					}
 
 					client, err := NewGRPCClient(ctx, clientOpts...)
@@ -2176,7 +2176,7 @@ func TestReadObjectWrongChecksumUnfinalizedWholeObjectSizeEmulated(t *testing.T)
 			return clientStream, err
 		})
 
-	client, err := NewGRPCClient(ctx, option.WithGRPCDialOption(streamInterceptor), experimental.WithGRPCBidiReads())
+	client, err := NewGRPCClient(ctx, option.WithGRPCDialOption(streamInterceptor), WithGRPCBidiReads())
 	if err != nil {
 		t.Fatalf("NewGRPCClient: %v", err)
 	}
@@ -2234,7 +2234,7 @@ func TestMRDWrongChunkChecksumEmulated(t *testing.T) {
 					return clientStream, err
 				})
 
-			client, err := NewGRPCClient(ctx, option.WithGRPCDialOption(streamInterceptor), experimental.WithGRPCBidiReads())
+			client, err := NewGRPCClient(ctx, option.WithGRPCDialOption(streamInterceptor), WithGRPCBidiReads())
 			if err != nil {
 				t.Fatalf("NewGRPCClient: %v", err)
 			}
@@ -3702,7 +3702,7 @@ func TestReadCodecLeaksEmulated(t *testing.T) {
 	checkEmulatorEnvironment(t)
 	ctx := context.Background()
 	var bp testBufferPool
-	client, err := NewGRPCClient(ctx, option.WithGRPCDialOption(expgrpc.WithBufferPool(&bp)), experimental.WithZonalBucketAPIs())
+	client, err := NewGRPCClient(ctx, option.WithGRPCDialOption(expgrpc.WithBufferPool(&bp)), WithGRPCBidiReads(), WithAppendableUploads())
 	if err != nil {
 		t.Fatalf("NewGRPCClient: %v", err)
 	}

--- a/storage/example_test.go
+++ b/storage/example_test.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"cloud.google.com/go/storage/experimental"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
@@ -436,7 +435,7 @@ func ExampleObjectHandle_NewWriterFromAppendableObject() {
 	if err != nil {
 		// TODO: handle error.
 	}
-	bucketName := "my-rapid-bucket"
+	bucketName := "my-bucket"
 	objectName := "appendable-obj"
 	obj := client.Bucket(bucketName).Object(objectName)
 
@@ -510,7 +509,7 @@ func ExampleWriter_Flush() {
 	if err != nil {
 		// TODO: handle error.
 	}
-	bucketName := "my-rapid-bucket"
+	bucketName := "my-bucket"
 	objectName := "appendable-obj"
 	obj := client.Bucket(bucketName).Object(objectName)
 
@@ -1040,7 +1039,7 @@ func ExampleGenerateSignedPostPolicyV4() {
 func ExampleMultiRangeDownloader() {
 	ctx := context.Background()
 	// NewMultiRangeDownloader is only available on gRPC.
-	client, err := storage.NewGRPCClient(ctx, experimental.WithGRPCBidiReads())
+	client, err := storage.NewGRPCClient(ctx, storage.WithGRPCBidiReads())
 	if err != nil {
 		// TODO: handle error.
 	}

--- a/storage/experimental/experimental.go
+++ b/storage/experimental/experimental.go
@@ -82,32 +82,6 @@ type ReadStallTimeoutConfig struct {
 	TargetPercentile float64
 }
 
-// WithGRPCBidiReads provides an [option.ClientOption] that may be passed to
-// [cloud.google.com/go/storage.NewGRPCClient].
-// It enables the client to use bi-directional gRPC APIs for downloads rather than the
-// server streaming API. In particular, it allows users to use the
-// [cloud.google.com/go/storage.MultiRangeDownloader]
-// surface, which requires bi-directional streaming.
-//
-// The bi-directional API is in private preview; please contact your account manager if
-// interested.
-func WithGRPCBidiReads() option.ClientOption {
-	return internal.WithGRPCBidiReads.(func() option.ClientOption)()
-}
-
-// WithZonalBucketAPIs provides an [option.ClientOption] that may be passed to
-// [cloud.google.com/go/storage.NewGRPCClient].
-// It enables the client to use bi-directional gRPC APIs for downloads rather than the
-// server streaming API (same as [WithGRPCBidiReads]) as well as appendable
-// object semantics for uploads. By setting this option, both upload and download
-// paths will use zonal bucket compatible APIs by default.
-//
-// Zonal buckets and rapid storage is in private preview; please contact your
-// account manager if interested.
-func WithZonalBucketAPIs() option.ClientOption {
-	return internal.WithZonalBucketAPIs.(func() option.ClientOption)()
-}
-
 // WithDirectConnectivityEnforced provides an [option.ClientOption] that may be passed to
 // [cloud.google.com/go/storage.NewGRPCClient].
 // It sets the gRPC client to use direct path connectivity for all requests and may fail

--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -1645,7 +1645,7 @@ type bidiReadStreamResponse struct {
 	decoder *readResponseDecoder
 }
 
-// gRPCReader is used by storage.Reader if the experimental option WithGRPCBidiReads is passed.
+// gRPCReader is used by storage.Reader if the option WithGRPCBidiReads is passed.
 type gRPCReader struct {
 	seen, size      int64
 	zeroRange       bool

--- a/storage/grpc_reader.go
+++ b/storage/grpc_reader.go
@@ -32,7 +32,7 @@ import (
 )
 
 // Below is the legacy implementation of gRPC downloads using the ReadObject API.
-// It's used by gRPC if the experimental option WithGRPCBidiReads was not passed.
+// It's used by gRPC if the option WithGRPCBidiReads was not passed.
 // TODO: once BidiReadObject is in GA, remove this implementation.
 
 // Custom codec to be used for unmarshaling ReadObjectResponse messages.

--- a/storage/grpc_reader_multi_range.go
+++ b/storage/grpc_reader_multi_range.go
@@ -135,7 +135,7 @@ func (s *mrdStream) updateCapacity(m *multiRangeDownloaderManager, deltaRanges i
 // Top level entry point into the MultiRangeDownloader via the storageClient interface.
 func (c *grpcStorageClient) NewMultiRangeDownloader(ctx context.Context, params *newMultiRangeDownloaderParams, opts ...storageOption) (*MultiRangeDownloader, error) {
 	if !c.config.grpcBidiReads {
-		return nil, errors.New("storage: MultiRangeDownloader requires the experimental.WithGRPCBidiReads option")
+		return nil, errors.New("storage: MultiRangeDownloader requires the WithGRPCBidiReads option")
 	}
 	s := callSettings(c.settings, opts...)
 	// Force the use of the custom codec to enable zero-copy reads.

--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -308,7 +308,7 @@ func testConfigGRPC(ctx context.Context, t *testing.T, opts ...option.ClientOpti
 // initTransportClients initializes Storage clients for each supported transport.
 func initTransportClients(ctx context.Context, t *testing.T, opts ...option.ClientOption) map[string]*Client {
 	withJSON := append(slices.Clone(opts), WithJSONReads())
-	withZonal := append(slices.Clone(opts), experimental.WithZonalBucketAPIs())
+	withZonal := append(slices.Clone(opts), WithGRPCBidiReads(), WithAppendableUploads())
 	return map[string]*Client{
 		"http": testConfig(ctx, t, opts...),
 		"grpc": testConfigGRPC(ctx, t, opts...),

--- a/storage/internal/experimental.go
+++ b/storage/internal/experimental.go
@@ -34,15 +34,6 @@ var (
 	// It takes ReadStallTimeoutConfig as inputs and returns a option.ClientOption.
 	WithReadStallTimeout any // func (*ReadStallTimeoutConfig) option.ClientOption
 
-	// WithGRPCBidiReads is a function which is implemented by the storage package.
-	// It sets the gRPC client to use the BidiReadObject API for downloads.
-	WithGRPCBidiReads any // func() option.ClientOption
-
-	// WithZonalBucketAPIs is a function which is implemented by the storage package.
-	// It sets the gRPC client to use the BidiReadObject API for downloads and
-	// appendable object semantics by default for uploads.
-	WithZonalBucketAPIs any // func() option.ClientOption
-
 	// WithDirectConnectivityEnforced is a function which is implemented by the storage package.
 	// It sets the gRPC client to use direct path connectivity for all requests and may fail
 	// if direct path connectivity cannot be established for a request.

--- a/storage/option.go
+++ b/storage/option.go
@@ -41,8 +41,6 @@ func init() {
 	storageinternal.WithMetricInterval = withMetricInterval
 	storageinternal.WithMeterProvider = withMeterProvider
 	storageinternal.WithReadStallTimeout = withReadStallTimeout
-	storageinternal.WithGRPCBidiReads = withGRPCBidiReads
-	storageinternal.WithZonalBucketAPIs = withZonalBucketAPIs
 	storageinternal.WithDirectConnectivityEnforced = withDirectConnectivityEnforced
 	storageinternal.WithOtelMetrics = withOtelMetrics
 	storageinternal.WithOtelDebugMetrics = withOtelDebugMetrics
@@ -279,7 +277,15 @@ func (wrstc *withReadStallTimeoutConfig) ApplyStorageOpt(config *storageConfig) 
 	config.readStallTimeoutConfig = wrstc.readStallTimeoutConfig
 }
 
-func withGRPCBidiReads() option.ClientOption {
+// WithGRPCBidiReads provides an [option.ClientOption] that may be passed to
+// [NewGRPCClient].
+//
+// It instructs the client to use the bi-directional gRPC API for all standard object
+// downloads. Additionally, this option is strictly required to use the
+// [MultiRangeDownloader] surface.
+//
+// Note: This option is exclusively supported for gRPC clients.
+func WithGRPCBidiReads() option.ClientOption {
 	return &withGRPCBidiReadsConfig{}
 }
 
@@ -291,18 +297,22 @@ func (w *withGRPCBidiReadsConfig) ApplyStorageOpt(config *storageConfig) {
 	config.grpcBidiReads = true
 }
 
-func withZonalBucketAPIs() option.ClientOption {
-	return &withZonalBucketAPIsConfig{}
+// WithAppendableUploads provides an [option.ClientOption] that may be passed to
+// [NewGRPCClient].
+//
+// It enables the client to use appendable object semantics for uploads by default.
+//
+// Note: This option is exclusively supported for gRPC clients.
+func WithAppendableUploads() option.ClientOption {
+	return &withGRPCAppendableUploadsConfig{}
 }
 
-type withZonalBucketAPIsConfig struct {
+type withGRPCAppendableUploadsConfig struct {
 	internaloption.EmbeddableAdapter
 }
 
-func (w *withZonalBucketAPIsConfig) ApplyStorageOpt(config *storageConfig) {
-	// Use both appendable upload semantics and bidi reads.
+func (w *withGRPCAppendableUploadsConfig) ApplyStorageOpt(config *storageConfig) {
 	config.grpcAppendableUploads = true
-	config.grpcBidiReads = true
 }
 
 func withOtelMetrics() option.ClientOption {

--- a/storage/option_test.go
+++ b/storage/option_test.go
@@ -139,19 +139,19 @@ func TestApplyStorageOpt(t *testing.T) {
 		},
 		{
 			desc: "use gRPC bidi reads",
-			opts: []option.ClientOption{withGRPCBidiReads()},
+			opts: []option.ClientOption{WithGRPCBidiReads()},
 			want: storageConfig{
 				grpcBidiReads: true,
 			},
 		},
 		{
-			desc: "use gRPC zonal bucket APIs",
-			opts: []option.ClientOption{withZonalBucketAPIs()},
+			desc: "use gRPC appendable uploads",
+			opts: []option.ClientOption{WithAppendableUploads()},
 			want: storageConfig{
-				grpcBidiReads:         true,
 				grpcAppendableUploads: true,
 			},
 		},
+
 		{
 			desc: "enforce direct connectivity",
 			opts: []option.ClientOption{withDirectConnectivityEnforced()},

--- a/storage/reader.go
+++ b/storage/reader.go
@@ -259,13 +259,8 @@ func WithDisableReaderChecksum() ReaderOption {
 // NewMultiRangeDownloader creates a multi-range reader for an object.
 // Must be called on a gRPC client created using [NewGRPCClient].
 //
-// This uses the gRPC-specific bi-directional read API, which is in private
-// preview; please contact your account manager if interested. The option
-// [experimental.WithGRPCBidiReads] or [experimental.WithZonalBucketAPIs]
-// must be selected in order to use this API.
-
-// NewMultiRangeDownloader creates a multi-range reader for an object.
-// Must be called on a gRPC client created using [NewGRPCClient].
+// This uses the gRPC-specific bi-directional read API. The option
+// [WithGRPCBidiReads] must be selected in order to use this API.
 func (o *ObjectHandle) NewMultiRangeDownloader(ctx context.Context, opts ...MRDOption) (mrd *MultiRangeDownloader, err error) {
 	// This span covers the life of the MRD. It is closed via the context
 	// in MultiRangeDownloader.Close.
@@ -525,9 +520,7 @@ func (r *Reader) Metadata() map[string]string {
 // ReadHandle returns the read handle associated with an object.
 // ReadHandle will be periodically refreshed.
 //
-// ReadHandle requires the gRPC-specific bi-directional read API, which is in
-// private preview; please contact your account manager if interested.
-// Note that this only valid for gRPC and only with zonal buckets.
+// ReadHandle requires the gRPC-specific bi-directional read API.
 func (r *Reader) ReadHandle() ReadHandle {
 	if r.handle == nil {
 		r.handle = &ReadHandle{}
@@ -541,8 +534,6 @@ func (r *Reader) ReadHandle() ReadHandle {
 //
 // Typically, a MultiRangeDownloader opens a stream to which we can add
 // different ranges to read from the object.
-//
-// This API is currently in preview and is not yet available for general use.
 type MultiRangeDownloader struct {
 	// Attrs is populated when NewMultiRangeDownloader returns.
 	Attrs ReaderObjectAttrs

--- a/storage/retry_conformance_test.go
+++ b/storage/retry_conformance_test.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/internal/uid"
-	"cloud.google.com/go/storage/experimental"
 	storage_v1_tests "cloud.google.com/go/storage/internal/test/conformance"
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/gax-go/v2"
@@ -1303,7 +1302,7 @@ func (et *emulatorTest) create(instructions map[string][]string, transport strin
 		et.Fatalf("HTTP transportClient: %v", err)
 	}
 	if transport == "grpc" {
-		transportClient, err = NewGRPCClient(ctx, experimental.WithGRPCBidiReads())
+		transportClient, err = NewGRPCClient(ctx, WithGRPCBidiReads())
 		if err != nil {
 			et.Fatalf("GRPC transportClient: %v", err)
 		}

--- a/storage/retry_context_test.go
+++ b/storage/retry_context_test.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 	"testing"
 
-	"cloud.google.com/go/storage/experimental"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -289,7 +288,7 @@ func TestGRPCRetryContextMetadataMultiRangeDownloader(t *testing.T) {
 		option.WithEndpoint("localhost:1"),
 		option.WithoutAuthentication(),
 		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
-		experimental.WithGRPCBidiReads(),
+		WithGRPCBidiReads(),
 	)
 	if err != nil {
 		t.Fatalf("NewGRPCClient: %v", err)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1314,7 +1314,6 @@ func (o *ObjectHandle) NewWriter(ctx context.Context) *Writer {
 //
 // NewWriterFromAppendableObject is supported only for gRPC clients and only for
 // objects which were created append semantics and not finalized.
-// This feature is in preview and is not yet available for general use.
 func (o *ObjectHandle) NewWriterFromAppendableObject(ctx context.Context, opts *AppendableWriterOpts) (*Writer, int64, error) {
 	ctx, _ = startSpanWithBucket(ctx, o.c, o.bucket, "Object.WriterFromAppendableObject")
 	if o.gen < 0 {
@@ -1360,7 +1359,6 @@ func (o *ObjectHandle) NewWriterFromAppendableObject(ctx context.Context, opts *
 //
 // AppendableWriterOpts is supported only for gRPC clients and only for
 // objects which were created append semantics and not finalized.
-// This feature is in preview and is not yet available for general use.
 type AppendableWriterOpts struct {
 	// ChunkSize: See Writer.ChunkSize.
 	ChunkSize int

--- a/storage/writer.go
+++ b/storage/writer.go
@@ -153,11 +153,9 @@ type Writer struct {
 	// when Writer.Close() is called; otherwise, the object is left unfinalized
 	// and can be appended to later.
 	//
-	// Defaults to false unless the experiemental WithZonalBucketAPIs option was
-	// set.
+	// Defaults to false unless the [WithAppendableUploads] option was set.
 	//
-	// Append is only supported for gRPC. This feature is in preview and is not
-	// yet available for general use.
+	// Append is only supported for gRPC.
 	Append bool
 
 	// FinalizeOnClose indicates whether the Writer should finalize an object when
@@ -167,8 +165,6 @@ type Writer struct {
 	// finalized, which means they can be appended to later. If Append is set
 	// to false, this parameter will be ignored; non-appendable objects will
 	// always be finalized when Writer.Close returns without error.
-	//
-	// This feature is in preview and is not yet available for general use.
 	FinalizeOnClose bool
 
 	// ProgressFunc can be used to monitor the progress of a large write
@@ -360,7 +356,7 @@ func (w *Writer) Write(p []byte) (int, error) {
 // automatic content sniffing in the Writer.
 //
 // Flush is supported only on gRPC clients where [Writer.Append] is set
-// to true. This feature is in preview and is not yet available for general use.
+// to true.
 func (w *Writer) Flush() (int64, error) {
 	// Return error if Append is not true.
 	if !w.Append {


### PR DESCRIPTION
This PR promotes `WithGRPCBidiReads` and `WithGRPCAppendableUploads` to first-class client options in `cloud.google.com/go/storage` and deprecates `experimental.WithZonalBucketAPIs`, `experimental.WithGRPCBidiReads`, and `experimental.WithGRPCAppendableUploads`.

Addresses b/499344674 and b/522528862.