### PR TITLE
fix(storage): prevent spurious cancelled status on completed gRPC reads

### DIFF
--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -34,12 +34,15 @@ import (
 	"time"
 
 	"cloud.google.com/go/iam/apiv1/iampb"
+	"cloud.google.com/go/internal/testutil"
 	"cloud.google.com/go/storage/experimental"
 	"cloud.google.com/go/storage/internal/apiv2/storagepb"
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/gax-go/v2"
 	"github.com/googleapis/gax-go/v2/apierror"
 	"github.com/googleapis/gax-go/v2/callctx"
+	otcodes "go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
@@ -4002,5 +4005,177 @@ func setBidiReads(t *testing.T, client storageClient) {
 		t.Cleanup(func() {
 			c.config.grpcBidiReads = false
 		})
+	}
+}
+
+func TestGRPCRetryReadSuccessNotCancelledEmulated(t *testing.T) {
+	checkEmulatorEnvironment(t)
+	ctx := context.Background()
+
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	client := emulatorClients["grpc"]
+	if client == nil {
+		t.Skip("grpc emulator client not available")
+	}
+
+	project := "grpc-project"
+	bucket := fmt.Sprintf("grpc-read-cancel-bucket-%d", time.Now().Nanosecond())
+	objName := "test-read.txt"
+	data := []byte("Hello, verifying clean gRPC read completion without cancellation errors!")
+
+	// 1. Create bucket and upload object.
+	if _, err := client.CreateBucket(ctx, project, bucket, &BucketAttrs{Name: bucket}, nil); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	vc := &Client{tc: client}
+	w := vc.Bucket(bucket).Object(objName).NewWriter(ctx)
+	if _, err := w.Write(data); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("w.Close: %v", err)
+	}
+
+	testCases := []struct {
+		name   string
+		isBidi bool
+	}{
+		{name: "Unidirectional", isBidi: false},
+		{name: "Bidirectional", isBidi: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			te := testutil.NewOpenTelemetryTestExporter()
+			t.Cleanup(func() {
+				te.Unregister(ctx)
+			})
+
+			if tc.isBidi {
+				setBidiReads(t, client)
+			}
+
+			// Instruct emulator to return 503 twice on storage.objects.get
+			instructions := map[string][]string{
+				"storage.objects.get": {"return-503", "return-503"},
+			}
+			testID := createRetryTest(t, client, instructions)
+			ctxRetry := callctx.SetHeaders(ctx, "x-retry-test-id", testID)
+
+			r, err := vc.Bucket(bucket).Object(objName).NewReader(ctxRetry)
+			if err != nil {
+				t.Fatalf("NewReader: %v", err)
+			}
+			got, err := io.ReadAll(r)
+			if err != nil {
+				t.Fatalf("ReadAll: %v", err)
+			}
+			if !bytes.Equal(got, data) {
+				t.Fatalf("got data %q, want %q", got, data)
+			}
+			if err := r.Close(); err != nil {
+				t.Fatalf("r.Close: %v", err)
+			}
+
+			spans := te.Spans()
+			var parentReaderSpan tracetest.SpanStub
+			var successfulTransportSpans int
+			var cancelledSpans int
+
+			for _, s := range spans {
+				if strings.HasSuffix(s.Name, "Object.Reader") {
+					parentReaderSpan = s
+				}
+				for _, attr := range s.Attributes {
+					if string(attr.Key) == "rpc.response.status_code" && attr.Value.AsString() == "CANCELLED" {
+						cancelledSpans++
+					}
+				}
+				if (strings.Contains(s.Name, "NewRangeReader") || strings.Contains(s.Name, "ReadObject")) && s.Status.Code != otcodes.Error {
+					successfulTransportSpans++
+				}
+			}
+
+			if parentReaderSpan.Name != "" && parentReaderSpan.Status.Code == otcodes.Error {
+				t.Errorf("Object.Reader parent span was marked with Error status: %v", parentReaderSpan.Status.Description)
+			}
+			if cancelledSpans > 0 {
+				t.Errorf("expected 0 CANCELLED spans on completed read, got %d", cancelledSpans)
+			}
+			if successfulTransportSpans == 0 {
+				t.Errorf("expected at least 1 successful transport span with Status.Code == OK")
+			}
+		})
+	}
+}
+
+func TestMRDRetryReadSuccessNotCancelledEmulated(t *testing.T) {
+	checkEmulatorEnvironment(t)
+	ctx := context.Background()
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	client := emulatorClients["grpc"]
+	if client == nil {
+		t.Skip("grpc emulator client not available")
+	}
+	setBidiReads(t, client)
+
+	project := "grpc-project"
+	bucket := fmt.Sprintf("grpc-mrd-cancel-bucket-%d", time.Now().Nanosecond())
+	objName := "test-mrd.txt"
+	data := []byte("Multi-range downloader test data with multiple ranges to verify clean shutdown without cancellation.")
+
+	if _, err := client.CreateBucket(ctx, project, bucket, &BucketAttrs{Name: bucket}, nil); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	vc := &Client{tc: client}
+	w := vc.Bucket(bucket).Object(objName).NewWriter(ctx)
+	if _, err := w.Write(data); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("w.Close: %v", err)
+	}
+
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	instructions := map[string][]string{
+		"storage.objects.get": {"return-503", "return-503"},
+	}
+	testID := createRetryTest(t, client, instructions)
+	ctxRetry := callctx.SetHeaders(ctx, "x-retry-test-id", testID)
+
+	mrd, err := vc.Bucket(bucket).Object(objName).NewMultiRangeDownloader(ctxRetry)
+	if err != nil {
+		t.Fatalf("NewMultiRangeDownloader: %v", err)
+	}
+
+	var buf1, buf2 bytes.Buffer
+	mrd.Add(&buf1, 0, 10, nil)
+	mrd.Add(&buf2, 10, 20, nil)
+	mrd.Wait()
+	if err := mrd.Close(); err != nil {
+		t.Fatalf("mrd.Close: %v", err)
+	}
+
+	spans := te.Spans()
+	for _, s := range spans {
+		for _, attr := range s.Attributes {
+			if string(attr.Key) == "rpc.response.status_code" && attr.Value.AsString() == "CANCELLED" {
+				t.Errorf("span %q recorded CANCELLED status on clean MRD read completion", s.Name)
+			}
+		}
+		if strings.HasSuffix(s.Name, "Object.MultiRangeDownloader") && s.Status.Code == otcodes.Error {
+			t.Errorf("Object.MultiRangeDownloader parent span marked with Error status: %v", s.Status.Description)
+		}
 	}
 }

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -3864,6 +3864,166 @@ func TestReadCodecLeaksEmulated(t *testing.T) {
 	}
 }
 
