### PR TITLE
test: bump librarian to v0.38.0 (testing skill)

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: go
-version: v0.38.0
+version: v0.39.0
 repo: googleapis/google-cloud-go
 sources:
   discovery:


### PR DESCRIPTION
Initial test PR body
### Included Librarian Updates
- googleapis/librarian#7351: feat(go): add control for the protobuf code generation level
- googleapis/librarian#7341: refactor(librarian): move install and version cmds
- googleapis/librarian#7339: refactor(yaml): use supported go.yaml.in/yaml/v3
