### PR TITLE
feat(spanner): support caller-owned OpenTelemetry client metrics

### DIFF
--- a/spanner/README.md
+++ b/spanner/README.md
@@ -137,3 +137,51 @@ defer client.Close()
 You can also disable these metrics by setting `SPANNER_DISABLE_BUILTIN_METRICS` to `true`.
 
 > Note: Exporting client-side metrics requires the `monitoring.timeSeries.create` IAM permission. To grant this, ask your administrator to assign the [Monitoring Metric Writer](https://cloud.google.com/iam/docs/roles-permissions/monitoring#monitoring.metricWriter) (`roles/monitoring.metricWriter`) IAM role to your application's service account.
+
+### Exporting client metrics to OpenTelemetry
+
+To additionally export the same built-in client metrics through a caller-owned
+OpenTelemetry pipeline, configure a dedicated meter provider and set
+`ClientMetricsProvider`:
+
+```go
+reader := sdkmetric.NewPeriodicReader(exporter) // OTLP, Prometheus, or another exporter.
+providerOptions := spanner.ClientMetricsMeterProviderOptions()
+providerOptions = append(providerOptions, sdkmetric.WithReader(reader))
+provider := sdkmetric.NewMeterProvider(providerOptions...)
+defer provider.Shutdown(ctx)
+
+client, err := spanner.NewClientWithConfig(ctx, database, spanner.ClientConfig{
+	ClientMetricsProvider: provider,
+})
+if err != nil {
+	log.Fatal(err)
+}
+defer client.Close()
+```
+
+The caller owns the meter provider. Spanner instruments use the
+`spanner/client/` prefix; `ClientMetricsMeterProviderOptions` also maps the gRPC
+instruments into that namespace. Use a dedicated meter provider because these
+views select gRPC instrument names shared by other clients.
+
+The OpenTelemetry Prometheus exporter renders counters as
+`spanner_client_<name>_total` and millisecond histograms as
+`spanner_client_<name>_milliseconds_{bucket,count,sum}`. For example, it exports
+`spanner_client_operation_count_total` and
+`spanner_client_operation_latencies_milliseconds_bucket`.
+
+The gRPC-layer instruments are included only when gRPC built-in metrics are
+enabled through `SPANNER_DISABLE_DIRECT_ACCESS_GRPC_BUILTIN_METRICS=false` or
+DirectPath. AFE latency instruments are included only when AFE server timing is
+enabled.
+
+This caller-owned export is independent of the Cloud Monitoring export.
+`DisableNativeMetrics` and `SPANNER_DISABLE_BUILTIN_METRICS` control only Cloud
+Monitoring, so both sinks can be enabled together. Neither sink records metrics
+when the client targets the Spanner emulator. `OpenTelemetryMeterProvider`
+configures the older Spanner metrics surface and does not enable this built-in
+client-metrics export.
+
+On Spanner Omni, the Cloud Monitoring export is unavailable and always off.
+Use `ClientMetricsProvider` to export client metrics from an Omni client.

--- a/spanner/client.go
+++ b/spanner/client.go
@@ -371,6 +371,14 @@ type ClientConfig struct {
 
 	OpenTelemetryMeterProvider metric.MeterProvider
 
+	// ClientMetricsProvider exports Spanner built-in client metrics to a
+	// caller-owned OpenTelemetry pipeline. Metrics use the spanner/client/
+	// instrument namespace. This provider is independent of the native Cloud
+	// Monitoring export controlled by DisableNativeMetrics and
+	// SPANNER_DISABLE_BUILTIN_METRICS. A nil provider disables this export.
+	// The caller owns the provider lifecycle.
+	ClientMetricsProvider metric.MeterProvider
+
 	// EnableEndToEndTracing indicates whether end to end tracing is enabled or not. If
 	// it is enabled, trace spans will be created at Spanner layer. Enabling end to end
 	// tracing requires OpenTelemetry to be set up. Simply enabling this option won't
@@ -379,8 +387,8 @@ type ClientConfig struct {
 	// Default: false
 	EnableEndToEndTracing bool
 
-	// DisableNativeMetrics indicates whether native metrics should be disabled or not.
-	// If true, native metrics will not be emitted.
+	// DisableNativeMetrics disables the native Cloud Monitoring export. It does
+	// not affect the caller-owned export configured by ClientMetricsProvider.
 	//
 	// Default: false
 	DisableNativeMetrics bool
@@ -551,6 +559,11 @@ func isDCPEnabledForConfig(config ClientConfig, gme *grpcgcp.GCPMultiEndpoint) b
 		os.Getenv("SPANNER_EMULATOR_HOST") == ""
 }
 
+// isSpannerEmulatorEnabled is the shared metrics gate for emulator clients.
+func isSpannerEmulatorEnabled() bool {
+	return os.Getenv("SPANNER_EMULATOR_HOST") != ""
+}
+
 func createDCPConnPool(
 	ctx context.Context,
 	database string,
@@ -691,18 +704,19 @@ func newClientWithConfig(ctx context.Context, database string, config ClientConf
 		config.NumChannels = numChannels
 	}
 
+	emulatorEnabled := isSpannerEmulatorEnabled()
 	var metricsProvider metric.MeterProvider
-	if emulatorAddr := os.Getenv("SPANNER_EMULATOR_HOST"); emulatorAddr != "" {
-		// Do not emit native metrics when emulator is being used
-		metricsProvider = noop.NewMeterProvider()
-	}
 	// Check if native metrics are disabled via env.
 	if disableNativeMetrics, _ := strconv.ParseBool(os.Getenv("SPANNER_DISABLE_BUILTIN_METRICS")); disableNativeMetrics {
 		config.DisableNativeMetrics = true
 	}
-	if config.DisableNativeMetrics {
-		// Do not emit native metrics when DisableNativeMetrics is set
+	if config.DisableNativeMetrics || config.Type == OMNI || config.IsExperimentalHost || emulatorEnabled {
+		// Do not emit native metrics when the Cloud Monitoring sink is unavailable or disabled.
 		metricsProvider = noop.NewMeterProvider()
+	}
+	clientMetricsProvider := config.ClientMetricsProvider
+	if emulatorEnabled {
+		clientMetricsProvider = nil
 	}
 	isAFEBuiltInMetricEnabled := strings.EqualFold("false", os.Getenv("SPANNER_DISABLE_AFE_SERVER_TIMING"))
 	isGRPCBuiltInMetricsEnabled := strings.EqualFold("false", os.Getenv("SPANNER_DISABLE_DIRECT_ACCESS_GRPC_BUILTIN_METRICS"))
@@ -723,7 +737,7 @@ func newClientWithConfig(ctx context.Context, database string, config ClientConf
 		isGRPCBuiltInMetricsEnabled = false
 	}
 
-	metricsTracerFactory, err := newBuiltinMetricsTracerFactory(ctx, database, config.Compression, isAFEBuiltInMetricEnabled, isGRPCBuiltInMetricsEnabled, metricsProvider, opts...)
+	metricsTracerFactory, err := newBuiltinMetricsTracerFactory(ctx, database, config.Compression, isAFEBuiltInMetricEnabled, isGRPCBuiltInMetricsEnabled, metricsProvider, clientMetricsProvider, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/spanner/client_metrics_test.go
+++ b/spanner/client_metrics_test.go
@@ -18,10 +18,13 @@ package spanner
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"google.golang.org/api/option"
@@ -429,4 +432,45 @@ func TestClientMetricsOptionsDoNotRenameEEFMetrics(t *testing.T) {
 	if _, ok := findTestMetric(rm, clientMetricsPrefix+"eef/fallback/count"); ok {
 		t.Fatal("EEF metric renamed into caller-owned client namespace")
 	}
+}
+
+type failingInstrumentMeter struct {
+	noop.Meter
+}
+
+func (failingInstrumentMeter) Float64Histogram(string, ...otelmetric.Float64HistogramOption) (otelmetric.Float64Histogram, error) {
+	return nil, errors.New("instrument creation failed")
+}
+
+type failingInstrumentMeterProvider struct {
+	noop.MeterProvider
+}
+
+func (failingInstrumentMeterProvider) Meter(string, ...otelmetric.MeterOption) otelmetric.Meter {
+	return failingInstrumentMeter{}
+}
+
+func TestNewBuiltinMetricsTracerFactoryReleasesNativeProviderOnClientSinkError(t *testing.T) {
+	installTestMonitoringExporter(t)
+	factory, err := newBuiltinMetricsTracerFactory(
+		context.Background(),
+		"projects/p/instances/i/databases/d",
+		"identity",
+		true,
+		false,
+		nil,
+		failingInstrumentMeterProvider{},
+	)
+	if err == nil {
+		t.Fatal("newBuiltinMetricsTracerFactory() succeeded with a failing client metrics provider")
+	}
+	native, ok := factory.meterProvider.(*metric.MeterProvider)
+	if !ok {
+		t.Fatalf("native meter provider type = %T, want *metric.MeterProvider", factory.meterProvider)
+	}
+	if err := native.ForceFlush(context.Background()); !errors.Is(err, metric.ErrReaderShutdown) {
+		t.Fatalf("native meter provider ForceFlush() error = %v, want %v after constructor failure", err, metric.ErrReaderShutdown)
+	}
+	// The failed constructor already released what it owned; a later shutdown must be a no-op.
+	factory.shutdown(context.Background())
 }

--- a/spanner/client_metrics_test.go
+++ b/spanner/client_metrics_test.go
@@ -1,0 +1,432 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spanner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type testMonitoringExporter struct {
+	server             *MetricsTestServer
+	createOptionsCalls int
+}
+
+func installTestMonitoringExporter(t *testing.T) *testMonitoringExporter {
+	t.Helper()
+	server, err := NewMetricTestServer()
+	if err != nil {
+		t.Fatalf("NewMetricTestServer() failed: %v", err)
+	}
+	go server.Serve()
+
+	testExporter := &testMonitoringExporter{server: server}
+	original := createExporterOptions
+	createExporterOptions = func(...option.ClientOption) []option.ClientOption {
+		testExporter.createOptionsCalls++
+		return []option.ClientOption{
+			option.WithEndpoint(server.Endpoint),
+			option.WithoutAuthentication(),
+			option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		}
+	}
+	t.Cleanup(func() {
+		createExporterOptions = original
+		server.Shutdown()
+	})
+	return testExporter
+}
+
+func newTestMeterProvider() (*metric.ManualReader, *metric.MeterProvider) {
+	reader := metric.NewManualReader()
+	options := ClientMetricsMeterProviderOptions()
+	options = append(options, metric.WithReader(reader))
+	return reader, metric.NewMeterProvider(options...)
+}
+
+func collectTestMetrics(t *testing.T, reader *metric.ManualReader) metricdata.ResourceMetrics {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect() failed: %v", err)
+	}
+	return rm
+}
+
+func findTestMetric(rm metricdata.ResourceMetrics, name string) (metricdata.Metrics, bool) {
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				return m, true
+			}
+		}
+	}
+	return metricdata.Metrics{}, false
+}
+
+func requireTestMetric(t *testing.T, rm metricdata.ResourceMetrics, name string) metricdata.Metrics {
+	t.Helper()
+	m, ok := findTestMetric(rm, name)
+	if !ok {
+		t.Fatalf("metric %q not found in %+v", name, rm.ScopeMetrics)
+	}
+	return m
+}
+
+func sumInt64Metric(t *testing.T, rm metricdata.ResourceMetrics, name string) int64 {
+	t.Helper()
+	m := requireTestMetric(t, rm, name)
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	if !ok {
+		t.Fatalf("metric %q data type = %T, want metricdata.Sum[int64]", name, m.Data)
+	}
+	var value int64
+	for _, point := range sum.DataPoints {
+		value += point.Value
+	}
+	return value
+}
+
+func hasAttrs(set attribute.Set, want map[attribute.Key]string) bool {
+	for key, value := range want {
+		got, ok := set.Value(key)
+		if !ok || got.AsString() != value {
+			return false
+		}
+	}
+	return true
+}
+
+func requireOperationCountAttrs(t *testing.T, rm metricdata.ResourceMetrics, prefix string) {
+	t.Helper()
+	m := requireTestMetric(t, rm, prefix+metricNameOperationCount)
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	if !ok {
+		t.Fatalf("metric %q data type = %T, want metricdata.Sum[int64]", m.Name, m.Data)
+	}
+	want := map[attribute.Key]string{
+		metricLabelKeyMethod:     "Spanner.StreamingRead",
+		metricLabelKeyStatus:     "OK",
+		metricLabelKeyDatabase:   "[DATABASE]",
+		metricLabelKeyClientName: clientName,
+	}
+	for _, point := range sum.DataPoints {
+		if point.Value > 0 && hasAttrs(point.Attributes, want) {
+			return
+		}
+	}
+	t.Fatalf("metric %q has no positive point with attributes %v: %+v", m.Name, want, sum.DataPoints)
+}
+
+func issueClientMetricsRead(t *testing.T, config ClientConfig) metricdata.ResourceMetrics {
+	t.Helper()
+	reader, provider := newTestMeterProvider()
+	config.ClientMetricsProvider = provider
+	_, client, teardown := setupMockedTestServerWithConfig(t, config)
+	defer teardown()
+	if _, err := client.Single().ReadRow(context.Background(), "Albums", Key{"foo"}, []string{"SingerId", "AlbumId", "AlbumTitle"}); err != nil {
+		t.Fatalf("ReadRow() failed: %v", err)
+	}
+	return collectTestMetrics(t, reader)
+}
+
+func TestClientMetricsProviderRecordsBuiltInMetrics(t *testing.T) {
+	rm := issueClientMetricsRead(t, ClientConfig{DisableNativeMetrics: true})
+	requireOperationCountAttrs(t, rm, clientMetricsPrefix)
+	requireTestMetric(t, rm, clientMetricsPrefix+metricNameAttemptLatencies)
+	if _, ok := findTestMetric(rm, nativeMetricsPrefix+metricNameOperationCount); ok {
+		t.Fatalf("custom provider contains reserved metric %q", nativeMetricsPrefix+metricNameOperationCount)
+	}
+}
+
+func TestClientMetricsProviderIndependentOfNativeDisableControls(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		disable    bool
+		disableEnv string
+	}{
+		{name: "config", disable: true},
+		{name: "environment", disableEnv: "true"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("SPANNER_DISABLE_BUILTIN_METRICS", test.disableEnv)
+			rm := issueClientMetricsRead(t, ClientConfig{DisableNativeMetrics: test.disable})
+			requireOperationCountAttrs(t, rm, clientMetricsPrefix)
+		})
+	}
+}
+
+func TestClientMetricsProviderNilPreservesDisabledBehavior(t *testing.T) {
+	_, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{DisableNativeMetrics: true})
+	defer teardown()
+	if client.metricsTracerFactory.enabled {
+		t.Fatal("metrics tracer enabled with native metrics disabled and nil ClientMetricsProvider")
+	}
+}
+
+func TestOpenTelemetryMeterProviderDoesNotEnableClientMetrics(t *testing.T) {
+	_, provider := newTestMeterProvider()
+	_, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{
+		DisableNativeMetrics:       true,
+		OpenTelemetryMeterProvider: provider,
+	})
+	defer teardown()
+	if client.metricsTracerFactory.enabled {
+		t.Fatal("OpenTelemetryMeterProvider enabled built-in client metrics")
+	}
+}
+
+func TestClientMetricsOmniMatrix(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		config ClientConfig
+		custom bool
+	}{
+		{
+			name: "omni default",
+			config: ClientConfig{
+				Type:         OMNI,
+				UsePlainText: true,
+			},
+		},
+		{
+			name: "omni custom provider",
+			config: ClientConfig{
+				Type:         OMNI,
+				UsePlainText: true,
+			},
+			custom: true,
+		},
+		{
+			name: "deprecated experimental host",
+			config: ClientConfig{
+				IsExperimentalHost: true,
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("SPANNER_DISABLE_BUILTIN_METRICS", "")
+			testExporter := installTestMonitoringExporter(t)
+			var reader *metric.ManualReader
+			if test.custom {
+				var provider *metric.MeterProvider
+				reader, provider = newTestMeterProvider()
+				test.config.ClientMetricsProvider = provider
+			}
+
+			_, client, teardown := setupMockedTestServerWithConfig(t, test.config)
+			defer teardown()
+			if testExporter.createOptionsCalls != 0 {
+				t.Fatalf("native monitoring exporter constructed %d times for Omni", testExporter.createOptionsCalls)
+			}
+			if test.custom {
+				if !client.metricsTracerFactory.enabled || len(client.metricsTracerFactory.sinks) != 1 {
+					t.Fatalf("custom Omni sinks = %d, enabled = %v, want one enabled sink", len(client.metricsTracerFactory.sinks), client.metricsTracerFactory.enabled)
+				}
+				if client.metricsTracerFactory.meterProvider != nil {
+					t.Fatal("custom provider wired to native DirectPath fallback metrics")
+				}
+				if _, err := client.Single().ReadRow(context.Background(), "Albums", Key{"foo"}, []string{"SingerId", "AlbumId", "AlbumTitle"}); err != nil {
+					t.Fatalf("ReadRow() failed: %v", err)
+				}
+				requireOperationCountAttrs(t, collectTestMetrics(t, reader), clientMetricsPrefix)
+			} else if client.metricsTracerFactory.enabled || len(client.metricsTracerFactory.sinks) != 0 {
+				t.Fatalf("default Omni sinks = %d, enabled = %v, want none", len(client.metricsTracerFactory.sinks), client.metricsTracerFactory.enabled)
+			}
+		})
+	}
+}
+
+func TestClientMetricsBothProvidersRecord(t *testing.T) {
+	nativeReader, nativeProvider := newTestMeterProvider()
+	clientReader, clientProvider := newTestMeterProvider()
+	factory, err := newBuiltinMetricsTracerFactory(
+		context.Background(),
+		"projects/p/instances/i/databases/d",
+		"identity",
+		true,
+		false,
+		nativeProvider,
+		clientProvider,
+	)
+	if err != nil {
+		t.Fatalf("newBuiltinMetricsTracerFactory() failed: %v", err)
+	}
+	recordSuccessfulTestOperation(factory)
+	nativeMetrics := collectTestMetrics(t, nativeReader)
+	clientMetrics := collectTestMetrics(t, clientReader)
+	requireTestMetric(t, nativeMetrics, nativeMetricsPrefix+metricNameOperationCount)
+	requireTestMetric(t, clientMetrics, clientMetricsPrefix+metricNameOperationCount)
+	if _, ok := findTestMetric(nativeMetrics, clientMetricsPrefix+metricNameOperationCount); ok {
+		t.Fatal("native provider contains caller-owned metric namespace")
+	}
+	if _, ok := findTestMetric(clientMetrics, nativeMetricsPrefix+metricNameOperationCount); ok {
+		t.Fatal("caller-owned provider contains native metric namespace")
+	}
+}
+
+func TestClientMetricsBothSinksThroughClient(t *testing.T) {
+	t.Setenv("SPANNER_DISABLE_BUILTIN_METRICS", "")
+	t.Setenv("SPANNER_DISABLE_DIRECT_ACCESS_GRPC_BUILTIN_METRICS", "false")
+	testExporter := installTestMonitoringExporter(t)
+	reader, provider := newTestMeterProvider()
+	_, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{ClientMetricsProvider: provider})
+	defer teardown()
+
+	before := collectTestMetrics(t, reader)
+	beforeGRPC := sumInt64Metric(t, before, clientMetricsPrefix+"grpc/client/attempt/started")
+	beforeAttempts := sumInt64Metric(t, before, clientMetricsPrefix+metricNameAttemptCount)
+	if _, err := client.Single().ReadRow(context.Background(), "Albums", Key{"foo"}, []string{"SingerId", "AlbumId", "AlbumTitle"}); err != nil {
+		t.Fatalf("ReadRow() failed: %v", err)
+	}
+	after := collectTestMetrics(t, reader)
+	grpcDelta := sumInt64Metric(t, after, clientMetricsPrefix+"grpc/client/attempt/started") - beforeGRPC
+	attemptDelta := sumInt64Metric(t, after, clientMetricsPrefix+metricNameAttemptCount) - beforeAttempts
+	if grpcDelta != 1 || attemptDelta != 1 || grpcDelta != attemptDelta {
+		t.Fatalf("read metric deltas: gRPC attempts = %d, client attempts = %d, want one each", grpcDelta, attemptDelta)
+	}
+	requireTestMetric(t, after, clientMetricsPrefix+metricNameAttemptLatencies)
+	requireTestMetric(t, after, clientMetricsPrefix+metricNameGFELatencies)
+
+	client.Close()
+	if testExporter.createOptionsCalls != 1 {
+		t.Fatalf("native monitoring exporter construction count = %d, want 1", testExporter.createOptionsCalls)
+	}
+	wantNative := map[string]bool{
+		nativeMetricsPrefix + metricNameAttemptLatencies: false,
+		nativeMetricsPrefix + metricNameGFELatencies:     false,
+	}
+	for _, req := range testExporter.server.CreateServiceTimeSeriesRequests() {
+		for _, series := range req.TimeSeries {
+			if _, ok := wantNative[series.GetMetric().GetType()]; ok {
+				wantNative[series.GetMetric().GetType()] = true
+			}
+		}
+	}
+	for name, found := range wantNative {
+		if !found {
+			t.Errorf("native sink metric %q not exported", name)
+		}
+	}
+}
+
+func recordSuccessfulTestOperation(factory *builtinMetricsTracerFactory) {
+	mt := factory.createBuiltinMetricsTracer(context.Background())
+	mt.method = "/google.spanner.v1.Spanner/Read"
+	mt.currOp.incrementAttemptCount()
+	mt.currOp.setStatus("OK")
+	mt.currOp.currAttempt = &attemptTracer{status: "OK", serverTimingMetrics: map[string]time.Duration{}}
+	recordOperationCompletion(&mt)
+}
+
+func TestClientMetricsSuppressedForEmulator(t *testing.T) {
+	reader, provider := newTestMeterProvider()
+	t.Setenv("SPANNER_EMULATOR_HOST", "localhost:9010")
+	if !isSpannerEmulatorEnabled() {
+		t.Fatal("isSpannerEmulatorEnabled() = false, want true")
+	}
+	factory, err := newBuiltinMetricsTracerFactory(
+		context.Background(),
+		"projects/p/instances/i/databases/d",
+		"identity",
+		true,
+		true,
+		nil,
+		provider,
+	)
+	if err != nil {
+		t.Fatalf("newBuiltinMetricsTracerFactory() failed: %v", err)
+	}
+	if factory.enabled {
+		t.Fatal("metrics tracer enabled for emulator")
+	}
+	recordSuccessfulTestOperation(factory)
+	if got := collectTestMetrics(t, reader).ScopeMetrics; len(got) != 0 {
+		t.Fatalf("emulator metrics = %+v, want none", got)
+	}
+}
+
+func TestEmulatorDetectionUsesEnvironmentOnly(t *testing.T) {
+	t.Setenv("SPANNER_EMULATOR_HOST", "")
+	if isSpannerEmulatorEnabled() {
+		t.Fatal("isSpannerEmulatorEnabled() = true without SPANNER_EMULATOR_HOST")
+	}
+}
+
+func TestClientMetricsProviderReceivesGRPCMetrics(t *testing.T) {
+	t.Setenv("SPANNER_DISABLE_DIRECT_ACCESS_GRPC_BUILTIN_METRICS", "false")
+	rm := issueClientMetricsRead(t, ClientConfig{DisableNativeMetrics: true})
+	m := requireTestMetric(t, rm, clientMetricsPrefix+"grpc/client/attempt/started")
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	if !ok {
+		t.Fatalf("metric %q data type = %T, want metricdata.Sum[int64]", m.Name, m.Data)
+	}
+	for _, point := range sum.DataPoints {
+		if _, ok := point.Attributes.Value("grpc.method"); ok {
+			return
+		}
+	}
+	t.Fatalf("metric %q has no point with grpc.method: %+v", m.Name, sum.DataPoints)
+}
+
+func TestClientCloseDoesNotShutdownClientMetricsProvider(t *testing.T) {
+	reader, provider := newTestMeterProvider()
+	_, client, teardown := setupMockedTestServerWithConfig(t, ClientConfig{
+		DisableNativeMetrics:  true,
+		ClientMetricsProvider: provider,
+	})
+	defer func() {
+		teardown()
+		provider.Shutdown(context.Background())
+	}()
+	client.Close()
+
+	counter, err := provider.Meter("client-close-test").Int64Counter("client_close_test")
+	if err != nil {
+		t.Fatalf("Int64Counter() failed after Client.Close(): %v", err)
+	}
+	counter.Add(context.Background(), 1)
+	rm := collectTestMetrics(t, reader)
+	if got := sumInt64Metric(t, rm, "client_close_test"); got != 1 {
+		t.Fatalf("client_close_test = %d, want 1", got)
+	}
+}
+
+func TestClientMetricsOptionsDoNotRenameEEFMetrics(t *testing.T) {
+	reader, provider := newTestMeterProvider()
+	t.Cleanup(func() { provider.Shutdown(context.Background()) })
+	counter, err := provider.Meter(grpcGcpMetricMeterName).Int64Counter(metricNameEEFFallbackCount)
+	if err != nil {
+		t.Fatalf("Int64Counter() failed: %v", err)
+	}
+	counter.Add(context.Background(), 1)
+	rm := collectTestMetrics(t, reader)
+	if got := sumInt64Metric(t, rm, metricNameEEFFallbackCount); got != 1 {
+		t.Fatalf("%s = %d, want 1", metricNameEEFFallbackCount, got)
+	}
+	if _, ok := findTestMetric(rm, clientMetricsPrefix+"eef/fallback/count"); ok {
+		t.Fatal("EEF metric renamed into caller-owned client namespace")
+	}
+}