+func TestGRPCRetryReadSuccessNotCancelledEmulated(t *testing.T) {
+	checkEmulatorEnvironment(t)
+	ctx := context.Background()
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	client := emulatorClients["grpc"]
+	project := "grpc-project"
+	bucket := fmt.Sprintf("grpc-read-cancel-bucket-%d", time.Now().Nanosecond())
+	objName := "test-read.txt"
+	data := []byte("Hello, verifying clean gRPC read completion without cancellation errors!")
+
+	// Create bucket and upload object.
+	if _, err := client.CreateBucket(ctx, project, bucket, &BucketAttrs{Name: bucket}, nil); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	vc := &Client{tc: client}
+	w := vc.Bucket(bucket).Object(objName).NewWriter(ctx)
+	if _, err := w.Write(data); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("w.Close: %v", err)
+	}
+
+	testCases := []struct {
+		name   string
+		isBidi bool
+	}{
+		{name: "Unidirectional", isBidi: false},
+		{name: "Bidirectional", isBidi: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			te := testutil.NewOpenTelemetryTestExporter()
+			t.Cleanup(func() {
+				te.Unregister(ctx)
+			})
+
+			if tc.isBidi {
+				setBidiReads(t, client)
+			}
+
+			// Instruct emulator to return 503 twice on storage.objects.get.
+			instructions := map[string][]string{
+				"storage.objects.get": {"return-503", "return-503"},
+			}
+			testID := createRetryTest(t, client, instructions)
+			ctxRetry := callctx.SetHeaders(ctx, "x-retry-test-id", testID)
+
+			r, err := vc.Bucket(bucket).Object(objName).NewReader(ctxRetry)
+			if err != nil {
+				t.Fatalf("NewReader: %v", err)
+			}
+			got, err := io.ReadAll(r)
+			if err != nil {
+				t.Fatalf("ReadAll: %v", err)
+			}
+			if !bytes.Equal(got, data) {
+				t.Fatalf("got data %q, want %q", got, data)
+			}
+			if err := r.Close(); err != nil {
+				t.Fatalf("r.Close: %v", err)
+			}
+
+			spans := te.Spans()
+			var parentReaderSpan tracetest.SpanStub
+			var successfulTransportSpans int
+			var cancelledSpans int
+
+			for _, s := range spans {
+				if strings.HasSuffix(s.Name, "Object.Reader") {
+					parentReaderSpan = s
+				}
+				for _, attr := range s.Attributes {
+					if string(attr.Key) == "rpc.response.status_code" && attr.Value.AsString() == "CANCELLED" {
+						cancelledSpans++
+					}
+				}
+				if (strings.Contains(s.Name, "NewRangeReader") || strings.Contains(s.Name, "ReadObject")) && s.Status.Code != otcodes.Error {
+					successfulTransportSpans++
+				}
+			}
+
+			if parentReaderSpan.Name != "" && parentReaderSpan.Status.Code == otcodes.Error {
+				t.Errorf("Object.Reader parent span was marked with Error status: %v", parentReaderSpan.Status.Description)
+			}
+			if cancelledSpans > 0 {
+				t.Errorf("expected 0 CANCELLED spans on completed read, got %d", cancelledSpans)
+			}
+			if successfulTransportSpans == 0 {
+				t.Errorf("expected at least 1 successful transport span with Status.Code == OK")
+			}
+		})
+	}
+}
+
+func TestMRDRetryReadSuccessNotCancelledEmulated(t *testing.T) {
+	checkEmulatorEnvironment(t)
+	ctx := context.Background()
+	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
+
+	client := emulatorClients["grpc"]
+	setBidiReads(t, client)
+
+	project := "grpc-project"
+	bucket := fmt.Sprintf("grpc-mrd-cancel-bucket-%d", time.Now().Nanosecond())
+	objName := "test-mrd.txt"
+	data := []byte("Multi-range downloader test data with multiple ranges to verify clean shutdown without cancellation.")
+
+	if _, err := client.CreateBucket(ctx, project, bucket, &BucketAttrs{Name: bucket}, nil); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	vc := &Client{tc: client}
+	w := vc.Bucket(bucket).Object(objName).NewWriter(ctx)
+	if _, err := w.Write(data); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("w.Close: %v", err)
+	}
+
+	te := testutil.NewOpenTelemetryTestExporter()
+	t.Cleanup(func() {
+		te.Unregister(ctx)
+	})
+	instructions := map[string][]string{
+		"storage.objects.get": {"return-503", "return-503"},
+	}
+	testID := createRetryTest(t, client, instructions)
+	ctxRetry := callctx.SetHeaders(ctx, "x-retry-test-id", testID)
+
+	mrd, err := vc.Bucket(bucket).Object(objName).NewMultiRangeDownloader(ctxRetry)
+	if err != nil {
+		t.Fatalf("NewMultiRangeDownloader: %v", err)
+	}
+
+	var buf1, buf2 bytes.Buffer
+	mrd.Add(&buf1, 0, 10, nil)
+	mrd.Add(&buf2, 10, 20, nil)
+	mrd.Wait()
+	if err := mrd.Close(); err != nil {
+		t.Fatalf("mrd.Close: %v", err)
+	}
+
+	spans := te.Spans()
+	for _, s := range spans {
+		for _, attr := range s.Attributes {
+			if string(attr.Key) == "rpc.response.status_code" && attr.Value.AsString() == "CANCELLED" {
+				t.Errorf("span %q recorded CANCELLED status on clean MRD read completion", s.Name)
+			}
+		}
+		if strings.HasSuffix(s.Name, "Object.MultiRangeDownloader") && s.Status.Code == otcodes.Error {
+			t.Errorf("Object.MultiRangeDownloader parent span marked with Error status: %v", s.Status.Description)
+		}
+	}
+}
+
 // createRetryTest creates a bucket in the emulator and sets up a test using the
 // Retry Test API for the given instructions. This is intended for emulator tests
 // of retry behavior that are not covered by conformance tests.
