### PR TITLE
fix(spanner): stop leaking endpointLatencyRegistry cleanup goroutine

### DIFF
--- a/spanner/endpoint_latency_registry.go
+++ b/spanner/endpoint_latency_registry.go
@@ -18,7 +18,6 @@ package spanner
 
 import (
 	"math"
-	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -28,6 +27,7 @@ const (
 	endpointLatencyDefaultPenaltyValue = 1_000_000.0
 	endpointLatencyMaxTrackers         = 100_000
 	endpointLatencyCleanupInterval     = time.Minute
+	endpointLatencyEvictSampleSize     = 8
 )
 
 var (
@@ -201,6 +201,9 @@ func (r *endpointLatencyRegistry) getOrCreateTracker(key endpointLatencyTrackerK
 	}
 	entry.lastAccessNanos.Store(now.UnixNano())
 	r.trackers[key] = entry
+	if r.maxTrackers > 0 && len(r.trackers) > r.maxTrackers {
+		r.evictSampleLocked(now)
+	}
 	if r.claimCleanup(now) {
 		r.cleanupLocked(now)
 	}
@@ -246,30 +249,34 @@ func (r *endpointLatencyRegistry) cleanup(now time.Time) {
 }
 
 func (r *endpointLatencyRegistry) cleanupLocked(now time.Time) {
-	if len(r.trackers) == 0 {
-		return
-	}
-
-	entries := make([]*endpointLatencyTrackerEntry, 0, len(r.trackers))
 	for key, entry := range r.trackers {
 		if r.isExpiredEntry(entry, now) {
 			delete(r.trackers, key)
-			continue
 		}
-		entries = append(entries, entry)
 	}
+}
 
-	if r.maxTrackers <= 0 || len(entries) <= r.maxTrackers {
-		return
-	}
-
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].lastAccessNanos.Load() < entries[j].lastAccessNanos.Load()
-	})
-
-	excess := len(entries) - r.maxTrackers
-	for i := 0; i < excess; i++ {
-		delete(r.trackers, entries[i].key)
+func (r *endpointLatencyRegistry) evictSampleLocked(now time.Time) {
+	for r.maxTrackers > 0 && len(r.trackers) > r.maxTrackers {
+		var victim *endpointLatencyTrackerEntry
+		sampled := 0
+		for _, entry := range r.trackers {
+			if r.isExpiredEntry(entry, now) {
+				victim = entry
+				break
+			}
+			if victim == nil || entry.lastAccessNanos.Load() < victim.lastAccessNanos.Load() {
+				victim = entry
+			}
+			sampled++
+			if sampled >= endpointLatencyEvictSampleSize {
+				break
+			}
+		}
+		if victim == nil {
+			return
+		}
+		delete(r.trackers, victim.key)
 	}
 }
 

--- a/spanner/endpoint_latency_registry.go
+++ b/spanner/endpoint_latency_registry.go
@@ -50,16 +50,13 @@ type endpointLatencyTrackerEntry struct {
 }
 
 type endpointLatencyRegistry struct {
-	mu              sync.RWMutex
-	stopOnce        sync.Once
-	now             func() time.Time
-	maxTrackers     int
-	expireAfter     time.Duration
-	cleanupInterval time.Duration
-	trackers        map[endpointLatencyTrackerKey]*endpointLatencyTrackerEntry
-	cleanupCh       chan struct{}
-	stopCh          chan struct{}
-	doneCh          chan struct{}
+	mu               sync.RWMutex
+	now              func() time.Time
+	maxTrackers      int
+	expireAfter      time.Duration
+	cleanupInterval  time.Duration
+	trackers         map[endpointLatencyTrackerKey]*endpointLatencyTrackerEntry
+	lastCleanupNanos atomic.Int64
 }
 
 func init() {
@@ -76,11 +73,7 @@ func newEndpointLatencyRegistry(now func() time.Time) *endpointLatencyRegistry {
 		expireAfter:     endpointLatencyTrackerExpireAfter,
 		cleanupInterval: endpointLatencyCleanupInterval,
 		trackers:        make(map[endpointLatencyTrackerKey]*endpointLatencyTrackerEntry),
-		cleanupCh:       make(chan struct{}, 1),
-		stopCh:          make(chan struct{}),
-		doneCh:          make(chan struct{}),
 	}
-	go registry.runCleanup()
 	return registry
 }
 
@@ -100,7 +93,6 @@ func clearEndpointLatencyRegistry() {
 	current := currentEndpointLatencyRegistry()
 	replacement := newEndpointLatencyRegistry(current.now)
 	defaultEndpointLatencyRegistry.Store(replacement)
-	current.close()
 }
 
 func currentEndpointLatencyRegistry() *endpointLatencyRegistry {
@@ -111,18 +103,7 @@ func currentEndpointLatencyRegistry() *endpointLatencyRegistry {
 	if defaultEndpointLatencyRegistry.CompareAndSwap(nil, registry) {
 		return registry
 	}
-	registry.close()
 	return defaultEndpointLatencyRegistry.Load()
-}
-
-func (r *endpointLatencyRegistry) close() {
-	if r == nil {
-		return
-	}
-	r.stopOnce.Do(func() {
-		close(r.stopCh)
-		<-r.doneCh
-	})
 }
 
 func (r *endpointLatencyRegistry) hasScore(operationUID uint64, preferLeader bool, address string) bool {
@@ -174,6 +155,8 @@ func (r *endpointLatencyRegistry) recordError(operationUID uint64, preferLeader 
 }
 
 func (r *endpointLatencyRegistry) lookupTracker(key endpointLatencyTrackerKey, now time.Time, refresh bool) *endpointLatencyTrackerEntry {
+	r.maybeCleanup(now)
+
 	r.mu.RLock()
 	entry := r.trackers[key]
 	r.mu.RUnlock()
@@ -181,7 +164,6 @@ func (r *endpointLatencyRegistry) lookupTracker(key endpointLatencyTrackerKey, n
 		return nil
 	}
 	if r.isExpiredEntry(entry, now) {
-		r.requestCleanup()
 		return nil
 	}
 	if refresh {
@@ -196,13 +178,13 @@ func (r *endpointLatencyRegistry) getOrCreateTracker(key endpointLatencyTrackerK
 	}
 
 	r.mu.Lock()
-	defer r.mu.Unlock()
 
 	if entry := r.trackers[key]; entry != nil {
 		if r.isExpiredEntry(entry, now) {
 			delete(r.trackers, key)
 		} else {
 			entry.lastAccessNanos.Store(now.UnixNano())
+			r.mu.Unlock()
 			return entry
 		}
 	}
@@ -213,8 +195,10 @@ func (r *endpointLatencyRegistry) getOrCreateTracker(key endpointLatencyTrackerK
 	}
 	entry.lastAccessNanos.Store(now.UnixNano())
 	r.trackers[key] = entry
-	if r.maxTrackers > 0 && len(r.trackers) > r.maxTrackers {
-		r.requestCleanup()
+	overLimit := r.maxTrackers > 0 && len(r.trackers) > r.maxTrackers
+	r.mu.Unlock()
+	if overLimit {
+		r.cleanup(now)
 	}
 	return entry
 }
@@ -231,32 +215,20 @@ func (r *endpointLatencyRegistry) isExpiredEntry(entry *endpointLatencyTrackerEn
 	return !lastAccess.Add(r.expireAfter).After(now)
 }
 
-func (r *endpointLatencyRegistry) requestCleanup() {
+func (r *endpointLatencyRegistry) maybeCleanup(now time.Time) {
 	if r == nil {
 		return
 	}
-	select {
-	case r.cleanupCh <- struct{}{}:
-	default:
+
+	nowNanos := now.UnixNano()
+	lastCleanupNanos := r.lastCleanupNanos.Load()
+	if r.cleanupInterval > 0 && lastCleanupNanos != 0 && nowNanos-lastCleanupNanos < int64(r.cleanupInterval) {
+		return
 	}
-}
-
-func (r *endpointLatencyRegistry) runCleanup() {
-	defer close(r.doneCh)
-
-	ticker := time.NewTicker(r.cleanupInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			r.cleanup(r.now())
-		case <-r.cleanupCh:
-			r.cleanup(r.now())
-		case <-r.stopCh:
-			return
-		}
+	if !r.lastCleanupNanos.CompareAndSwap(lastCleanupNanos, nowNanos) {
+		return
 	}
+	r.cleanup(now)
 }
 
 func (r *endpointLatencyRegistry) cleanup(now time.Time) {

--- a/spanner/endpoint_latency_registry.go
+++ b/spanner/endpoint_latency_registry.go
@@ -111,7 +111,9 @@ func (r *endpointLatencyRegistry) hasScore(operationUID uint64, preferLeader boo
 	if !ok {
 		return false
 	}
-	entry := r.lookupTracker(key, r.now(), true)
+	now := r.now()
+	r.maybeCleanup(now)
+	entry := r.lookupTracker(key, now, true)
 	return entry != nil && entry.tracker.hasScore()
 }
 
@@ -126,7 +128,9 @@ func (r *endpointLatencyRegistry) selectionCost(operationUID uint64, preferLeade
 		activeRequests = float64(endpoint.ActiveRequestCount())
 	}
 
-	entry := r.lookupTracker(key, r.now(), true)
+	now := r.now()
+	r.maybeCleanup(now)
+	entry := r.lookupTracker(key, now, true)
 	if entry != nil {
 		return entry.tracker.scoreValue() * (activeRequests + 1)
 	}
@@ -155,8 +159,6 @@ func (r *endpointLatencyRegistry) recordError(operationUID uint64, preferLeader 
 }
 
 func (r *endpointLatencyRegistry) lookupTracker(key endpointLatencyTrackerKey, now time.Time, refresh bool) *endpointLatencyTrackerEntry {
-	r.maybeCleanup(now)
-
 	r.mu.RLock()
 	entry := r.trackers[key]
 	r.mu.RUnlock()
@@ -174,6 +176,7 @@ func (r *endpointLatencyRegistry) lookupTracker(key endpointLatencyTrackerKey, n
 
 func (r *endpointLatencyRegistry) getOrCreateTracker(key endpointLatencyTrackerKey, now time.Time) *endpointLatencyTrackerEntry {
 	if entry := r.lookupTracker(key, now, true); entry != nil {
+		r.maybeCleanup(now)
 		return entry
 	}
 
@@ -184,6 +187,9 @@ func (r *endpointLatencyRegistry) getOrCreateTracker(key endpointLatencyTrackerK
 			delete(r.trackers, key)
 		} else {
 			entry.lastAccessNanos.Store(now.UnixNano())
+			if r.claimCleanup(now) {
+				r.cleanupLocked(now)
+			}
 			r.mu.Unlock()
 			return entry
 		}
@@ -195,11 +201,10 @@ func (r *endpointLatencyRegistry) getOrCreateTracker(key endpointLatencyTrackerK
 	}
 	entry.lastAccessNanos.Store(now.UnixNano())
 	r.trackers[key] = entry
-	overLimit := r.maxTrackers > 0 && len(r.trackers) > r.maxTrackers
-	r.mu.Unlock()
-	if overLimit {
-		r.cleanup(now)
+	if r.claimCleanup(now) {
+		r.cleanupLocked(now)
 	}
+	r.mu.Unlock()
 	return entry
 }
 
@@ -219,22 +224,28 @@ func (r *endpointLatencyRegistry) maybeCleanup(now time.Time) {
 	if r == nil {
 		return
 	}
-
-	nowNanos := now.UnixNano()
-	lastCleanupNanos := r.lastCleanupNanos.Load()
-	if r.cleanupInterval > 0 && lastCleanupNanos != 0 && nowNanos-lastCleanupNanos < int64(r.cleanupInterval) {
-		return
-	}
-	if !r.lastCleanupNanos.CompareAndSwap(lastCleanupNanos, nowNanos) {
+	if !r.claimCleanup(now) {
 		return
 	}
 	r.cleanup(now)
 }
 
+func (r *endpointLatencyRegistry) claimCleanup(now time.Time) bool {
+	nowNanos := now.UnixNano()
+	lastCleanupNanos := r.lastCleanupNanos.Load()
+	if r.cleanupInterval > 0 && lastCleanupNanos != 0 && nowNanos-lastCleanupNanos < int64(r.cleanupInterval) {
+		return false
+	}
+	return r.lastCleanupNanos.CompareAndSwap(lastCleanupNanos, nowNanos)
+}
+
 func (r *endpointLatencyRegistry) cleanup(now time.Time) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.cleanupLocked(now)
+}
 
+func (r *endpointLatencyRegistry) cleanupLocked(now time.Time) {
 	if len(r.trackers) == 0 {
 		return
 	}

--- a/spanner/endpoint_latency_registry_goroutine_test.go
+++ b/spanner/endpoint_latency_registry_goroutine_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanner
+
+import (
+	"bytes"
+	"context"
+	"runtime"
+	"testing"
+
+	"google.golang.org/api/option"
+)
+
+func TestEndpointLatencyRegistryDoesNotStartCleanupGoroutine(t *testing.T) {
+	assertNoEndpointLatencyRegistryCleanupGoroutine(t)
+
+	client, err := NewClientWithConfig(
+		context.Background(),
+		"projects/p/instances/i/databases/d",
+		ClientConfig{},
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("NewClientWithConfig: %v", err)
+	}
+	client.Close()
+
+	assertNoEndpointLatencyRegistryCleanupGoroutine(t)
+}
+
+func assertNoEndpointLatencyRegistryCleanupGoroutine(t *testing.T) {
+	t.Helper()
+
+	buf := make([]byte, 64<<10)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			if bytes.Contains(buf[:n], []byte("endpointLatencyRegistry).runCleanup")) {
+				t.Error("endpoint latency registry cleanup goroutine is running")
+			}
+			return
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+}

--- a/spanner/endpoint_latency_registry_test.go
+++ b/spanner/endpoint_latency_registry_test.go
@@ -59,7 +59,6 @@ func TestEndpointLatencyRegistryKeysByOperationUID(t *testing.T) {
 func TestEndpointLatencyRegistryLookupRefreshesAccess(t *testing.T) {
 	now := time.Unix(1_000, 0)
 	registry := newEndpointLatencyRegistry(func() time.Time { return now })
-	defer registry.close()
 
 	registry.recordLatency(7, false, "server-a:443", 25*time.Millisecond)
 	if !registry.hasScore(7, false, "server-a:443") {
@@ -98,23 +97,21 @@ func TestEndpointLatencyRegistryLookupRefreshesAccess(t *testing.T) {
 	}
 }
 
-func TestEndpointLatencyRegistryExpiredEntryIsHiddenBeforeCleanup(t *testing.T) {
+func TestEndpointLatencyRegistryExpiredEntryIsCleanedUpOnAccess(t *testing.T) {
 	now := time.Unix(1_500, 0)
 	registry := newEndpointLatencyRegistry(func() time.Time { return now })
-	defer registry.close()
 	registry.expireAfter = time.Minute
 
 	registry.recordLatency(7, false, "server-a:443", 25*time.Millisecond)
 	now = now.Add(2 * time.Minute)
 
 	if registry.hasScore(7, false, "server-a:443") {
-		t.Fatal("expected expired entry to be hidden before janitor cleanup")
+		t.Fatal("expected expired entry to be hidden")
 	}
 	if got := registry.selectionCost(7, false, nil, "server-a:443"); got == 0 {
 		t.Fatal("expected fallback selection cost after expiry")
 	}
 
-	registry.cleanup(now)
 	registry.mu.RLock()
 	_, ok := registry.trackers[endpointLatencyTrackerKey{
 		operationUID: 7,
@@ -123,14 +120,13 @@ func TestEndpointLatencyRegistryExpiredEntryIsHiddenBeforeCleanup(t *testing.T) 
 	}]
 	registry.mu.RUnlock()
 	if ok {
-		t.Fatal("expected cleanup to remove expired entry")
+		t.Fatal("expected access-driven cleanup to remove expired entry")
 	}
 }
 
 func TestEndpointLatencyRegistryCleanupEvictsLeastRecentlyAccessedWhenBounded(t *testing.T) {
 	now := time.Unix(2_000, 0)
 	registry := newEndpointLatencyRegistry(func() time.Time { return now })
-	defer registry.close()
 	registry.maxTrackers = 2
 	registry.expireAfter = 10 * time.Minute
 

--- a/spanner/endpoint_latency_registry_test.go
+++ b/spanner/endpoint_latency_registry_test.go
@@ -160,23 +160,17 @@ func TestEndpointLatencyRegistryRateLimitsCleanupWhenOverLimit(t *testing.T) {
 	registry.maxTrackers = 2
 
 	registry.recordLatency(1, false, "server-a:443", 10*time.Millisecond)
+	lastCleanupNanos := registry.lastCleanupNanos.Load()
 	registry.recordLatency(2, false, "server-b:443", 10*time.Millisecond)
 	registry.recordLatency(3, false, "server-c:443", 10*time.Millisecond)
 
 	registry.mu.RLock()
 	trackerCount := len(registry.trackers)
 	registry.mu.RUnlock()
-	if trackerCount != 3 {
-		t.Fatalf("tracker count before cleanup interval = %d, want 3", trackerCount)
-	}
-
-	now = now.Add(registry.cleanupInterval)
-	registry.recordLatency(4, false, "server-d:443", 10*time.Millisecond)
-
-	registry.mu.RLock()
-	trackerCount = len(registry.trackers)
-	registry.mu.RUnlock()
 	if trackerCount != registry.maxTrackers {
-		t.Fatalf("tracker count after cleanup interval = %d, want %d", trackerCount, registry.maxTrackers)
+		t.Fatalf("tracker count after over-cap insert = %d, want %d", trackerCount, registry.maxTrackers)
+	}
+	if got := registry.lastCleanupNanos.Load(); got != lastCleanupNanos {
+		t.Fatalf("last cleanup timestamp after sampled eviction = %d, want %d", got, lastCleanupNanos)
 	}
 }

--- a/spanner/endpoint_latency_registry_test.go
+++ b/spanner/endpoint_latency_registry_test.go
@@ -153,3 +153,30 @@ func TestEndpointLatencyRegistryCleanupEvictsLeastRecentlyAccessedWhenBounded(t 
 		t.Fatal("expected newly added tracker 3 to exist")
 	}
 }
+
+func TestEndpointLatencyRegistryRateLimitsCleanupWhenOverLimit(t *testing.T) {
+	now := time.Unix(3_000, 0)
+	registry := newEndpointLatencyRegistry(func() time.Time { return now })
+	registry.maxTrackers = 2
+
+	registry.recordLatency(1, false, "server-a:443", 10*time.Millisecond)
+	registry.recordLatency(2, false, "server-b:443", 10*time.Millisecond)
+	registry.recordLatency(3, false, "server-c:443", 10*time.Millisecond)
+
+	registry.mu.RLock()
+	trackerCount := len(registry.trackers)
+	registry.mu.RUnlock()
+	if trackerCount != 3 {
+		t.Fatalf("tracker count before cleanup interval = %d, want 3", trackerCount)
+	}
+
+	now = now.Add(registry.cleanupInterval)
+	registry.recordLatency(4, false, "server-d:443", 10*time.Millisecond)
+
+	registry.mu.RLock()
+	trackerCount = len(registry.trackers)
+	registry.mu.RUnlock()
+	if trackerCount != registry.maxTrackers {
+		t.Fatalf("tracker count after cleanup interval = %d, want %d", trackerCount, registry.maxTrackers)
+	}
+}

--- a/spanner/endpoint_latency_registry_test.go
+++ b/spanner/endpoint_latency_registry_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package spanner
 
 import (
+	"fmt"
+	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -172,5 +175,101 @@ func TestEndpointLatencyRegistryRateLimitsCleanupWhenOverLimit(t *testing.T) {
 	}
 	if got := registry.lastCleanupNanos.Load(); got != lastCleanupNanos {
 		t.Fatalf("last cleanup timestamp after sampled eviction = %d, want %d", got, lastCleanupNanos)
+	}
+}
+
+func TestEndpointLatencyRegistryConcurrentAccessDuringEviction(t *testing.T) {
+	const (
+		hotTrackerCount  = 10
+		coldTrackerCount = 90
+		coldInsertCount  = 200
+	)
+
+	var currentTime atomic.Int64
+	currentTime.Store(int64(time.Hour))
+	nowFunc := func() time.Time {
+		return time.Unix(0, currentTime.Load())
+	}
+	registry := newEndpointLatencyRegistry(nowFunc)
+	registry.expireAfter = 24 * time.Hour
+	registry.maxTrackers = hotTrackerCount + coldTrackerCount
+
+	coldNow := time.Unix(0, 1)
+	for i := 0; i < coldTrackerCount; i++ {
+		key := endpointLatencyTrackerKey{
+			operationUID: uint64(1_000 + i),
+			address:      fmt.Sprintf("cold-%d:443", i),
+		}
+		registry.getOrCreateTracker(key, coldNow)
+	}
+	hotEntries := make([]*endpointLatencyTrackerEntry, hotTrackerCount)
+	for i := 0; i < hotTrackerCount; i++ {
+		key := endpointLatencyTrackerKey{
+			operationUID: uint64(i + 1),
+			address:      fmt.Sprintf("hot-%d:443", i),
+		}
+		registry.recordLatency(key.operationUID, false, key.address, time.Millisecond)
+		registry.mu.RLock()
+		hotEntries[i] = registry.trackers[key]
+		registry.mu.RUnlock()
+	}
+
+	stop := make(chan struct{})
+	var ready sync.WaitGroup
+	var workers sync.WaitGroup
+	ready.Add(hotTrackerCount)
+	workers.Add(hotTrackerCount)
+	for i := 0; i < hotTrackerCount; i++ {
+		operationUID := uint64(i + 1)
+		address := fmt.Sprintf("hot-%d:443", i)
+		go func() {
+			defer workers.Done()
+			currentTime.Add(int64(time.Nanosecond))
+			registry.hasScore(operationUID, false, address)
+			registry.recordLatency(operationUID, false, address, time.Millisecond)
+			ready.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					currentTime.Add(int64(time.Nanosecond))
+					registry.hasScore(operationUID, false, address)
+					registry.recordLatency(operationUID, false, address, time.Millisecond)
+				}
+			}
+		}()
+	}
+	ready.Wait()
+
+	for i := 0; i < coldInsertCount; i++ {
+		key := endpointLatencyTrackerKey{
+			operationUID: uint64(2_000 + i),
+			address:      fmt.Sprintf("cold-insert-%d:443", i),
+		}
+		registry.getOrCreateTracker(key, coldNow)
+		runtime.Gosched()
+	}
+	close(stop)
+	workers.Wait()
+
+	hotSurvivors := 0
+	for i := 0; i < hotTrackerCount; i++ {
+		key := endpointLatencyTrackerKey{
+			operationUID: uint64(i + 1),
+			address:      fmt.Sprintf("hot-%d:443", i),
+		}
+		registry.mu.RLock()
+		entry := registry.trackers[key]
+		registry.mu.RUnlock()
+		if entry == hotEntries[i] && registry.hasScore(key.operationUID, false, key.address) {
+			hotSurvivors++
+		}
+	}
+	// With 90 cold entries and a sample of 8, two hot evictions among 200
+	// insertions have probability below 1e-15. Allowing one avoids a flaky
+	// assertion while still detecting eviction that ignores concurrent access.
+	if hotSurvivors < hotTrackerCount-1 {
+		t.Fatalf("hot tracker survivors = %d, want at least %d", hotSurvivors, hotTrackerCount-1)
 	}
 }


### PR DESCRIPTION
Replace timer-driven cleanup with amortized inline sweeps guarded by an atomic timestamp. Importing spanner and closing clients now leave no endpoint latency registry cleanup goroutine behind.

Fixes #14488