--- a/spanner/doc.go
+++ b/spanner/doc.go
@@ -40,6 +40,56 @@ of interest:
 Remember to close the client after use to free up the sessions in the session
 pool.
 
+# Exporting client metrics to OpenTelemetry
+
+By default, Spanner exports built-in client metrics to Cloud Monitoring. To
+additionally export the same metrics through a caller-owned OpenTelemetry
+pipeline, set [ClientConfig.ClientMetricsProvider]. The provider may use any
+OpenTelemetry-compatible reader or exporter, including OTLP and Prometheus:
+
+	reader := sdkmetric.NewPeriodicReader(exporter)
+	providerOptions := spanner.ClientMetricsMeterProviderOptions()
+	providerOptions = append(providerOptions, sdkmetric.WithReader(reader))
+	provider := sdkmetric.NewMeterProvider(providerOptions...)
+	defer provider.Shutdown(ctx)
+
+	client, err := spanner.NewClientWithConfig(ctx, database, spanner.ClientConfig{
+	    ClientMetricsProvider: provider,
+	})
+	if err != nil {
+	    // TODO: Handle error.
+	}
+	defer client.Close()
+
+The caller owns the meter provider and must shut it down. Spanner application
+instruments use the spanner/client/ prefix. The options returned by
+[ClientMetricsMeterProviderOptions] also rename the gRPC instruments into that
+namespace. Use a meter provider dedicated to Spanner client metrics because
+those views select instrument names shared by other gRPC clients.
+
+The OpenTelemetry Prometheus exporter renders counters as
+spanner_client_<name>_total and millisecond histograms as
+spanner_client_<name>_milliseconds_{bucket,count,sum}. For example, it exports
+spanner_client_operation_count_total and
+spanner_client_operation_latencies_milliseconds_bucket.
+
+The gRPC-layer instruments are included only when gRPC built-in metrics are
+enabled through SPANNER_DISABLE_DIRECT_ACCESS_GRPC_BUILTIN_METRICS=false or
+DirectPath. AFE latency instruments are included only when AFE server timing is
+enabled.
+
+This export is independent of the built-in Cloud Monitoring sink.
+[ClientConfig.DisableNativeMetrics] and SPANNER_DISABLE_BUILTIN_METRICS control
+only Cloud Monitoring; they do not disable ClientMetricsProvider. Both sinks
+may be active simultaneously. Client metrics are not recorded for emulator
+clients. [ClientConfig.OpenTelemetryMeterProvider] configures the older Spanner
+OpenTelemetry metrics surface and does not enable this built-in client-metrics
+export.
+
+On Spanner Omni, the Cloud Monitoring export is unavailable and is always off.
+Set [ClientConfig.ClientMetricsProvider] to export client metrics from an Omni
+client.
+
 To use an emulator with this library, you can set the SPANNER_EMULATOR_HOST
 environment variable to the address at which your emulator is running. This will
 send requests to that address instead of to Cloud Spanner. You can then create