@@ -4005,173 +4165,5 @@ func setBidiReads(t *testing.T, client storageClient) {
 		t.Cleanup(func() {
 			c.config.grpcBidiReads = false
 		})
-	}
-}
-
-func TestGRPCRetryReadSuccessNotCancelledEmulated(t *testing.T) {
-	checkEmulatorEnvironment(t)
-	ctx := context.Background()
-
-	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
-
-	client := emulatorClients["grpc"]
-	if client == nil {
-		t.Skip("grpc emulator client not available")
-	}
-
-	project := "grpc-project"
-	bucket := fmt.Sprintf("grpc-read-cancel-bucket-%d", time.Now().Nanosecond())
-	objName := "test-read.txt"
-	data := []byte("Hello, verifying clean gRPC read completion without cancellation errors!")
-
-	// 1. Create bucket and upload object.
-	if _, err := client.CreateBucket(ctx, project, bucket, &BucketAttrs{Name: bucket}, nil); err != nil {
-		t.Fatalf("CreateBucket: %v", err)
-	}
-
-	vc := &Client{tc: client}
-	w := vc.Bucket(bucket).Object(objName).NewWriter(ctx)
-	if _, err := w.Write(data); err != nil {
-		t.Fatalf("Write: %v", err)
-	}
-	if err := w.Close(); err != nil {
-		t.Fatalf("w.Close: %v", err)
-	}
-
-	testCases := []struct {
-		name   string
-		isBidi bool
-	}{
-		{name: "Unidirectional", isBidi: false},
-		{name: "Bidirectional", isBidi: true},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			te := testutil.NewOpenTelemetryTestExporter()
-			t.Cleanup(func() {
-				te.Unregister(ctx)
-			})
-
-			if tc.isBidi {
-				setBidiReads(t, client)
-			}
-
-			// Instruct emulator to return 503 twice on storage.objects.get.
-			instructions := map[string][]string{
-				"storage.objects.get": {"return-503", "return-503"},
-			}
-			testID := createRetryTest(t, client, instructions)
-			ctxRetry := callctx.SetHeaders(ctx, "x-retry-test-id", testID)
-
-			r, err := vc.Bucket(bucket).Object(objName).NewReader(ctxRetry)
-			if err != nil {
-				t.Fatalf("NewReader: %v", err)
-			}
-			got, err := io.ReadAll(r)
-			if err != nil {
-				t.Fatalf("ReadAll: %v", err)
-			}
-			if !bytes.Equal(got, data) {
-				t.Fatalf("got data %q, want %q", got, data)
-			}
-			if err := r.Close(); err != nil {
-				t.Fatalf("r.Close: %v", err)
-			}
-
-			spans := te.Spans()
-			var parentReaderSpan tracetest.SpanStub
-			var successfulTransportSpans int
-			var cancelledSpans int
-
-			for _, s := range spans {
-				if strings.HasSuffix(s.Name, "Object.Reader") {
-					parentReaderSpan = s
-				}
-				for _, attr := range s.Attributes {
-					if string(attr.Key) == "rpc.response.status_code" && attr.Value.AsString() == "CANCELLED" {
-						cancelledSpans++
-					}
-				}
-				if (strings.Contains(s.Name, "NewRangeReader") || strings.Contains(s.Name, "ReadObject")) && s.Status.Code != otcodes.Error {
-					successfulTransportSpans++
-				}
-			}
-
-			if parentReaderSpan.Name != "" && parentReaderSpan.Status.Code == otcodes.Error {
-				t.Errorf("Object.Reader parent span was marked with Error status: %v", parentReaderSpan.Status.Description)
-			}
-			if cancelledSpans > 0 {
-				t.Errorf("expected 0 CANCELLED spans on completed read, got %d", cancelledSpans)
-			}
-			if successfulTransportSpans == 0 {
-				t.Errorf("expected at least 1 successful transport span with Status.Code == OK")
-			}
-		})
-	}
-}
-
-func TestMRDRetryReadSuccessNotCancelledEmulated(t *testing.T) {
-	checkEmulatorEnvironment(t)
-	ctx := context.Background()
-	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
-
-	client := emulatorClients["grpc"]
-	if client == nil {
-		t.Skip("grpc emulator client not available")
-	}
-	setBidiReads(t, client)
-
-	project := "grpc-project"
-	bucket := fmt.Sprintf("grpc-mrd-cancel-bucket-%d", time.Now().Nanosecond())
-	objName := "test-mrd.txt"
-	data := []byte("Multi-range downloader test data with multiple ranges to verify clean shutdown without cancellation.")
-
-	if _, err := client.CreateBucket(ctx, project, bucket, &BucketAttrs{Name: bucket}, nil); err != nil {
-		t.Fatalf("CreateBucket: %v", err)
-	}
-
-	vc := &Client{tc: client}
-	w := vc.Bucket(bucket).Object(objName).NewWriter(ctx)
-	if _, err := w.Write(data); err != nil {
-		t.Fatalf("Write: %v", err)
-	}
-	if err := w.Close(); err != nil {
-		t.Fatalf("w.Close: %v", err)
-	}
-
-	te := testutil.NewOpenTelemetryTestExporter()
-	t.Cleanup(func() {
-		te.Unregister(ctx)
-	})
-	instructions := map[string][]string{
-		"storage.objects.get": {"return-503", "return-503"},
-	}
-	testID := createRetryTest(t, client, instructions)
-	ctxRetry := callctx.SetHeaders(ctx, "x-retry-test-id", testID)
-
-	mrd, err := vc.Bucket(bucket).Object(objName).NewMultiRangeDownloader(ctxRetry)
-	if err != nil {
-		t.Fatalf("NewMultiRangeDownloader: %v", err)
-	}
-
-	var buf1, buf2 bytes.Buffer
-	mrd.Add(&buf1, 0, 10, nil)
-	mrd.Add(&buf2, 10, 20, nil)
-	mrd.Wait()
-	if err := mrd.Close(); err != nil {
-		t.Fatalf("mrd.Close: %v", err)
-	}
-
-	spans := te.Spans()
-	for _, s := range spans {
-		for _, attr := range s.Attributes {
-			if string(attr.Key) == "rpc.response.status_code" && attr.Value.AsString() == "CANCELLED" {
-				t.Errorf("span %q recorded CANCELLED status on clean MRD read completion", s.Name)
-			}
-		}
-		if strings.HasSuffix(s.Name, "Object.MultiRangeDownloader") && s.Status.Code == otcodes.Error {
-			t.Errorf("Object.MultiRangeDownloader parent span marked with Error status: %v", s.Status.Description)
-		}
 	}
 }

