### PR TITLE
fix(pubsub/v2): update ackID batch size to 1000

### DIFF
--- a/pubsub/v2/iterator.go
+++ b/pubsub/v2/iterator.go
@@ -46,14 +46,8 @@ import (
 const gracePeriod = 5 * time.Second
 
 // ackIDBatchSize is the maximum number of ACK IDs to send in a single Ack/Modack RPC.
-// The backend imposes a maximum request size limit of 524288 bytes (512 KiB) per
-// acknowledge / modifyAckDeadline request. ACK IDs have a maximum size of 164
-// bytes, thus we cannot send more than 524288/176 ~= 2979 ACK IDs in an Ack/ModAc
-
-// Accounting for some overhead, we should thus only send a maximum of 2500 ACK
-// IDs at a time.
-// This is a var such that it can be modified for tests.
-const ackIDBatchSize int = 2500
+// This is aligned with Java's value: https://github.com/googleapis/google-cloud-java/blob/7604971c3ed8a419fd01e4800f4a3199a6fc15f1/java-pubsub/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/StreamingSubscriberConnection.java#L88
+const ackIDBatchSize int = 1000
 
 // The following configures how frequently
 // the client library will check for pending


### PR DESCRIPTION
AckID size have gotten bigger and the previous calculation is now incorrect

This aligns with [Java](https://github.com/googleapis/google-cloud-java/blob/7604971c3ed8a419fd01e4800f4a3199a6fc15f1/java-pubsub/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/StreamingSubscriberConnection.java#L88) and [Pythons](https://github.com/googleapis/python-pubsub/pull/802) value of 1000

Fixes #20391 