--- a/spanner/metrics.go
+++ b/spanner/metrics.go
@@ -18,7 +18,6 @@ package spanner
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"hash/fnv"
 	"log"
@@ -52,6 +51,7 @@ const (
 	grpcGcpMetricMeterName  = "grpc-gcp-go"
 
 	nativeMetricsPrefix = "spanner.googleapis.com/internal/client/"
+	clientMetricsPrefix = "spanner/client/"
 
 	// Monitored resource labels
 	monitoredResLabelKeyProject        = "project_id"
@@ -257,6 +257,52 @@ type metricInfo struct {
 	recordedPerAttempt bool
 }
 
+// ClientMetricsMeterProviderOptions returns OpenTelemetry SDK meter-provider
+// options for Spanner client metrics. The views rename gRPC instruments into
+// the spanner/client/ namespace and apply the same attribute filtering and
+// aggregation used by the native Cloud Monitoring export.
+//
+// Pass these options to [go.opentelemetry.io/otel/sdk/metric.NewMeterProvider]
+// before the resulting provider is assigned to
+// [ClientConfig.ClientMetricsProvider]. Use a meter provider dedicated to
+// Spanner client metrics because the views match gRPC instrument names shared
+// by other gRPC clients.
+func ClientMetricsMeterProviderOptions() []sdkmetric.Option {
+	var views []sdkmetric.View
+	for _, name := range grpcMetricsToEnable {
+		views = append(views, sdkmetric.NewView(
+			sdkmetric.Instrument{Name: name},
+			sdkmetric.Stream{
+				Name:        clientMetricsPrefix + strings.ReplaceAll(name, ".", "/"),
+				Aggregation: sdkmetric.AggregationSum{},
+				AttributeFilter: func(kv attribute.KeyValue) bool {
+					if kv.Key == "grpc.method" || kv.Key == "grpc.target" {
+						return true
+					}
+					return allowedMetricLabels[string(kv.Key)]
+				},
+			},
+		))
+	}
+	return []sdkmetric.Option{sdkmetric.WithView(views...)}
+}
+
+type builtinMetricInstruments struct {
+	operationLatencies metric.Float64Histogram
+	attemptLatencies   metric.Float64Histogram
+	gfeLatencies       metric.Float64Histogram
+	afeLatencies       metric.Float64Histogram
+	gfeErrorCount      metric.Int64Counter
+	afeErrorCount      metric.Int64Counter
+	operationCount     metric.Int64Counter
+	attemptCount       metric.Int64Counter
+}
+
+type builtinMetricsSink struct {
+	builtinMetricInstruments
+	includeClientAttributes bool
+}
+
 // builtinMetricsTracerFactory is responsible for creating and managing metrics tracers.
 type builtinMetricsTracerFactory struct {
 	enabled                   bool // Indicates if metrics tracing is enabled.
@@ -271,20 +317,12 @@ type builtinMetricsTracerFactory struct {
 	// clientAttributes are attributes specific to a client instance that do not change across different function calls on the client.
 	clientAttributes []attribute.KeyValue
 
-	// Metrics instruments
-	operationLatencies metric.Float64Histogram // Histogram for operation latencies.
-	attemptLatencies   metric.Float64Histogram // Histogram for attempt latencies.
-	gfeLatencies       metric.Float64Histogram // Latency between Google's network receiving an RPC and reading back the first byte of the response
-	afeLatencies       metric.Float64Histogram // Latency between Spanner API Frontend receiving an RPC and starting to write back the response.
-	gfeErrorCount      metric.Int64Counter     // Counter for the number of requests that failed to reach the Google network.
-	afeErrorCount      metric.Int64Counter     // Counter for the number of requests that failed to reach the Spanner API Frontend.
-	operationCount     metric.Int64Counter     // Counter for the number of operations.
-	attemptCount       metric.Int64Counter     // Counter for the number of attempts.
+	sinks []builtinMetricsSink
 
 	meterProvider metric.MeterProvider
 }
 
-func newBuiltinMetricsTracerFactory(ctx context.Context, dbpath, compression string, isAFEBuiltInMetricEnabled, isEnableGRPCBuiltInMetrics bool, metricsProvider metric.MeterProvider, opts ...option.ClientOption) (*builtinMetricsTracerFactory, error) {
+func newBuiltinMetricsTracerFactory(ctx context.Context, dbpath, compression string, isAFEBuiltInMetricEnabled, isEnableGRPCBuiltInMetrics bool, metricsProvider, clientMetricsProvider metric.MeterProvider, opts ...option.ClientOption) (*builtinMetricsTracerFactory, error) {
 	clientUID, err := generateClientUID()
 	if err != nil {
 		log.Printf("built-in metrics: generateClientUID failed: %v. Using empty string in the %v metric atteribute", err, metricLabelKeyClientUID)
@@ -312,35 +350,23 @@ func newBuiltinMetricsTracerFactory(ctx context.Context, dbpath, compression str
 	tracerFactory.isAFEBuiltInMetricEnabled = isAFEBuiltInMetricEnabled
 	tracerFactory.isDirectPathEnabled = false
 	tracerFactory.enabled = false
-	var meterProvider *sdkmetric.MeterProvider
+	if isSpannerEmulatorEnabled() {
+		return tracerFactory, nil
+	}
+
+	var grpcMeterProviders []metric.MeterProvider
 	if metricsProvider == nil {
 		// Create default meter provider
 		mpOptions, exporter, err := builtInMeterProviderOptions(project, compression, tracerFactory.clientAttributes, opts...)
 		if err != nil {
 			return tracerFactory, err
 		}
-		meterProvider = sdkmetric.NewMeterProvider(mpOptions...)
+		meterProvider := sdkmetric.NewMeterProvider(mpOptions...)
 		tracerFactory.meterProvider = meterProvider
-
-		if isEnableGRPCBuiltInMetrics {
-			mo := opentelemetry.MetricsOptions{
-				MeterProvider:  meterProvider,
-				Metrics:        stats.NewMetrics(grpcMetricsToEnable...),
-				OptionalLabels: grpcOptionalLabels,
-			}
-
-			// Configure gRPC dial options to enable gRPC metrics collection and static method call option.
-			// The static method call option ensures consistent method names in metrics by preventing gRPC from
-			// automatically adding service prefixes to method names. This helps maintain consistent metric
-			// naming across different gRPC calls.
-			tracerFactory.clientOpts = []option.ClientOption{
-				option.WithGRPCDialOption(
-					opentelemetry.DialOption(opentelemetry.Options{MetricsOptions: mo})),
-				option.WithGRPCDialOption(
-					grpc.WithDefaultCallOptions(grpc.StaticMethodCallOption{})),
-			}
+		if err := tracerFactory.addMetricsSink(meterProvider, nativeMetricsPrefix, false); err != nil {
+			return tracerFactory, err
 		}
-		tracerFactory.enabled = true
+		grpcMeterProviders = append(grpcMeterProviders, meterProvider)
 		tracerFactory.shutdown = func(ctx context.Context) {
 			exporter.stop()
 			meterProvider.Shutdown(ctx)
@@ -348,16 +374,58 @@ func newBuiltinMetricsTracerFactory(ctx context.Context, dbpath, compression str
 	} else {
 		switch metricsProvider.(type) {
 		case noop.MeterProvider:
-			return tracerFactory, nil
+			// Native Cloud Monitoring export is disabled.
 		default:
-			return tracerFactory, errors.New("unknown MetricsProvider type")
+			tracerFactory.meterProvider = metricsProvider
+			if err := tracerFactory.addMetricsSink(metricsProvider, nativeMetricsPrefix, false); err != nil {
+				return tracerFactory, err
+			}
+			grpcMeterProviders = append(grpcMeterProviders, metricsProvider)
 		}
 	}
 
-	// Create meter and instruments
-	meter := meterProvider.Meter(builtInMetricsMeterName, metric.WithInstrumentationVersion(internal.Version))
-	err = tracerFactory.createInstruments(meter)
-	return tracerFactory, err
+	if clientMetricsProvider != nil {
+		switch clientMetricsProvider.(type) {
+		case noop.MeterProvider:
+			// A no-op provider is equivalent to leaving ClientMetricsProvider nil.
+		default:
+			if err := tracerFactory.addMetricsSink(clientMetricsProvider, clientMetricsPrefix, true); err != nil {
+				return tracerFactory, err
+			}
+			grpcMeterProviders = append(grpcMeterProviders, clientMetricsProvider)
+		}
+	}
+
+	if isEnableGRPCBuiltInMetrics && len(grpcMeterProviders) > 0 {
+		for _, provider := range grpcMeterProviders {
+			mo := opentelemetry.MetricsOptions{
+				MeterProvider:  provider,
+				Metrics:        stats.NewMetrics(grpcMetricsToEnable...),
+				OptionalLabels: grpcOptionalLabels,
+			}
+			tracerFactory.clientOpts = append(tracerFactory.clientOpts, option.WithGRPCDialOption(
+				opentelemetry.DialOption(opentelemetry.Options{MetricsOptions: mo})))
+		}
+		// Static method names keep gRPC metric attributes consistent across calls.
+		tracerFactory.clientOpts = append(tracerFactory.clientOpts, option.WithGRPCDialOption(
+			grpc.WithDefaultCallOptions(grpc.StaticMethodCallOption{})))
+	}
+
+	tracerFactory.enabled = len(tracerFactory.sinks) > 0
+	return tracerFactory, nil
+}
+
+func (tf *builtinMetricsTracerFactory) addMetricsSink(provider metric.MeterProvider, prefix string, includeClientAttributes bool) error {
+	meter := provider.Meter(builtInMetricsMeterName, metric.WithInstrumentationVersion(internal.Version))
+	instruments, err := createBuiltinMetricInstruments(meter, prefix)
+	if err != nil {
+		return err
+	}
+	tf.sinks = append(tf.sinks, builtinMetricsSink{
+		builtinMetricInstruments: instruments,
+		includeClientAttributes:  includeClientAttributes,
+	})
+	return nil
 }
 
 func builtInMeterProviderOptions(project, compression string, clientAttributes []attribute.KeyValue, opts ...option.ClientOption) ([]sdkmetric.Option, *monitoringExporter, error) {
@@ -421,86 +489,87 @@ func builtInMeterProviderOptions(project, compression string, clientAttributes [
 	), sdkmetric.WithView(views...)}, defaultExporter, nil
 }
 
-func (tf *builtinMetricsTracerFactory) createInstruments(meter metric.Meter) error {
+func createBuiltinMetricInstruments(meter metric.Meter, prefix string) (builtinMetricInstruments, error) {
+	var instruments builtinMetricInstruments
 	var err error
 
 	// Create operation_latencies
-	tf.operationLatencies, err = meter.Float64Histogram(
-		nativeMetricsPrefix+metricNameOperationLatencies,
+	instruments.operationLatencies, err = meter.Float64Histogram(
+		prefix+metricNameOperationLatencies,
 		metric.WithDescription("Total time until final operation success or failure, including retries and backoff."),
 		metric.WithUnit(metricUnitMS),
 		metric.WithExplicitBucketBoundaries(bucketBounds...),
 	)
 	if err != nil {
-		return err
+		return instruments, err
 	}
 
 	// Create attempt_latencies
-	tf.attemptLatencies, err = meter.Float64Histogram(
-		nativeMetricsPrefix+metricNameAttemptLatencies,
+	instruments.attemptLatencies, err = meter.Float64Histogram(
+		prefix+metricNameAttemptLatencies,
 		metric.WithDescription("Client observed latency per RPC attempt."),
 		metric.WithUnit(metricUnitMS),
 		metric.WithExplicitBucketBoundaries(bucketBounds...),
 	)
 	if err != nil {
-		return err
+		return instruments, err
 	}
 
-	tf.gfeLatencies, err = meter.Float64Histogram(
-		nativeMetricsPrefix+metricNameGFELatencies,
+	instruments.gfeLatencies, err = meter.Float64Histogram(
+		prefix+metricNameGFELatencies,
 		metric.WithDescription("Latency between Google's network receiving an RPC and reading back the first byte of the response."),
 		metric.WithUnit(metricUnitMS),
 		metric.WithExplicitBucketBoundaries(bucketBounds...),
 	)
 	if err != nil {
-		return err
+		return instruments, err
 	}
 
-	tf.afeLatencies, err = meter.Float64Histogram(
-		nativeMetricsPrefix+metricNameAFELatencies,
+	instruments.afeLatencies, err = meter.Float64Histogram(
+		prefix+metricNameAFELatencies,
 		metric.WithDescription("Latency between Spanner API Frontend receiving an RPC and starting to write back the response."),
 		metric.WithUnit(metricUnitMS),
 		metric.WithExplicitBucketBoundaries(bucketBounds...),
 	)
 	if err != nil {
-		return err
+		return instruments, err
 	}
 
 	// Create operation_count
-	tf.operationCount, err = meter.Int64Counter(
-		nativeMetricsPrefix+metricNameOperationCount,
+	instruments.operationCount, err = meter.Int64Counter(
+		prefix+metricNameOperationCount,
 		metric.WithDescription("The count of database operations."),
 		metric.WithUnit(metricUnitCount),
 	)
 	if err != nil {
-		return err
+		return instruments, err
 	}
 
 	// Create attempt_count
-	tf.attemptCount, err = meter.Int64Counter(
-		nativeMetricsPrefix+metricNameAttemptCount,
+	instruments.attemptCount, err = meter.Int64Counter(
+		prefix+metricNameAttemptCount,
 		metric.WithDescription("The number of attempts made for the operation, including the initial attempt."),
 		metric.WithUnit(metricUnitCount),
 	)
 	if err != nil {
-		return err
+		return instruments, err
 	}
 
-	tf.gfeErrorCount, err = meter.Int64Counter(
-		nativeMetricsPrefix+metricNameGFEConnectivityErrorCount,
+	instruments.gfeErrorCount, err = meter.Int64Counter(
+		prefix+metricNameGFEConnectivityErrorCount,
 		metric.WithDescription("Number of requests that failed to reach the Google network."),
 		metric.WithUnit(metricUnitCount),
 	)
 	if err != nil {
-		return err
+		return instruments, err
 	}
 
-	tf.afeErrorCount, err = meter.Int64Counter(
-		nativeMetricsPrefix+metricNameAFEConnectivityErrorCount,
+	instruments.afeErrorCount, err = meter.Int64Counter(
+		prefix+metricNameAFEConnectivityErrorCount,
 		metric.WithDescription("Number of requests that failed to reach the Spanner API Frontend."),
 		metric.WithUnit(metricUnitCount),
 	)
-	return err
+	return instruments, err
 }
 
 // builtinMetricsTracer is created one per operation.
@@ -513,15 +582,7 @@ type builtinMetricsTracer struct {
 	// clientAttributes are attributes specific to a client instance that do not change across different operations on the client.
 	clientAttributes []attribute.KeyValue
 
-	// Metrics instruments
-	instrumentOperationLatencies metric.Float64Histogram // Histogram for operation latencies.
-	instrumentAttemptLatencies   metric.Float64Histogram // Histogram for attempt latencies.
-	instrumentGFELatencies       metric.Float64Histogram // Histogram for GFE latencies.
-	instrumentAFELatencies       metric.Float64Histogram // Histogram for AFE latencies.
-	instrumentGFEErrorCount      metric.Int64Counter     // Counter for GFE connectivity errors.
-	instrumentAFEErrorCount      metric.Int64Counter     // Counter for AFE connectivity errors.
-	instrumentOperationCount     metric.Int64Counter     // Counter for the number of operations.
-	instrumentAttemptCount       metric.Int64Counter     // Counter for the number of attempts.
+	sinks []builtinMetricsSink
 
 	method string // The method being traced.
 
@@ -610,21 +671,12 @@ func (tf *builtinMetricsTracerFactory) createBuiltinMetricsTracer(ctx context.Co
 		clientAttributes:          tf.clientAttributes,
 		isAFEBuiltInMetricEnabled: tf.isAFEBuiltInMetricEnabled,
 
-		instrumentOperationLatencies: tf.operationLatencies,
-		instrumentAttemptLatencies:   tf.attemptLatencies,
-		instrumentOperationCount:     tf.operationCount,
-		instrumentAttemptCount:       tf.attemptCount,
-		instrumentGFELatencies:       tf.gfeLatencies,
-		instrumentAFELatencies:       tf.afeLatencies,
-		instrumentGFEErrorCount:      tf.gfeErrorCount,
-		instrumentAFEErrorCount:      tf.afeErrorCount,
+		sinks: tf.sinks,
 	}
 }
 
-// toOtelMetricAttrs:
-// - converts metric attributes values captured throughout the operation / attempt
-// to OpenTelemetry attributes format,
-// - combines these with common client attributes and returns
+// toOtelMetricAttrs converts per-operation and per-attempt metric attributes
+// to OpenTelemetry attribute values.
 func (mt *builtinMetricsTracer) toOtelMetricAttrs(metricName string) ([]attribute.KeyValue, error) {
 	if mt.currOp == nil || mt.currOp.currAttempt == nil {
 		return nil, fmt.Errorf("unable to create attributes list for unknown metric: %v", metricName)
@@ -648,13 +700,27 @@ func (mt *builtinMetricsTracer) toOtelMetricAttrs(metricName string) ([]attribut
 	}, nil
 }
 
+func (mt *builtinMetricsTracer) attributesForSink(metricName string, sink builtinMetricsSink) ([]attribute.KeyValue, error) {
+	attrs, err := mt.toOtelMetricAttrs(metricName)
+	if err != nil {
+		return nil, err
+	}
+	if sink.includeClientAttributes {
+		attrs = append(attrs, mt.clientAttributes...)
+	}
+	return attrs, nil
+}
+
 func (t *builtinMetricsTracer) recordGFELatency(latency time.Duration) {
-	if t.builtInEnabled {
-		attrs, err := t.toOtelMetricAttrs(metricNameGFELatencies)
+	if !t.builtInEnabled {
+		return
+	}
+	for _, sink := range t.sinks {
+		attrs, err := t.attributesForSink(metricNameGFELatencies, sink)
 		if err != nil {
-			return
+			continue
 		}
-		t.instrumentGFELatencies.Record(t.ctx, float64(latency.Milliseconds()), metric.WithAttributes(attrs...))
+		sink.gfeLatencies.Record(t.ctx, float64(latency.Milliseconds()), metric.WithAttributes(attrs...))
 	}
 }
 
@@ -662,30 +728,36 @@ func (t *builtinMetricsTracer) recordAFELatency(latency time.Duration) {
 	if !t.isAFEBuiltInMetricEnabled {
 		return
 	}
-	attrs, err := t.toOtelMetricAttrs(metricNameAFELatencies)
-	if err != nil {
-		return
+	for _, sink := range t.sinks {
+		attrs, err := t.attributesForSink(metricNameAFELatencies, sink)
+		if err != nil {
+			continue
+		}
+		sink.afeLatencies.Record(t.ctx, float64(latency.Milliseconds()), metric.WithAttributes(attrs...))
 	}
-	t.instrumentAFELatencies.Record(t.ctx, float64(latency.Milliseconds()), metric.WithAttributes(attrs...))
 }
 
 func (t *builtinMetricsTracer) recordGFEError() {
-	attrs, err := t.toOtelMetricAttrs(metricNameGFEConnectivityErrorCount)
-	if err != nil {
-		return
+	for _, sink := range t.sinks {
+		attrs, err := t.attributesForSink(metricNameGFEConnectivityErrorCount, sink)
+		if err != nil {
+			continue
+		}
+		sink.gfeErrorCount.Add(t.ctx, 1, metric.WithAttributes(attrs...))
 	}
-	t.instrumentGFEErrorCount.Add(t.ctx, 1, metric.WithAttributes(attrs...))
 }
 
 func (t *builtinMetricsTracer) recordAFEError() {
 	if !t.isAFEBuiltInMetricEnabled {
 		return
 	}
-	attrs, err := t.toOtelMetricAttrs(metricNameAFEConnectivityErrorCount)
-	if err != nil {
-		return
+	for _, sink := range t.sinks {
+		attrs, err := t.attributesForSink(metricNameAFEConnectivityErrorCount, sink)
+		if err != nil {
+			continue
+		}
+		sink.afeErrorCount.Add(t.ctx, 1, metric.WithAttributes(attrs...))
 	}
-	t.instrumentAFEErrorCount.Add(t.ctx, 1, metric.WithAttributes(attrs...))
 }
 
 // Convert error to grpc status error
@@ -732,11 +804,13 @@ func recordAttemptCompletion(mt *builtinMetricsTracer) {
 	elapsedTime := convertToMs(time.Since(mt.currOp.currAttempt.startTime))
 
 	// Record attempt_latencies
-	attemptLatAttrs, err := mt.toOtelMetricAttrs(metricNameAttemptLatencies)
-	if err != nil {
-		return
+	for _, sink := range mt.sinks {
+		attemptLatAttrs, err := mt.attributesForSink(metricNameAttemptLatencies, sink)
+		if err != nil {
+			continue
+		}
+		sink.attemptLatencies.Record(mt.ctx, elapsedTime, metric.WithAttributes(attemptLatAttrs...))
 	}
-	mt.instrumentAttemptLatencies.Record(mt.ctx, elapsedTime, metric.WithAttributes(attemptLatAttrs...))
 }
 
 // recordOperationCompletion records as many operation specific metrics as it can
@@ -750,26 +824,22 @@ func recordOperationCompletion(mt *builtinMetricsTracer) {
 	// Calculate elapsed time
 	elapsedTimeMs := convertToMs(time.Since(mt.currOp.startTime))
 
-	// Record operation_count
-	opCntAttrs, err := mt.toOtelMetricAttrs(metricNameOperationCount)
-	if err != nil {
-		return
-	}
-	mt.instrumentOperationCount.Add(mt.ctx, 1, metric.WithAttributes(opCntAttrs...))
+	for _, sink := range mt.sinks {
+		opCntAttrs, err := mt.attributesForSink(metricNameOperationCount, sink)
+		if err == nil {
+			sink.operationCount.Add(mt.ctx, 1, metric.WithAttributes(opCntAttrs...))
+		}
 
-	// Record operation_latencies
-	opLatAttrs, err := mt.toOtelMetricAttrs(metricNameOperationLatencies)
-	if err != nil {
-		return
-	}
-	mt.instrumentOperationLatencies.Record(mt.ctx, elapsedTimeMs, metric.WithAttributes(opLatAttrs...))
+		opLatAttrs, err := mt.attributesForSink(metricNameOperationLatencies, sink)
+		if err == nil {
+			sink.operationLatencies.Record(mt.ctx, elapsedTimeMs, metric.WithAttributes(opLatAttrs...))
+		}
 
-	// Record attempt_count
-	attemptCntAttrs, err := mt.toOtelMetricAttrs(metricNameAttemptCount)
-	if err != nil {
-		return
+		attemptCntAttrs, err := mt.attributesForSink(metricNameAttemptCount, sink)
+		if err == nil {
+			sink.attemptCount.Add(mt.ctx, mt.currOp.attemptCount, metric.WithAttributes(attemptCntAttrs...))
+		}
 	}
-	mt.instrumentAttemptCount.Add(mt.ctx, mt.currOp.attemptCount, metric.WithAttributes(attemptCntAttrs...))
 }
 
 func convertToMs(d time.Duration) float64 {

--- a/spanner/metrics.go
+++ b/spanner/metrics.go
@@ -322,7 +322,7 @@ type builtinMetricsTracerFactory struct {
 	meterProvider metric.MeterProvider
 }
 
-func newBuiltinMetricsTracerFactory(ctx context.Context, dbpath, compression string, isAFEBuiltInMetricEnabled, isEnableGRPCBuiltInMetrics bool, metricsProvider, clientMetricsProvider metric.MeterProvider, opts ...option.ClientOption) (*builtinMetricsTracerFactory, error) {
+func newBuiltinMetricsTracerFactory(ctx context.Context, dbpath, compression string, isAFEBuiltInMetricEnabled, isEnableGRPCBuiltInMetrics bool, metricsProvider, clientMetricsProvider metric.MeterProvider, opts ...option.ClientOption) (tracerFactory *builtinMetricsTracerFactory, err error) {
 	clientUID, err := generateClientUID()
 	if err != nil {
 		log.Printf("built-in metrics: generateClientUID failed: %v. Using empty string in the %v metric atteribute", err, metricLabelKeyClientUID)
@@ -332,7 +332,7 @@ func newBuiltinMetricsTracerFactory(ctx context.Context, dbpath, compression str
 		return nil, err
 	}
 
-	tracerFactory := &builtinMetricsTracerFactory{
+	tracerFactory = &builtinMetricsTracerFactory{
 		enabled: false,
 		clientAttributes: []attribute.KeyValue{
 			attribute.String(monitoredResLabelKeyProject, project),
@@ -347,6 +347,15 @@ func newBuiltinMetricsTracerFactory(ctx context.Context, dbpath, compression str
 		},
 		shutdown: func(ctx context.Context) {},
 	}
+	// Release the native meter provider and exporter created below if a later
+	// step fails. Only resources owned by this factory are stopped; a
+	// caller-owned ClientMetricsProvider is never shut down here.
+	defer func() {
+		if err != nil {
+			tracerFactory.shutdown(ctx)
+			tracerFactory.shutdown = func(context.Context) {}
+		}
+	}()
 	tracerFactory.isAFEBuiltInMetricEnabled = isAFEBuiltInMetricEnabled
 	tracerFactory.isDirectPathEnabled = false
 	tracerFactory.enabled = false
@@ -363,21 +372,21 @@ func newBuiltinMetricsTracerFactory(ctx context.Context, dbpath, compression str
 		}
 		meterProvider := sdkmetric.NewMeterProvider(mpOptions...)
 		tracerFactory.meterProvider = meterProvider
-		if err := tracerFactory.addMetricsSink(meterProvider, nativeMetricsPrefix, false); err != nil {
-			return tracerFactory, err
-		}
-		grpcMeterProviders = append(grpcMeterProviders, meterProvider)
 		tracerFactory.shutdown = func(ctx context.Context) {
 			exporter.stop()
 			meterProvider.Shutdown(ctx)
 		}
+		if err = tracerFactory.addMetricsSink(meterProvider, nativeMetricsPrefix, false); err != nil {
+			return tracerFactory, err
+		}
+		grpcMeterProviders = append(grpcMeterProviders, meterProvider)
 	} else {
 		switch metricsProvider.(type) {
 		case noop.MeterProvider:
 			// Native Cloud Monitoring export is disabled.
 		default:
 			tracerFactory.meterProvider = metricsProvider
-			if err := tracerFactory.addMetricsSink(metricsProvider, nativeMetricsPrefix, false); err != nil {
+			if err = tracerFactory.addMetricsSink(metricsProvider, nativeMetricsPrefix, false); err != nil {
 				return tracerFactory, err
 			}
 			grpcMeterProviders = append(grpcMeterProviders, metricsProvider)
@@ -389,7 +398,7 @@ func newBuiltinMetricsTracerFactory(ctx context.Context, dbpath, compression str
 		case noop.MeterProvider:
 			// A no-op provider is equivalent to leaving ClientMetricsProvider nil.
 		default:
-			if err := tracerFactory.addMetricsSink(clientMetricsProvider, clientMetricsPrefix, true); err != nil {
+			if err = tracerFactory.addMetricsSink(clientMetricsProvider, clientMetricsPrefix, true); err != nil {
 				return tracerFactory, err
 			}
 			grpcMeterProviders = append(grpcMeterProviders, clientMetricsProvider)

--- a/spanner/metrics_test.go
+++ b/spanner/metrics_test.go
@@ -183,10 +183,11 @@ func TestNewBuiltinMetricsTracerFactory(t *testing.T) {
 			}
 
 			// Check instruments
-			gotNonNilInstruments := client.metricsTracerFactory.operationLatencies != nil &&
-				client.metricsTracerFactory.operationCount != nil &&
-				client.metricsTracerFactory.attemptLatencies != nil &&
-				client.metricsTracerFactory.attemptCount != nil
+			gotNonNilInstruments := len(client.metricsTracerFactory.sinks) > 0 &&
+				client.metricsTracerFactory.sinks[0].operationLatencies != nil &&
+				client.metricsTracerFactory.sinks[0].operationCount != nil &&
+				client.metricsTracerFactory.sinks[0].attemptLatencies != nil &&
+				client.metricsTracerFactory.sinks[0].attemptCount != nil
 			if test.wantBuiltinEnabled != gotNonNilInstruments {
 				t.Errorf("NonNilInstruments: got: %v, want: %v", gotNonNilInstruments, test.wantBuiltinEnabled)
 			}

--- a/spanner/read_test.go
+++ b/spanner/read_test.go
@@ -2013,7 +2013,7 @@ func TestIteratorStopEarly(t *testing.T) {
 }
 
 func TestIteratorWithError(t *testing.T) {
-	metricsTracerFactory, err := newBuiltinMetricsTracerFactory(context.Background(), "projects/my-project/instances/my-instance/databases/my-database", "identity", false, false, noop.NewMeterProvider())
+	metricsTracerFactory, err := newBuiltinMetricsTracerFactory(context.Background(), "projects/my-project/instances/my-instance/databases/my-database", "identity", false, false, noop.NewMeterProvider(), nil)
 	if err != nil {
 		t.Fatalf("failed to create metrics tracer factory: %v", err)
 	}


### PR DESCRIPTION
Internal Reference: go/built-in-metric-custom-export
Java PR: https://github.com/googleapis/google-cloud-java/pull/13741