--- a/storage/client_test.go
+++ b/storage/client_test.go
@@ -4012,10 +4012,6 @@ func TestGRPCRetryReadSuccessNotCancelledEmulated(t *testing.T) {
 	checkEmulatorEnvironment(t)
 	ctx := context.Background()
 
-	te := testutil.NewOpenTelemetryTestExporter()
-	t.Cleanup(func() {
-		te.Unregister(ctx)
-	})
 	t.Setenv("GO_STORAGE_DEV_OTEL_TRACING", "true")
 
 	client := emulatorClients["grpc"]
@@ -4061,7 +4057,7 @@ func TestGRPCRetryReadSuccessNotCancelledEmulated(t *testing.T) {
 				setBidiReads(t, client)
 			}
 
-			// Instruct emulator to return 503 twice on storage.objects.get
+			// Instruct emulator to return 503 twice on storage.objects.get.
 			instructions := map[string][]string{
 				"storage.objects.get": {"return-503", "return-503"},
 			}

--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/auth"
 	"cloud.google.com/go/iam/apiv1/iampb"
@@ -1703,6 +1704,13 @@ func (r *gRPCReader) Read(p []byte) (int, error) {
 		if err := r.runCRCCheck(); err != nil {
 			return 0, err
 		}
+		if r.stream != nil {
+			for {
+				if err := r.recv(); err != nil {
+					break
+				}
+			}
+		}
 		return 0, io.EOF
 	}
 
@@ -1851,10 +1859,22 @@ func (r *gRPCReader) WriteTo(w io.Writer) (int64, error) {
 // Close cancels the read stream's context in order for it to be closed and
 // collected, and frees any currently in use buffers.
 func (r *gRPCReader) Close() error {
+	if r.stream != nil && ((r.finalized || r.negativeOffset) && r.size == r.seen || r.zeroRange) {
+		if r.cancel != nil {
+			timer := time.AfterFunc(200*time.Millisecond, r.cancel)
+			defer timer.Stop()
+		}
+		for {
+			if err := r.recv(); err != nil {
+				break
+			}
+		}
+	}
 	if r.cancel != nil {
 		r.cancel()
 	}
 
+	r.stream = nil
 	r.currMsg = nil
 	return nil
 }
@@ -1876,7 +1896,7 @@ func (r *gRPCReader) recv() error {
 	err := r.stream.RecvMsg(&databufs)
 	// If we get a mid-stream error on a recv call, reopen the stream.
 	// ABORTED could indicate a redirect so should also trigger a reopen.
-	if err != nil && (r.settings.retry.runShouldRetry(err, nil) || status.Code(err) == codes.Aborted) {
+	if err != nil && ((r.settings != nil && r.settings.retry != nil && r.settings.retry.runShouldRetry(err, nil)) || status.Code(err) == codes.Aborted) {
 		// This will "close" the existing stream and immediately attempt to
 		// reopen the stream, but will backoff if further attempts are necessary.
 		// Reopening the stream Recvs the first message, so if retrying is

--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	"cloud.google.com/go/auth"
 	"cloud.google.com/go/iam/apiv1/iampb"
@@ -1704,13 +1703,6 @@ func (r *gRPCReader) Read(p []byte) (int, error) {
 		if err := r.runCRCCheck(); err != nil {
 			return 0, err
 		}
-		if r.stream != nil {
-			for {
-				if err := r.recv(); err != nil {
-					break
-				}
-			}
-		}
 		return 0, io.EOF
 	}
 
@@ -1860,15 +1852,7 @@ func (r *gRPCReader) WriteTo(w io.Writer) (int64, error) {
 // collected, and frees any currently in use buffers.
 func (r *gRPCReader) Close() error {
 	if r.stream != nil && ((r.finalized || r.negativeOffset) && r.size == r.seen || r.zeroRange) {
-		if r.cancel != nil {
-			timer := time.AfterFunc(200*time.Millisecond, r.cancel)
-			defer timer.Stop()
-		}
-		for {
-			if err := r.recv(); err != nil {
-				break
-			}
-		}
+		drainStreamOnCompletion(r.cancel, r.recv)
 	}
 	if r.cancel != nil {
 		r.cancel()

--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -1851,8 +1851,8 @@ func (r *gRPCReader) WriteTo(w io.Writer) (int64, error) {
 // Close cancels the read stream's context in order for it to be closed and
 // collected, and frees any currently in use buffers.
 func (r *gRPCReader) Close() error {
-	if (r.finalized || r.negativeOffset) && r.size == r.seen || r.zeroRange {
-		drainStream(r.stream, r.cancel)
+	if r.stream != nil && ((r.finalized || r.negativeOffset) && r.size == r.seen || r.zeroRange) {
+		drainStreamOnCompletion(r.cancel, r.stream)
 	}
 	if r.cancel != nil {
 		r.cancel()

--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -1851,8 +1851,8 @@ func (r *gRPCReader) WriteTo(w io.Writer) (int64, error) {
 // Close cancels the read stream's context in order for it to be closed and
 // collected, and frees any currently in use buffers.
 func (r *gRPCReader) Close() error {
-	if r.stream != nil && ((r.finalized || r.negativeOffset) && r.size == r.seen || r.zeroRange) {
-		drainStreamOnCompletion(r.cancel, r.recv)
+	if (r.finalized || r.negativeOffset) && r.size == r.seen || r.zeroRange {
+		drainStream(r.stream, r.cancel)
 	}
 	if r.cancel != nil {
 		r.cancel()

--- a/storage/grpc_client.go
+++ b/storage/grpc_client.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/auth"
 	"cloud.google.com/go/iam/apiv1/iampb"
@@ -76,6 +77,10 @@ const (
 	directConnectivityDiagnosticHeaderKey = "direct_connectivity_diagnostic"
 	requestParamsHeaderKey                = "x-goog-request-params"
 	directPathEndpointPrefix              = "google-c2p:///"
+
+	// defaultStreamDrainTimeout is the maximum duration allowed to drain trailing
+	// messages and trailers from a completed gRPC read stream before cancellation.
+	defaultStreamDrainTimeout = 200 * time.Millisecond
 )
 
 // defaultGRPCOptions returns a set of the default client options

--- a/storage/grpc_client_test.go
+++ b/storage/grpc_client_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/md5"
 	"fmt"
 	"hash/crc32"
+	"io"
 	"math/rand"
 	"reflect"
 	"strings"
@@ -943,4 +944,130 @@ func TestVerifyChecksums(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBidiReadStreamSessionGracefulShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	session := &bidiReadStreamSession{
+		reqC:   make(chan *storagepb.BidiReadObjectRequest, 5),
+		ctx:    ctx,
+		cancel: cancel,
+	}
+
+	// 1. Initial shutdown should close reqC and set manualShutdown.
+	session.Shutdown()
+
+	if !session.manualShutdown {
+		t.Errorf("expected session.manualShutdown to be true")
+	}
+
+	select {
+	case _, ok := <-session.reqC:
+		if ok {
+			t.Errorf("expected reqC to be closed")
+		}
+	default:
+		t.Errorf("expected reqC to be closed and readable")
+	}
+
+	// 2. Calling Shutdown again should be idempotent and not panic.
+	session.Shutdown()
+}
+
+func TestGRPCReaderCloseDrainOnCompletion(t *testing.T) {
+	var canceled bool
+	mockCancel := func() {
+		canceled = true
+	}
+
+	fakeStream := &fakeBidiReadObjectClient{}
+	r := &gRPCReader{
+		size:      100,
+		seen:      100,
+		finalized: true,
+		cancel:    mockCancel,
+		stream:    fakeStream,
+		settings:  &settings{},
+	}
+
+	if err := r.Close(); err != nil {
+		t.Fatalf("r.Close(): %v", err)
+	}
+
+	if !fakeStream.recvd {
+		t.Errorf("expected stream.RecvMsg to be drained on completed read Close")
+	}
+	if !canceled {
+		t.Errorf("expected cancel to be called")
+	}
+	if r.stream != nil {
+		t.Errorf("expected r.stream to be nil after Close")
+	}
+}
+
+func TestGRPCReadObjectReaderCloseDrainOnCompletion(t *testing.T) {
+	var canceled bool
+	mockCancel := func() {
+		canceled = true
+	}
+
+	fakeStream := &fakeReadObjectClient{}
+	r := &gRPCReadObjectReader{
+		size:     100,
+		seen:     100,
+		cancel:   mockCancel,
+		stream:   fakeStream,
+		settings: &settings{},
+	}
+
+	if err := r.Close(); err != nil {
+		t.Fatalf("r.Close(): %v", err)
+	}
+
+	if !fakeStream.recvd {
+		t.Errorf("expected stream.RecvMsg to be drained on completed read Close")
+	}
+	if !canceled {
+		t.Errorf("expected cancel to be called")
+	}
+}
+
+type fakeBidiReadObjectClient struct {
+	grpc.ClientStream
+	recvd bool
+}
+
+func (f *fakeBidiReadObjectClient) RecvMsg(m interface{}) error {
+	f.recvd = true
+	return io.EOF
+}
+
+func (f *fakeBidiReadObjectClient) Send(*storagepb.BidiReadObjectRequest) error {
+	return nil
+}
+
+func (f *fakeBidiReadObjectClient) Recv() (*storagepb.BidiReadObjectResponse, error) {
+	f.recvd = true
+	return nil, io.EOF
+}
+
+func (f *fakeBidiReadObjectClient) CloseSend() error {
+	return nil
+}
+
+type fakeReadObjectClient struct {
+	grpc.ClientStream
+	recvd bool
+}
+
+func (f *fakeReadObjectClient) RecvMsg(m interface{}) error {
+	f.recvd = true
+	return io.EOF
+}
+
+func (f *fakeReadObjectClient) Recv() (*storagepb.ReadObjectResponse, error) {
+	f.recvd = true
+	return nil, io.EOF
 }

--- a/storage/grpc_client_test.go
+++ b/storage/grpc_client_test.go
@@ -956,7 +956,7 @@ func TestBidiReadStreamSessionGracefulShutdown(t *testing.T) {
 		cancel: cancel,
 	}
 
-	// 1. Initial shutdown should close reqC and set manualShutdown.
+	// Initial shutdown should close reqC and set manualShutdown.
 	session.Shutdown()
 
 	if !session.manualShutdown {
@@ -972,7 +972,7 @@ func TestBidiReadStreamSessionGracefulShutdown(t *testing.T) {
 		t.Errorf("expected reqC to be closed and readable")
 	}
 
-	// 2. Calling Shutdown again should be idempotent and not panic.
+	// Calling Shutdown again should be idempotent and not panic.
 	session.Shutdown()
 }
 

--- a/storage/grpc_reader.go
+++ b/storage/grpc_reader.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
+	"time"
 
 	"cloud.google.com/go/storage/internal/apiv2/storagepb"
 	"github.com/googleapis/gax-go/v2"
@@ -325,6 +326,13 @@ func (r *gRPCReadObjectReader) Read(p []byte) (int, error) {
 		if err := r.runCRCCheck(); err != nil {
 			return 0, err
 		}
+		if r.stream != nil {
+			for {
+				if err := r.recv(); err != nil {
+					break
+				}
+			}
+		}
 		return 0, io.EOF
 	}
 
@@ -492,6 +500,17 @@ func (r *gRPCReadObjectReader) WriteTo(w io.Writer) (int64, error) {
 // Close cancels the read stream's context in order for it to be closed and
 // collected, and frees any currently in use buffers.
 func (r *gRPCReadObjectReader) Close() error {
+	if r.stream != nil && (r.size == r.seen || r.zeroRange) {
+		if r.cancel != nil {
+			timer := time.AfterFunc(200*time.Millisecond, r.cancel)
+			defer timer.Stop()
+		}
+		for {
+			if err := r.recv(); err != nil {
+				break
+			}
+		}
+	}
 	if r.cancel != nil {
 		r.cancel()
 	}
@@ -515,7 +534,7 @@ func (r *gRPCReadObjectReader) recv() error {
 	databufs := mem.BufferSlice{}
 	err := r.stream.RecvMsg(&databufs)
 
-	if err != nil && r.settings.retry.runShouldRetry(err, nil) {
+	if err != nil && r.settings != nil && r.settings.retry != nil && r.settings.retry.runShouldRetry(err, nil) {
 		// This will "close" the existing stream and immediately attempt to
 		// reopen the stream, but will backoff if further attempts are necessary.
 		// Reopening the stream Recvs the first message, so if retrying is

--- a/storage/grpc_reader.go
+++ b/storage/grpc_reader.go
@@ -326,13 +326,6 @@ func (r *gRPCReadObjectReader) Read(p []byte) (int, error) {
 		if err := r.runCRCCheck(); err != nil {
 			return 0, err
 		}
-		if r.stream != nil {
-			for {
-				if err := r.recv(); err != nil {
-					break
-				}
-			}
-		}
 		return 0, io.EOF
 	}
 
@@ -501,15 +494,7 @@ func (r *gRPCReadObjectReader) WriteTo(w io.Writer) (int64, error) {
 // collected, and frees any currently in use buffers.
 func (r *gRPCReadObjectReader) Close() error {
 	if r.stream != nil && (r.size == r.seen || r.zeroRange) {
-		if r.cancel != nil {
-			timer := time.AfterFunc(200*time.Millisecond, r.cancel)
-			defer timer.Stop()
-		}
-		for {
-			if err := r.recv(); err != nil {
-				break
-			}
-		}
+		drainStreamOnCompletion(r.cancel, r.recv)
 	}
 	if r.cancel != nil {
 		r.cancel()
@@ -517,6 +502,20 @@ func (r *gRPCReadObjectReader) Close() error {
 	r.stream = nil
 	r.currMsg = nil
 	return nil
+}
+
+// drainStreamOnCompletion drains remaining messages from an in-flight gRPC read stream
+// up to EOF with a 200ms timeout before cancellation to allow clean HTTP/2 stream teardown.
+func drainStreamOnCompletion(cancel context.CancelFunc, recv func() error) {
+	if cancel != nil {
+		timer := time.AfterFunc(200*time.Millisecond, cancel)
+		defer timer.Stop()
+	}
+	for {
+		if err := recv(); err != nil {
+			break
+		}
+	}
 }
 
 // recv attempts to Recv the next message on the stream and extract the object

--- a/storage/grpc_reader.go
+++ b/storage/grpc_reader.go
@@ -493,8 +493,8 @@ func (r *gRPCReadObjectReader) WriteTo(w io.Writer) (int64, error) {
 // Close cancels the read stream's context in order for it to be closed and
 // collected, and frees any currently in use buffers.
 func (r *gRPCReadObjectReader) Close() error {
-	if r.stream != nil && (r.size == r.seen || r.zeroRange) {
-		drainStreamOnCompletion(r.cancel, r.recv)
+	if r.size == r.seen || r.zeroRange {
+		drainStream(r.stream, r.cancel)
 	}
 	if r.cancel != nil {
 		r.cancel()
@@ -504,17 +504,22 @@ func (r *gRPCReadObjectReader) Close() error {
 	return nil
 }
 
-// drainStreamOnCompletion drains remaining messages from an in-flight gRPC read stream
-// up to EOF with a 200ms timeout before cancellation to allow clean HTTP/2 stream teardown.
-func drainStreamOnCompletion(cancel context.CancelFunc, recv func() error) {
+// drainStream cleanly exhausts a finished stream to allow HTTP2 connection reuse.
+func drainStream(stream grpc.ClientStream, cancel context.CancelFunc) {
+	if stream == nil {
+		return
+	}
 	if cancel != nil {
 		timer := time.AfterFunc(200*time.Millisecond, cancel)
 		defer timer.Stop()
 	}
 	for {
-		if err := recv(); err != nil {
+		var drop mem.BufferSlice
+		if err := stream.RecvMsg(&drop); err != nil {
 			break
 		}
+		// Free the raw buffers to prevent memory leaks from the parsing loop
+		drop.Free()
 	}
 }
 

--- a/storage/grpc_reader.go
+++ b/storage/grpc_reader.go
@@ -493,8 +493,8 @@ func (r *gRPCReadObjectReader) WriteTo(w io.Writer) (int64, error) {
 // Close cancels the read stream's context in order for it to be closed and
 // collected, and frees any currently in use buffers.
 func (r *gRPCReadObjectReader) Close() error {
-	if r.size == r.seen || r.zeroRange {
-		drainStream(r.stream, r.cancel)
+	if r.stream != nil && (r.size == r.seen || r.zeroRange) {
+		drainStreamOnCompletion(r.cancel, r.stream)
 	}
 	if r.cancel != nil {
 		r.cancel()
@@ -504,8 +504,8 @@ func (r *gRPCReadObjectReader) Close() error {
 	return nil
 }
 
-// drainStream cleanly exhausts a finished stream to allow HTTP2 connection reuse.
-func drainStream(stream grpc.ClientStream, cancel context.CancelFunc) {
+// drainStreamOnCompletion cleanly exhausts a finished stream to allow HTTP2 connection reuse.
+func drainStreamOnCompletion(cancel context.CancelFunc, stream grpc.ClientStream) {
 	if stream == nil {
 		return
 	}

--- a/storage/grpc_reader.go
+++ b/storage/grpc_reader.go
@@ -504,13 +504,15 @@ func (r *gRPCReadObjectReader) Close() error {
 	return nil
 }
 
+const defaultStreamDrainTimeout = 200 * time.Millisecond
+
 // drainStreamOnCompletion cleanly exhausts a finished stream to allow HTTP2 connection reuse.
 func drainStreamOnCompletion(cancel context.CancelFunc, stream grpc.ClientStream) {
 	if stream == nil {
 		return
 	}
 	if cancel != nil {
-		timer := time.AfterFunc(200*time.Millisecond, cancel)
+		timer := time.AfterFunc(defaultStreamDrainTimeout, cancel)
 		defer timer.Stop()
 	}
 	for {

--- a/storage/grpc_reader.go
+++ b/storage/grpc_reader.go
@@ -504,8 +504,6 @@ func (r *gRPCReadObjectReader) Close() error {
 	return nil
 }
 
-const defaultStreamDrainTimeout = 200 * time.Millisecond
-
 // drainStreamOnCompletion cleanly exhausts a finished stream to allow HTTP2 connection reuse.
 func drainStreamOnCompletion(cancel context.CancelFunc, stream grpc.ClientStream) {
 	if stream == nil {

--- a/storage/grpc_reader.go
+++ b/storage/grpc_reader.go
@@ -518,7 +518,7 @@ func drainStreamOnCompletion(cancel context.CancelFunc, stream grpc.ClientStream
 		if err := stream.RecvMsg(&drop); err != nil {
 			break
 		}
-		// Free the raw buffers to prevent memory leaks from the parsing loop
+		// Free the raw buffers to prevent memory leaks from the parsing loop.
 		drop.Free()
 	}
 }

--- a/storage/grpc_reader_multi_range.go
+++ b/storage/grpc_reader_multi_range.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"log"
 	"sync"
+	"time"
 
 	"cloud.google.com/go/storage/internal/apiv2/storagepb"
 	"google.golang.org/grpc"
@@ -157,6 +158,7 @@ func (c *grpcStorageClient) NewMultiRangeDownloader(ctx context.Context, params 
 
 	// Create the manager
 	manager := &multiRangeDownloaderManager{
+		rootCtx:        ctx,
 		ctx:            mCtx,
 		cancel:         cancel,
 		client:         c,
@@ -361,6 +363,7 @@ var (
 // Manages main event loop for MRD commands and processing responses.
 // Spawns bidiStreamSession to deal with actual stream management, retries, etc.
 type multiRangeDownloaderManager struct {
+	rootCtx      context.Context
 	ctx          context.Context
 	cancel       context.CancelFunc
 	client       *grpcStorageClient
@@ -519,6 +522,9 @@ func (m *multiRangeDownloaderManager) getSpanCtx() context.Context {
 }
 
 func (m *multiRangeDownloaderManager) runCallback(origOffset, numBytes int64, err error, cb func(int64, int64, error)) {
+	if cb == nil {
+		return
+	}
 	m.callbackWg.Add(1)
 	go func() {
 		defer m.callbackWg.Done()
@@ -787,7 +793,7 @@ func (m *multiRangeDownloaderManager) createNewSession(id int, readSpec *storage
 }
 
 func (m *multiRangeDownloaderManager) openAndInitializeSession(ctx context.Context, id int, spec *storagepb.BidiReadObjectSpec, waitForResult bool) (*bidiReadStreamSession, mrdSessionResult) {
-	session, err := newBidiReadStreamSession(m.ctx, id, m.sessionResps, m.client, m.settings, m.params, spec)
+	session, err := newBidiReadStreamSession(m.rootCtx, id, m.sessionResps, m.client, m.settings, m.params, spec)
 	if err != nil {
 		return nil, mrdSessionResult{err: err}
 	}
@@ -1294,11 +1300,30 @@ func (s *bidiReadStreamSession) SendRequest(req *storagepb.BidiReadObjectRequest
 }
 func (s *bidiReadStreamSession) Shutdown() {
 	s.mu.Lock()
+	if s.manualShutdown {
+		s.mu.Unlock()
+		return
+	}
 	s.manualShutdown = true
 	s.mu.Unlock()
 
+	// Close reqC to tell sendLoop to exit cleanly and invoke CloseSend()
+	close(s.reqC)
+
+	done := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		s.cancel()
+		<-done
+	}
+
 	s.cancel()
-	s.wg.Wait()
 	s.setError(s.ctx.Err())
 }
 func (s *bidiReadStreamSession) setError(err error) {

--- a/storage/grpc_reader_multi_range.go
+++ b/storage/grpc_reader_multi_range.go
@@ -42,9 +42,10 @@ const (
 	// This should never be hit in practice, but is a safety valve to prevent
 	// unbounded memory usage if the user is adding ranges faster than they
 	// can be processed.
-	mrdAddInternalQueueMaxSize = 50000
-	defaultTargetPendingBytes  = 1 << 30 // 1 GiB
-	defaultTargetPendingRanges = 500
+	mrdAddInternalQueueMaxSize    = 50000
+	defaultTargetPendingBytes     = 1 << 30 // 1 GiB
+	defaultTargetPendingRanges    = 500
+	defaultSessionShutdownTimeout = 200 * time.Millisecond
 )
 
 // --- internalMultiRangeDownloader Interface ---
@@ -1318,7 +1319,7 @@ func (s *bidiReadStreamSession) Shutdown() {
 
 	select {
 	case <-done:
-	case <-time.After(200 * time.Millisecond):
+	case <-time.After(defaultSessionShutdownTimeout):
 		s.cancel()
 		<-done
 	}


### PR DESCRIPTION
This PR resolves an issue where completed gRPC read streams (Unidirectional, Bidirectional, and Multi-Range Downloader) were erroneously recorded with `CANCELLED` status and marked as errors in Cloud Trace/OpenTelemetry upon calling `Close()`. It also prevents a nil-pointer panic during Multi-Range Downloader shutdown.

---

## Motivation & Problem Statement
1. **Spurious `CANCELLED` status on completed gRPC reads**:
   - When a gRPC read completed successfully (`seen == size`), calling `r.Close()` immediately invoked the context `cancel()` function before consuming the final end-of-stream trailers.
   - This caused the underlying HTTP/2 stream to be abruptly cancelled on the client side, causing OpenTelemetry stats handlers and Cloud Trace to tag the successful RPC attempt as `CANCELLED` (Status Code 1 / Error).
2. **Multi-Range Downloader (MRD) Shutdown**:
   - Calling `Shutdown()` on `bidiReadStreamSession` aborted the context before giving in-flight goroutines a chance to call `CloseSend()`.
   - When `runCallback` was called with a `nil` callback during range processing or teardown, it resulted in a `SIGSEGV` nil-pointer dereference panic.

---

## Changes Made
### 1. Graceful gRPC Stream Draining on EOF (`grpc_client.go`, `grpc_reader.go`)
- Drains the gRPC stream (`r.recv()` until `EOF`) when `seen == size` prior to context cancellation in `Close()`.
- Uses `time.AfterFunc(200*time.Millisecond, r.cancel)` with `defer timer.Stop()` to prevent `Close()` from blocking indefinitely if the server stalls during stream teardown.
- Adds nil-guards on `r.settings` and `r.settings.retry` during `recv()` retry checks.

### 2. Multi-Range Downloader Fixes (`grpc_reader_multi_range.go`)
- **Graceful Shutdown**: Closes `reqC` to let the send loop terminate gracefully and invoke `CloseSend()`, waiting on worker goroutines with a 200ms fallback cancellation. Calls `s.cancel()` unconditionally to ensure context cleanup.
- **Context Isolation**: Plumbs `rootCtx` to session creation so session lifecycles are properly isolated from intermediate manager contexts.
- **Nil Guard**: Adds a nil check in `runCallback` to safely handle optional callbacks without panic.

---

## Testing & Verification
### Unit Tests (`grpc_client_test.go`):
- `TestGRPCReaderCloseDrainOnCompletion`: Verifies stream draining prior to context cancellation on `gRPCReader.Close()`.
- `TestGRPCReadObjectReaderCloseDrainOnCompletion`: Verifies stream draining for `gRPCReadObjectReader.Close()`.
- `TestBidiReadStreamSessionGracefulShutdown`: Verifies `reqC` closure, graceful shutdown, and idempotency.

### Emulated Integration Tests (`client_test.go`):
- `TestGRPCRetryReadSuccessNotCancelledEmulated`:
  - Injects two 503 errors via the Storage Testbench emulator.
  - Verifies that after retrying across the 503s, the final successful attempt (both Unidirectional and Bidirectional) completes cleanly with `OK` status and **zero `CANCELLED` error spans**.
- `TestMRDRetryReadSuccessNotCancelledEmulated`:
  - Simulates 503 retries on Multi-Range Downloader and verifies clean shutdown without crashes or cancellation errors.
