### PR TITLE
feat(storage): add object metadata and list call trace attributes

### DIFF
--- a/storage/bucket.go
+++ b/storage/bucket.go
@@ -2435,6 +2435,10 @@ func ownerEntityFromProto(p *storagepb.Owner) string {
 // Note: The returned iterator is not safe for concurrent operations without explicit synchronization.
 func (b *BucketHandle) Objects(ctx context.Context, q *Query) *ObjectIterator {
 	o := makeStorageOpts(true, b.retry, b.userProject)
+	if isOTelTracingDevEnabled() && b.c != nil && b.c.bucketMetadataCache != nil {
+		ctx = context.WithValue(ctx, cacheContextKey, b.c.bucketMetadataCache)
+		ctx = context.WithValue(ctx, bucketContextKey, b.name)
+	}
 	return b.c.tc.ListObjects(ctx, b.name, q, o...)
 }
 

--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -632,7 +632,7 @@ func (c *grpcStorageClient) ListObjects(ctx context.Context, bucket string, q *Q
 		ctx, record := startMetricsOp(it.ctx, "ListObjects", false)
 		defer func() { record(err) }()
 		// Add trace span around List API call within the fetch.
-		ctx, _ = startSpan(ctx, "grpcStorageClient.ObjectsListCall")
+		ctx, _ = startSpanWithBucket(ctx, nil, bucket, "grpcStorageClient.ObjectsListCall")
 		defer func() { endSpan(ctx, err) }()
 		var objects []*storagepb.Object
 		var gitr *gapic.ObjectIterator

--- a/storage/http_client.go
+++ b/storage/http_client.go
@@ -449,7 +449,7 @@ func (c *httpStorageClient) ListObjects(ctx context.Context, bucket string, q *Q
 		ctx, record := startMetricsOp(it.ctx, "ListObjects", true)
 		defer func() { record(err) }()
 		// Add trace span around List API call within the fetch.
-		ctx, _ = startSpan(ctx, "httpStorageClient.ObjectsListCall")
+		ctx, _ = startSpanWithBucket(ctx, nil, bucket, "httpStorageClient.ObjectsListCall")
 		defer func() { endSpan(ctx, err) }()
 		req := c.raw.Objects.List(bucket)
 		if it.query.SoftDeleted {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1068,6 +1068,7 @@ func (o *ObjectHandle) Key(encryptionKey []byte) *ObjectHandle {
 func (o *ObjectHandle) Attrs(ctx context.Context) (attrs *ObjectAttrs, err error) {
 	ctx, _ = startSpanWithBucket(ctx, o.c, o.bucket, "Object.Attrs")
 	defer func() { endSpan(ctx, err) }()
+	recordObjectTraceAttributes(ctx, o.object)
 
 	if err := o.validate(); err != nil {
 		return nil, err
@@ -1082,6 +1083,7 @@ func (o *ObjectHandle) Attrs(ctx context.Context) (attrs *ObjectAttrs, err error
 func (o *ObjectHandle) Update(ctx context.Context, uattrs ObjectAttrsToUpdate) (oa *ObjectAttrs, err error) {
 	ctx, _ = startSpanWithBucket(ctx, o.c, o.bucket, "Object.Update")
 	defer func() { endSpan(ctx, err) }()
+	recordObjectTraceAttributes(ctx, o.object)
 
 	if err := o.validate(); err != nil {
 		return nil, err
@@ -1160,6 +1162,7 @@ type ObjectAttrsToUpdate struct {
 func (o *ObjectHandle) Delete(ctx context.Context) (err error) {
 	ctx, _ = startSpanWithBucket(ctx, o.c, o.bucket, "Object.Delete")
 	defer func() { endSpan(ctx, err) }()
+	recordObjectTraceAttributes(ctx, o.object)
 	if err := o.validate(); err != nil {
 		return err
 	}

--- a/storage/trace.go
+++ b/storage/trace.go
@@ -75,27 +75,43 @@ func startSpanWithBucket(ctx context.Context, client *Client, bucket string, nam
 	if !isOTelTracingDevEnabled() {
 		return startSpan(ctx, name, opts...)
 	}
-	if client != nil && client.bucketMetadataCache != nil && bucket != "" {
-		ctx = context.WithValue(ctx, cacheContextKey, client.bucketMetadataCache)
-		ctx = context.WithValue(ctx, bucketContextKey, bucket)
-		isBucket := strings.HasPrefix(name, "Bucket.") || strings.HasPrefix(name, "ACL.") || strings.HasPrefix(name, "storage.IAM.")
-		ctx = context.WithValue(ctx, isBucketContextKey, isBucket)
+	var cache *bucketMetadataCache
+	if client != nil && client.bucketMetadataCache != nil {
+		cache = client.bucketMetadataCache
+	} else if c, ok := ctx.Value(cacheContextKey).(*bucketMetadataCache); ok {
+		cache = c
+	}
 
-		cache := client.bucketMetadataCache
-		meta, hit := cache.get(bucket)
-		if !hit {
-			placeholder := bucketMetadata{
-				resource:    fmt.Sprintf("projects/_/buckets/%s", bucket),
-				location:    "global",
-				placeholder: true,
+	if bucket != "" {
+		var attrs []attribute.KeyValue
+		if cache != nil {
+			if ctx.Value(cacheContextKey) == nil {
+				ctx = context.WithValue(ctx, cacheContextKey, cache)
+				ctx = context.WithValue(ctx, bucketContextKey, bucket)
+				isBucket := strings.HasPrefix(name, "Bucket.") || strings.HasPrefix(name, "ACL.") || strings.HasPrefix(name, "storage.IAM.")
+				ctx = context.WithValue(ctx, isBucketContextKey, isBucket)
 			}
-			cache.put(bucket, placeholder)
-			cache.fetchBackground(bucket)
-			meta = placeholder
-		}
-		attrs := []attribute.KeyValue{
-			attribute.String("gcp.resource.destination.id", meta.resource),
-			attribute.String("gcp.resource.destination.location", meta.location),
+
+			meta, hit := cache.get(bucket)
+			if !hit {
+				placeholder := bucketMetadata{
+					resource:    fmt.Sprintf("projects/_/buckets/%s", bucket),
+					location:    "global",
+					placeholder: true,
+				}
+				cache.put(bucket, placeholder)
+				cache.fetchBackground(bucket)
+				meta = placeholder
+			}
+			attrs = []attribute.KeyValue{
+				attribute.String("gcp.resource.destination.id", meta.resource),
+				attribute.String("gcp.resource.destination.location", meta.location),
+			}
+		} else {
+			attrs = []attribute.KeyValue{
+				attribute.String("gcp.resource.destination.id", fmt.Sprintf("projects/_/buckets/%s", bucket)),
+				attribute.String("gcp.resource.destination.location", "global"),
+			}
 		}
 		ctx = contextWithTraceAttributes(ctx, attrs)
 	}
@@ -179,4 +195,17 @@ func getCommonAttributes() []attribute.KeyValue {
 
 func appendPackageName(spanName string) string {
 	return fmt.Sprintf("%s.%s", gcpClientArtifact, spanName)
+}
+
+// recordObjectTraceAttributes attaches the object name attribute to object metadata spans.
+func recordObjectTraceAttributes(ctx context.Context, objectName string) {
+	if !isOTelTracingDevEnabled() || objectName == "" {
+		return
+	}
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+
+	span.SetAttributes(attribute.String("gcp.storage.object.name", objectName))
 }

--- a/storage/trace_test.go
+++ b/storage/trace_test.go
@@ -350,3 +350,127 @@ func TestEndSpanEviction(t *testing.T) {
 		})
 	}
 }
+
+func TestRecordObjectTraceAttributes(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	spanName := "Object.Attrs"
+	ctx, _ = startSpan(ctx, spanName)
+	recordObjectTraceAttributes(ctx, "data/file.txt")
+	endSpan(ctx, nil)
+
+	spans := te.Spans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	gotSpan := spans[0]
+
+	found := false
+	for _, a := range gotSpan.Attributes {
+		if string(a.Key) == "gcp.storage.object.name" {
+			found = true
+			if got := a.Value.AsString(); got != "data/file.txt" {
+				t.Errorf("gcp.storage.object.name: got %v, want %v", got, "data/file.txt")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("attribute gcp.storage.object.name not found on span")
+	}
+}
+
+func TestStartSpanWithBucketFromContext(t *testing.T) {
+	ctx := context.Background()
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	cache := newBucketMetadataCache(10, &mockMetadataFetcher{})
+	cache.put("my-bucket", bucketMetadata{
+		resource: "projects/_/buckets/my-bucket",
+		location: "us-central1",
+	})
+	ctx = context.WithValue(ctx, cacheContextKey, cache)
+
+	ctx, _ = startSpanWithBucket(ctx, nil, "my-bucket", "grpcStorageClient.ObjectsListCall")
+	endSpan(ctx, nil)
+
+	spans := te.Spans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	gotSpan := spans[0]
+
+	wantAttrs := map[string]string{
+		"gcp.resource.destination.id":       "projects/_/buckets/my-bucket",
+		"gcp.resource.destination.location": "us-central1",
+	}
+	for k, v := range wantAttrs {
+		found := false
+		for _, a := range gotSpan.Attributes {
+			if string(a.Key) == k && a.Value.AsString() == v {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("attribute %s=%s not found on span", k, v)
+		}
+	}
+}
+
+func TestRecordObjectTraceAttributes_EmptyAndDisabled(t *testing.T) {
+	t.Run("empty object name", func(t *testing.T) {
+		ctx := context.Background()
+		te := testutil.NewOpenTelemetryTestExporter()
+		t.Cleanup(func() {
+			te.Unregister(ctx)
+		})
+		t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+		ctx, _ = startSpan(ctx, "Object.Attrs")
+		recordObjectTraceAttributes(ctx, "")
+		endSpan(ctx, nil)
+
+		spans := te.Spans()
+		if len(spans) != 1 {
+			t.Fatalf("expected 1 span, got %d", len(spans))
+		}
+		for _, a := range spans[0].Attributes {
+			if string(a.Key) == "gcp.storage.object.name" {
+				t.Errorf("expected no gcp.storage.object.name attribute for empty object name, but found one: %v", a.Value)
+			}
+		}
+	})
+
+	t.Run("dev tracing disabled", func(t *testing.T) {
+		ctx := context.Background()
+		t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "false")
+
+		te := testutil.NewOpenTelemetryTestExporter()
+		t.Cleanup(func() {
+			te.Unregister(ctx)
+		})
+
+		ctx, span := tracer().Start(ctx, "Object.Attrs")
+		recordObjectTraceAttributes(ctx, "file.txt")
+		span.End()
+
+		spans := te.Spans()
+		if len(spans) != 1 {
+			t.Fatalf("expected 1 span, got %d", len(spans))
+		}
+		for _, a := range spans[0].Attributes {
+			if string(a.Key) == "gcp.storage.object.name" {
+				t.Errorf("expected no gcp.storage.object.name attribute when dev tracing is disabled, but found: %v", a.Value)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Description
This PR adds the `storage.object.name` trace attribute to object metadata spans and ensures destination resource attributes are properly populated for object listing calls across both gRPC and HTTP transports.
### 1. Object Metadata Trace Attribute
- Added `recordObjectTraceAttributes(ctx, objectName)` to record `storage.object.name` on:
  - `Object.Attrs`
  - `Object.Update`
  - `Object.Delete`
### 2. Destination Resource Attributes on `ObjectsListCall`
- Updated `startSpanWithBucket` to extract `bucketMetadataCache` from context when `client == nil`.
- Injected bucket name and cache context into iterator creation in `Bucket.Objects(ctx, q)`.
- Updated `grpcStorageClient.ObjectsListCall` and `httpStorageClient.ObjectsListCall` to use `startSpanWithBucket`, ensuring `gcp.resource.destination.id` (`projects/_/buckets/<bucket>`) and `gcp.resource.destination.location` are attached on both transports.