### PR TITLE
fix(spanner): prevent fastpath tablet routing flaps

### DIFF
--- a/spanner/client_test.go
+++ b/spanner/client_test.go
@@ -2050,7 +2050,7 @@ func TestLocationAwareExecuteSql_CooldownRoutesToNextReplicaAndEndpointBecomesEl
 	}
 }
 
-func TestLocationAwareExecuteSql_CooldownRetriesAlternateReplicaWhenAllRoutedReplicasCoolingDown(t *testing.T) {
+func TestLocationAwareExecuteSql_CooldownFallsBackWhenAllRoutedReplicasCoolingDown(t *testing.T) {
 	t.Parallel()
 
 	harness, clientOpts, teardown := NewSharedBackendSpannerReplicaHarness(t, 2)
@@ -2128,13 +2128,13 @@ func TestLocationAwareExecuteSql_CooldownRetriesAlternateReplicaWhenAllRoutedRep
 	replicaARequests := harness.Replicas[0].Requests(MethodExecuteSql)
 	replicaBRequests := harness.Replicas[1].Requests(MethodExecuteSql)
 	defaultRequests := harness.DefaultReplica.Requests(MethodExecuteSql)
-	if got, want := len(replicaARequests), 2; got != want {
+	if got, want := len(replicaARequests), 1; got != want {
 		t.Fatalf("replica A ExecuteSql request count = %d, want %d", got, want)
 	}
 	if got, want := len(replicaBRequests), 1; got != want {
 		t.Fatalf("replica B ExecuteSql request count = %d, want %d", got, want)
 	}
-	if got, want := len(defaultRequests), 0; got != want {
+	if got, want := len(defaultRequests), 1; got != want {
 		t.Fatalf("default ExecuteSql request count = %d, want %d", got, want)
 	}
 }

--- a/spanner/endpoint_lifecycle_manager.go
+++ b/spanner/endpoint_lifecycle_manager.go
@@ -46,6 +46,11 @@ type endpointLifecycleState struct {
 	needsCreate                  bool
 }
 
+type endpointLifecycleManagerTestHooks struct {
+	beforeCreateReconcile func()
+	beforeRemovalLock     func()
+}
+
 type endpointLifecycleManager struct {
 	endpointCache          channelEndpointCache
 	defaultEndpointAddress string
@@ -55,9 +60,11 @@ type endpointLifecycleManager struct {
 
 	mu                               sync.Mutex
 	endpoints                        map[string]*endpointLifecycleState
+	activeAddresses                  map[string]struct{}
 	transientFailureEvictedAddresses map[string]struct{}
 	shutdownOnce                     sync.Once
 	stopped                          bool
+	testHooks                        *endpointLifecycleManagerTestHooks
 
 	workCh chan struct{}
 	stopCh chan struct{}
@@ -104,6 +111,7 @@ func newEndpointLifecycleManagerWithOptions(
 		idleEvictionDuration:             idleEvictionDuration,
 		now:                              now,
 		endpoints:                        make(map[string]*endpointLifecycleState),
+		activeAddresses:                  make(map[string]struct{}),
 		transientFailureEvictedAddresses: make(map[string]struct{}),
 		workCh:                           make(chan struct{}, 1),
 		stopCh:                           make(chan struct{}),
@@ -161,6 +169,7 @@ func (m *endpointLifecycleManager) recordRealTraffic(address string) {
 		return
 	}
 	state, ok := m.endpoints[address]
+	m.activeAddresses[address] = struct{}{}
 	if !ok {
 		state = &endpointLifecycleState{
 			lastRealTrafficAt: now,
@@ -196,11 +205,13 @@ func (m *endpointLifecycleManager) requestEndpointRecreation(address string) {
 		m.mu.Unlock()
 		return
 	}
+	if _, active := m.activeAddresses[address]; !active {
+		m.mu.Unlock()
+		return
+	}
 	state, ok := m.endpoints[address]
 	if !ok {
-		state = &endpointLifecycleState{
-			lastRealTrafficAt: now,
-		}
+		state = &endpointLifecycleState{lastRealTrafficAt: now}
 		m.endpoints[address] = state
 	}
 	state.needsCreate = true
@@ -271,13 +282,48 @@ func (m *endpointLifecycleManager) createEndpoint(address string) bool {
 	}
 
 	m.mu.Lock()
+	if m.testHooks != nil && m.testHooks.beforeCreateReconcile != nil {
+		m.testHooks.beforeCreateReconcile()
+	}
 	_, stillManaged := m.endpoints[address]
 	stopped := m.stopped
-	m.mu.Unlock()
 	if stopped || !stillManaged {
 		m.endpointCache.Evict(address)
 	}
+	m.mu.Unlock()
 	return true
+}
+
+func (m *endpointLifecycleManager) updateActiveAddresses(addresses map[string]struct{}) {
+	if m == nil {
+		return
+	}
+	if m.testHooks != nil && m.testHooks.beforeRemovalLock != nil {
+		m.testHooks.beforeRemovalLock()
+	}
+
+	m.mu.Lock()
+	if m.stopped {
+		m.mu.Unlock()
+		return
+	}
+	next := make(map[string]struct{}, len(addresses))
+	for address := range addresses {
+		if address == "" || address == m.defaultEndpointAddress {
+			continue
+		}
+		next[address] = struct{}{}
+	}
+	for address := range m.activeAddresses {
+		if _, active := next[address]; active {
+			continue
+		}
+		delete(m.endpoints, address)
+		delete(m.transientFailureEvictedAddresses, address)
+		m.endpointCache.Evict(address)
+	}
+	m.activeAddresses = next
+	m.mu.Unlock()
 }
 
 func (m *endpointLifecycleManager) pendingCreationAddresses() []string {
@@ -430,9 +476,8 @@ func (m *endpointLifecycleManager) evictEndpoint(address string, reason lifecycl
 	} else {
 		delete(m.transientFailureEvictedAddresses, address)
 	}
-	m.mu.Unlock()
-
 	m.endpointCache.Evict(address)
+	m.mu.Unlock()
 }
 
 func (m *endpointLifecycleManager) isManaged(address string) bool {
@@ -483,6 +528,7 @@ func (m *endpointLifecycleManager) shutdown() {
 
 		m.mu.Lock()
 		m.endpoints = make(map[string]*endpointLifecycleState)
+		m.activeAddresses = make(map[string]struct{})
 		m.transientFailureEvictedAddresses = make(map[string]struct{})
 		m.mu.Unlock()
 	})

--- a/spanner/endpoint_lifecycle_manager.go
+++ b/spanner/endpoint_lifecycle_manager.go
@@ -295,9 +295,6 @@ func (m *endpointLifecycleManager) createEndpoint(address string) bool {
 }
 
 func (m *endpointLifecycleManager) updateActiveAddresses(addresses map[string]struct{}) {
-	if m == nil {
-		return
-	}
 	if m.testHooks != nil && m.testHooks.beforeRemovalLock != nil {
 		m.testHooks.beforeRemovalLock()
 	}

--- a/spanner/endpoint_lifecycle_manager_test.go
+++ b/spanner/endpoint_lifecycle_manager_test.go
@@ -246,6 +246,11 @@ func TestEndpointLifecycleManager_RequestEndpointRecreationCreatesEndpoint(t *te
 	)
 	defer manager.shutdown()
 
+	manager.recordRealTraffic("replica-2:443")
+	waitForCondition(t, time.Second, func() bool {
+		return cache.GetIfPresent("replica-2:443") != nil
+	})
+	cache.Evict("replica-2:443")
 	manager.requestEndpointRecreation("replica-2:443")
 
 	waitForCondition(t, time.Second, func() bool {
@@ -253,6 +258,88 @@ func TestEndpointLifecycleManager_RequestEndpointRecreationCreatesEndpoint(t *te
 			cache.GetIfPresent("replica-2:443") != nil &&
 			manager.isManaged("replica-2:443")
 	})
+}
+
+func TestEndpointLifecycleManager_RequestEndpointRecreationRefusesRemovedAddress(t *testing.T) {
+	cache := newLifecycleTestCache("default:443", func(_ context.Context, address string) channelEndpoint {
+		return &lifecycleTestEndpoint{address: address}
+	})
+	manager := newEndpointLifecycleManagerWithOptions(cache, time.Hour, time.Hour, time.Now)
+	defer manager.shutdown()
+
+	manager.updateActiveAddresses(map[string]struct{}{"removed:443": {}})
+	manager.updateActiveAddresses(nil)
+	getCalls := cache.getCallCount("removed:443")
+
+	manager.requestEndpointRecreation("removed:443")
+
+	if manager.isManaged("removed:443") {
+		t.Fatal("removed address was managed again")
+	}
+	if got := cache.getCallCount("removed:443"); got != getCalls {
+		t.Fatalf("Get call count = %d, want %d", got, getCalls)
+	}
+	if endpoint := cache.GetIfPresent("removed:443"); endpoint != nil {
+		t.Fatal("removed endpoint was recreated")
+	}
+}
+
+func TestEndpointLifecycleManager_CreateCannotResurrectConcurrentlyRemovedAddress(t *testing.T) {
+	cache := newLifecycleTestCache("default:443", func(_ context.Context, address string) channelEndpoint {
+		return &lifecycleTestEndpoint{address: address}
+	})
+	manager := newEndpointLifecycleManagerWithOptions(cache, time.Hour, time.Hour, time.Now)
+	defer manager.shutdown()
+
+	manager.updateActiveAddresses(map[string]struct{}{"racing:443": {}})
+
+	reconcileStarted := make(chan struct{})
+	releaseReconcile := make(chan struct{})
+	removalAttempted := make(chan struct{})
+	manager.testHooks = &endpointLifecycleManagerTestHooks{
+		beforeCreateReconcile: func() {
+			close(reconcileStarted)
+			<-releaseReconcile
+		},
+		beforeRemovalLock: func() {
+			close(removalAttempted)
+		},
+	}
+	manager.requestEndpointRecreation("racing:443")
+	select {
+	case <-reconcileStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for endpoint reconciliation")
+	}
+
+	removed := make(chan struct{})
+	go func() {
+		manager.updateActiveAddresses(nil)
+		close(removed)
+	}()
+	select {
+	case <-removalAttempted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for concurrent removal attempt")
+	}
+	select {
+	case <-removed:
+		t.Fatal("removal completed while endpoint reconciliation lock was held")
+	default:
+	}
+	close(releaseReconcile)
+
+	select {
+	case <-removed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for concurrent removal")
+	}
+	if endpoint := cache.GetIfPresent("racing:443"); endpoint != nil {
+		t.Fatal("concurrently removed endpoint was resurrected")
+	}
+	if manager.isManaged("racing:443") {
+		t.Fatal("concurrently removed address was managed again")
+	}
 }
 
 func TestEndpointLifecycleManager_ProbeEvictsTransientFailureEndpoint(t *testing.T) {
@@ -342,7 +429,7 @@ func TestEndpointLifecycleManager_ShutdownCancelsPendingCreation(t *testing.T) {
 		time.Now,
 	)
 
-	manager.requestEndpointRecreation("replica-5:443")
+	manager.recordRealTraffic("replica-5:443")
 
 	select {
 	case <-started:

--- a/spanner/endpoint_overload_cooldown.go
+++ b/spanner/endpoint_overload_cooldown.go
@@ -20,22 +20,44 @@ import (
 	"math/rand"
 	"sync"
 	"time"
+
+	"google.golang.org/grpc/codes"
 )
 
 const (
-	defaultEndpointOverloadInitialCooldown = 10 * time.Second
-	defaultEndpointOverloadMaxCooldown     = time.Minute
-	defaultEndpointOverloadResetAfter      = 10 * time.Minute
+	defaultEndpointOverloadInitialCooldown   = 10 * time.Second
+	defaultEndpointOverloadMaxCooldown       = time.Minute
+	defaultEndpointOverloadResetAfter        = 10 * time.Minute
+	defaultEndpointCooldownSuccessesToRepair = 3
+	defaultEndpointMinHintedCooldown         = 100 * time.Millisecond
+	defaultEndpointMaxHintedClientFloor      = 2 * time.Second
+	defaultEndpointMaxHintedJitter           = 500 * time.Millisecond
+	defaultEndpointCooldownMaxTier           = 6
+	minEndpointProbeReservation              = 250 * time.Millisecond
+	maxEndpointProbeReservation              = 500 * time.Millisecond
 )
 
 type endpointOverloadCooldownState struct {
-	consecutiveFailures int
-	cooldownUntil       time.Time
-	lastFailureAt       time.Time
+	overloadFailures         int
+	unavailableFailures      int
+	successesTowardRepair    int
+	overloadUntil            time.Time
+	unavailableUntil         time.Time
+	overloadProbeNotBefore   time.Time
+	probeReservedUntil       time.Time
+	lastOverloadFailureAt    time.Time
+	lastUnavailableFailureAt time.Time
 }
 
-// endpointOverloadCooldownTracker keeps routed endpoints out of selection for a
-// short period after RESOURCE_EXHAUSTED so the router can try another replica.
+type hintedEndpointCooldown struct {
+	cooldown   time.Duration
+	probeDelay time.Duration
+}
+
+// endpointOverloadCooldownTracker keeps routed endpoints out of selection after
+// overload or availability failures. The two failure classes escalate
+// independently so a short server-hinted load shed does not weaken connection
+// failure protection.
 type endpointOverloadCooldownTracker struct {
 	mu              sync.RWMutex
 	entries         map[string]endpointOverloadCooldownState
@@ -99,76 +121,161 @@ func (t *endpointOverloadCooldownTracker) isCoolingDown(address string) bool {
 	if t == nil || address == "" {
 		return false
 	}
-
 	now := t.now()
-
-	t.mu.RLock()
-	state, ok := t.entries[address]
-	t.mu.RUnlock()
-	if !ok {
-		return false
-	}
-	if state.cooldownUntil.After(now) {
-		return true
-	}
-
-	if now.Sub(state.lastFailureAt) < t.resetAfter {
-		return false
-	}
-
 	t.mu.Lock()
 	defer t.mu.Unlock()
-
-	state, ok = t.entries[address]
+	state, ok := t.entries[address]
 	if !ok {
 		return false
 	}
-	if state.cooldownUntil.After(now) {
+	if state.overloadUntil.After(now) || state.unavailableUntil.After(now) {
 		return true
 	}
-	if now.Sub(state.lastFailureAt) >= t.resetAfter {
+	if t.isIdle(state, now) {
 		delete(t.entries, address)
 	}
 	return false
 }
 
-func (t *endpointOverloadCooldownTracker) remainingCooldown(address string) time.Duration {
-	if t == nil || address == "" {
-		return 0
-	}
-
-	now := t.now()
-
-	t.mu.RLock()
-	state, ok := t.entries[address]
-	t.mu.RUnlock()
-	if !ok {
-		return 0
-	}
-	if state.cooldownUntil.After(now) {
-		return state.cooldownUntil.Sub(now)
-	}
-	return 0
+func (t *endpointOverloadCooldownTracker) recordFailure(address string) {
+	t.recordFailureWithStatus(address, codes.ResourceExhausted, nil)
 }
 
-func (t *endpointOverloadCooldownTracker) recordFailure(address string) {
+func (t *endpointOverloadCooldownTracker) recordFailureWithStatus(address string, code codes.Code, serverRetryDelay *time.Duration) {
+	if t == nil || address == "" || (code != codes.ResourceExhausted && code != codes.Unavailable) {
+		return
+	}
+	now := t.now()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	state, ok := t.entries[address]
+	if !ok || t.isIdle(state, now) {
+		state = t.emptyState(now)
+	}
+	state.successesTowardRepair = 0
+	if code == codes.ResourceExhausted {
+		failures := t.nextFailureTier(state.overloadFailures, state.lastOverloadFailureAt, now)
+		cooldown := t.cooldownForFailures(failures)
+		probeDelay := cooldown
+		if serverRetryDelay != nil && *serverRetryDelay >= 0 {
+			hinted := t.hintedOverloadCooldown(failures, *serverRetryDelay)
+			cooldown = hinted.cooldown
+			probeDelay = hinted.probeDelay
+		}
+		state.overloadFailures = failures
+		state.overloadUntil = laterTime(state.overloadUntil, now.Add(cooldown))
+		state.overloadProbeNotBefore = laterTime(state.overloadProbeNotBefore, now.Add(probeDelay))
+		state.lastOverloadFailureAt = now
+	} else {
+		failures := t.nextFailureTier(state.unavailableFailures, state.lastUnavailableFailureAt, now)
+		state.unavailableFailures = failures
+		state.unavailableUntil = laterTime(state.unavailableUntil, now.Add(t.cooldownForFailures(failures)))
+		state.lastUnavailableFailureAt = now
+	}
+	t.entries[address] = state
+}
+
+func (t *endpointOverloadCooldownTracker) recordSuccess(address string) {
 	if t == nil || address == "" {
 		return
 	}
-
 	now := t.now()
-
 	t.mu.Lock()
 	defer t.mu.Unlock()
-
-	state := t.entries[address]
-	if state.lastFailureAt.IsZero() || now.Sub(state.lastFailureAt) >= t.resetAfter {
-		state.consecutiveFailures = 0
+	state, ok := t.entries[address]
+	if !ok {
+		return
 	}
-	state.consecutiveFailures++
-	state.lastFailureAt = now
-	state.cooldownUntil = now.Add(t.cooldownForFailures(state.consecutiveFailures))
+	if t.isIdle(state, now) {
+		delete(t.entries, address)
+		return
+	}
+	state.successesTowardRepair++
+	if state.successesTowardRepair < defaultEndpointCooldownSuccessesToRepair {
+		t.entries[address] = state
+		return
+	}
+	if state.overloadFailures > 0 {
+		state.overloadFailures--
+	}
+	if state.unavailableFailures > 0 {
+		state.unavailableFailures--
+	}
+	state.successesTowardRepair = 0
+	if state.overloadFailures == 0 && state.unavailableFailures == 0 &&
+		!state.overloadUntil.After(now) && !state.unavailableUntil.After(now) {
+		delete(t.entries, address)
+		return
+	}
 	t.entries[address] = state
+}
+
+func (t *endpointOverloadCooldownTracker) tryReserveProbe(address string) bool {
+	if t == nil || address == "" {
+		return false
+	}
+	now := t.now()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	state, ok := t.entries[address]
+	if !ok || !state.overloadUntil.After(now) || state.unavailableUntil.After(now) ||
+		state.overloadProbeNotBefore.After(now) || state.probeReservedUntil.After(now) {
+		return false
+	}
+	minMillis := minEndpointProbeReservation.Milliseconds()
+	rangeMillis := maxEndpointProbeReservation.Milliseconds() - minMillis + 1
+	state.probeReservedUntil = now.Add(time.Duration(minMillis+t.randInt63n(rangeMillis)) * time.Millisecond)
+	t.entries[address] = state
+	return true
+}
+
+func (t *endpointOverloadCooldownTracker) lastOverloadFailure(address string) time.Time {
+	if t == nil || address == "" {
+		return time.Time{}
+	}
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.entries[address].lastOverloadFailureAt
+}
+
+func (t *endpointOverloadCooldownTracker) emptyState(now time.Time) endpointOverloadCooldownState {
+	return endpointOverloadCooldownState{
+		overloadUntil:          now,
+		unavailableUntil:       now,
+		overloadProbeNotBefore: now,
+		probeReservedUntil:     now,
+	}
+}
+
+func (t *endpointOverloadCooldownTracker) isRecent(lastFailureAt, now time.Time) bool {
+	return !lastFailureAt.IsZero() && now.Sub(lastFailureAt) < t.resetAfter
+}
+
+func (t *endpointOverloadCooldownTracker) isIdle(state endpointOverloadCooldownState, now time.Time) bool {
+	return !state.overloadUntil.After(now) && !state.unavailableUntil.After(now) &&
+		!t.isRecent(state.lastOverloadFailureAt, now) && !t.isRecent(state.lastUnavailableFailureAt, now)
+}
+
+func (t *endpointOverloadCooldownTracker) nextFailureTier(previous int, lastFailureAt, now time.Time) int {
+	if previous == 0 || !t.isRecent(lastFailureAt, now) {
+		return 1
+	}
+	if previous >= defaultEndpointCooldownMaxTier {
+		return defaultEndpointCooldownMaxTier
+	}
+	return previous + 1
+}
+
+func (t *endpointOverloadCooldownTracker) hintedOverloadCooldown(failures int, serverRetryDelay time.Duration) hintedEndpointCooldown {
+	serverFloor := maxCooldownDuration(serverRetryDelay, defaultEndpointMinHintedCooldown)
+	clientFloor := defaultEndpointMinHintedCooldown
+	for i := 1; i < failures && clientFloor < defaultEndpointMaxHintedClientFloor; i++ {
+		clientFloor = minCooldownDuration(clientFloor*2, defaultEndpointMaxHintedClientFloor)
+	}
+	base := maxCooldownDuration(serverFloor, clientFloor)
+	jitterLimit := minCooldownDuration(base/4, defaultEndpointMaxHintedJitter)
+	jitter := time.Duration(t.randInt63n(jitterLimit.Milliseconds()+1)) * time.Millisecond
+	return hintedEndpointCooldown{cooldown: base + jitter, probeDelay: serverFloor + jitter}
 }
 
 func (t *endpointOverloadCooldownTracker) cooldownForFailures(failures int) time.Duration {
@@ -199,18 +306,37 @@ func (t *endpointOverloadCooldownTracker) pruneStaleEntries(maxAge time.Duration
 	if t == nil || maxAge <= 0 {
 		return
 	}
-
 	now := t.now()
-
 	t.mu.Lock()
 	defer t.mu.Unlock()
-
 	for address, state := range t.entries {
-		if state.cooldownUntil.After(now) {
+		if state.overloadUntil.After(now) || state.unavailableUntil.After(now) {
 			continue
 		}
-		if now.Sub(state.lastFailureAt) >= maxAge {
+		lastFailureAt := laterTime(state.lastOverloadFailureAt, state.lastUnavailableFailureAt)
+		if lastFailureAt.IsZero() || now.Sub(lastFailureAt) >= maxAge {
 			delete(t.entries, address)
 		}
 	}
+}
+
+func minCooldownDuration(first, second time.Duration) time.Duration {
+	if first <= second {
+		return first
+	}
+	return second
+}
+
+func maxCooldownDuration(first, second time.Duration) time.Duration {
+	if first >= second {
+		return first
+	}
+	return second
+}
+
+func laterTime(first, second time.Time) time.Time {
+	if first.After(second) {
+		return first
+	}
+	return second
 }

--- a/spanner/endpoint_overload_cooldown.go
+++ b/spanner/endpoint_overload_cooldown.go
@@ -19,6 +19,7 @@ package spanner
 import (
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -61,6 +62,7 @@ type hintedEndpointCooldown struct {
 type endpointOverloadCooldownTracker struct {
 	mu              sync.RWMutex
 	entries         map[string]endpointOverloadCooldownState
+	entryCount      atomic.Int64
 	initialCooldown time.Duration
 	maxCooldown     time.Duration
 	resetAfter      time.Duration
@@ -132,7 +134,7 @@ func (t *endpointOverloadCooldownTracker) isCoolingDown(address string) bool {
 		return true
 	}
 	if t.isIdle(state, now) {
-		delete(t.entries, address)
+		t.deleteEntryLocked(address)
 	}
 	return false
 }
@@ -172,13 +174,19 @@ func (t *endpointOverloadCooldownTracker) recordFailureWithStatus(address string
 		state.unavailableUntil = laterTime(state.unavailableUntil, now.Add(t.cooldownForFailures(failures)))
 		state.lastUnavailableFailureAt = now
 	}
-	t.entries[address] = state
+	t.storeEntryLocked(address, state)
 }
 
 func (t *endpointOverloadCooldownTracker) recordSuccess(address string) {
 	if t == nil || address == "" {
 		return
 	}
+	if t.entryCount.Load() == 0 {
+		// A concurrent insertion can miss one success credit, delaying repair by
+		// one call without corrupting state.
+		return
+	}
+	// A stale nonzero read falls through to the locked lookup and finds no entry.
 	now := t.now()
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -187,12 +195,12 @@ func (t *endpointOverloadCooldownTracker) recordSuccess(address string) {
 		return
 	}
 	if t.isIdle(state, now) {
-		delete(t.entries, address)
+		t.deleteEntryLocked(address)
 		return
 	}
 	state.successesTowardRepair++
 	if state.successesTowardRepair < defaultEndpointCooldownSuccessesToRepair {
-		t.entries[address] = state
+		t.storeEntryLocked(address, state)
 		return
 	}
 	if state.overloadFailures > 0 {
@@ -204,10 +212,10 @@ func (t *endpointOverloadCooldownTracker) recordSuccess(address string) {
 	state.successesTowardRepair = 0
 	if state.overloadFailures == 0 && state.unavailableFailures == 0 &&
 		!state.overloadUntil.After(now) && !state.unavailableUntil.After(now) {
-		delete(t.entries, address)
+		t.deleteEntryLocked(address)
 		return
 	}
-	t.entries[address] = state
+	t.storeEntryLocked(address, state)
 }
 
 func (t *endpointOverloadCooldownTracker) tryReserveProbe(address string) bool {
@@ -225,12 +233,15 @@ func (t *endpointOverloadCooldownTracker) tryReserveProbe(address string) bool {
 	minMillis := minEndpointProbeReservation.Milliseconds()
 	rangeMillis := maxEndpointProbeReservation.Milliseconds() - minMillis + 1
 	state.probeReservedUntil = now.Add(time.Duration(minMillis+t.randInt63n(rangeMillis)) * time.Millisecond)
-	t.entries[address] = state
+	t.storeEntryLocked(address, state)
 	return true
 }
 
 func (t *endpointOverloadCooldownTracker) lastOverloadFailure(address string) time.Time {
 	if t == nil || address == "" {
+		return time.Time{}
+	}
+	if t.entryCount.Load() == 0 {
 		return time.Time{}
 	}
 	t.mu.RLock()
@@ -306,6 +317,9 @@ func (t *endpointOverloadCooldownTracker) pruneStaleEntries(maxAge time.Duration
 	if t == nil || maxAge <= 0 {
 		return
 	}
+	if t.entryCount.Load() == 0 {
+		return
+	}
 	now := t.now()
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -315,9 +329,26 @@ func (t *endpointOverloadCooldownTracker) pruneStaleEntries(maxAge time.Duration
 		}
 		lastFailureAt := laterTime(state.lastOverloadFailureAt, state.lastUnavailableFailureAt)
 		if lastFailureAt.IsZero() || now.Sub(lastFailureAt) >= maxAge {
-			delete(t.entries, address)
+			t.deleteEntryLocked(address)
 		}
 	}
+}
+
+// storeEntryLocked stores state and tracks first insertion. t.mu must be held.
+func (t *endpointOverloadCooldownTracker) storeEntryLocked(address string, state endpointOverloadCooldownState) {
+	if _, ok := t.entries[address]; !ok {
+		t.entryCount.Add(1)
+	}
+	t.entries[address] = state
+}
+
+// deleteEntryLocked deletes state and tracks removal. t.mu must be held.
+func (t *endpointOverloadCooldownTracker) deleteEntryLocked(address string) {
+	if _, ok := t.entries[address]; !ok {
+		return
+	}
+	delete(t.entries, address)
+	t.entryCount.Add(-1)
 }
 
 func minCooldownDuration(first, second time.Duration) time.Duration {

--- a/spanner/endpoint_overload_cooldown_test.go
+++ b/spanner/endpoint_overload_cooldown_test.go
@@ -128,6 +128,75 @@ func TestEndpointOverloadCooldownTracker_RepairDeletesZeroTierExpiredEntry(t *te
 	if _, ok := tracker.entries["replica-a:443"]; ok {
 		t.Fatal("zero-tier expired entry was retained")
 	}
+	assertEndpointCooldownEntryCount(t, tracker, 0)
+}
+
+func TestEndpointOverloadCooldownTracker_EntryCountTracksMapMutations(t *testing.T) {
+	newTracker := func(clock *lifecycleTestClock) *endpointOverloadCooldownTracker {
+		return newEndpointOverloadCooldownTrackerWithOptions(
+			time.Second, time.Second, 10*time.Minute, clock.Now,
+			func(int64) int64 { return 0 },
+		)
+	}
+
+	t.Run("insert and repair delete", func(t *testing.T) {
+		clock := newLifecycleTestClock(time.Unix(100, 0))
+		tracker := newTracker(clock)
+		assertEndpointCooldownEntryCount(t, tracker, 0)
+		hint := 100 * time.Millisecond
+		tracker.recordFailureWithStatus("replica-a:443", codes.ResourceExhausted, &hint)
+		tracker.recordFailureWithStatus("replica-a:443", codes.ResourceExhausted, &hint)
+		tracker.recordFailureWithStatus("replica-b:443", codes.ResourceExhausted, &hint)
+		assertEndpointCooldownEntryCount(t, tracker, 2)
+
+		clock.Advance(2 * hint)
+		for i := 0; i < 2*defaultEndpointCooldownSuccessesToRepair; i++ {
+			tracker.recordSuccess("replica-a:443")
+		}
+		assertEndpointCooldownEntryCount(t, tracker, 1)
+	})
+
+	t.Run("idle delete", func(t *testing.T) {
+		clock := newLifecycleTestClock(time.Unix(100, 0))
+		tracker := newTracker(clock)
+		tracker.recordFailure("replica-a:443")
+		assertEndpointCooldownEntryCount(t, tracker, 1)
+		clock.Advance(10 * time.Minute)
+		tracker.isCoolingDown("replica-a:443")
+		assertEndpointCooldownEntryCount(t, tracker, 0)
+	})
+
+	t.Run("prune delete", func(t *testing.T) {
+		clock := newLifecycleTestClock(time.Unix(100, 0))
+		tracker := newTracker(clock)
+		tracker.recordFailure("replica-a:443")
+		tracker.recordFailure("replica-b:443")
+		assertEndpointCooldownEntryCount(t, tracker, 2)
+		clock.Advance(20 * time.Minute)
+		tracker.pruneStaleEntries(20 * time.Minute)
+		assertEndpointCooldownEntryCount(t, tracker, 0)
+	})
+}
+
+func TestEndpointOverloadCooldownTracker_EmptyRecordSuccessSkipsClock(t *testing.T) {
+	tracker := newEndpointOverloadCooldownTrackerWithOptions(
+		time.Second, time.Second, 10*time.Minute,
+		func() time.Time { t.Fatal("recordSuccess called clock for empty tracker"); return time.Time{} },
+		func(int64) int64 { return 0 },
+	)
+
+	tracker.recordSuccess("replica-a:443")
+	assertEndpointCooldownEntryCount(t, tracker, 0)
+}
+
+func assertEndpointCooldownEntryCount(t *testing.T, tracker *endpointOverloadCooldownTracker, want int64) {
+	t.Helper()
+	if got := tracker.entryCount.Load(); got != want {
+		t.Fatalf("entryCount = %d, want %d", got, want)
+	}
+	if got := int64(len(tracker.entries)); got != want {
+		t.Fatalf("len(entries) = %d, want %d", got, want)
+	}
 }
 
 func TestEndpointOverloadCooldownTracker_FailureResetsRepairAndIdleResetsLanes(t *testing.T) {

--- a/spanner/endpoint_overload_cooldown_test.go
+++ b/spanner/endpoint_overload_cooldown_test.go
@@ -19,7 +19,195 @@ package spanner
 import (
 	"testing"
 	"time"
+
+	"google.golang.org/grpc/codes"
 )
+
+func TestEndpointOverloadCooldownTracker_HintedOverloadHonorsFloorJitterAndTierCap(t *testing.T) {
+	clock := newLifecycleTestClock(time.Unix(100, 0))
+	tracker := newEndpointOverloadCooldownTrackerWithOptions(
+		10*time.Second, time.Minute, 10*time.Minute, clock.Now,
+		func(n int64) int64 { return n - 1 },
+	)
+	zero := time.Duration(0)
+	tracker.recordFailureWithStatus("replica-a:443", codes.ResourceExhausted, &zero)
+	state := tracker.entries["replica-a:443"]
+	if got, want := state.overloadUntil.Sub(clock.Now()), 125*time.Millisecond; got != want {
+		t.Fatalf("hinted cooldown = %v, want %v", got, want)
+	}
+
+	tracker = newEndpointOverloadCooldownTrackerWithOptions(
+		10*time.Second, time.Minute, 10*time.Minute, clock.Now,
+		func(int64) int64 { return 0 },
+	)
+	hint := 100 * time.Millisecond
+	for i := 0; i < 20; i++ {
+		tracker.recordFailureWithStatus("replica-a:443", codes.ResourceExhausted, &hint)
+	}
+	state = tracker.entries["replica-a:443"]
+	if state.overloadFailures != defaultEndpointCooldownMaxTier {
+		t.Fatalf("overloadFailures = %d, want %d", state.overloadFailures, defaultEndpointCooldownMaxTier)
+	}
+	if got, want := state.overloadUntil.Sub(clock.Now()), 2*time.Second; got != want {
+		t.Fatalf("capped hinted cooldown = %v, want %v", got, want)
+	}
+}
+
+func TestEndpointOverloadCooldownTracker_UnhintedOverloadKeepsLongBackoff(t *testing.T) {
+	clock := newLifecycleTestClock(time.Unix(100, 0))
+	tracker := newEndpointOverloadCooldownTrackerWithOptions(
+		10*time.Second, time.Minute, 10*time.Minute, clock.Now,
+		func(int64) int64 { return 0 },
+	)
+	tracker.recordFailureWithStatus("replica-a:443", codes.ResourceExhausted, nil)
+	tracker.recordFailureWithStatus("replica-a:443", codes.ResourceExhausted, nil)
+	if got, want := tracker.entries["replica-a:443"].overloadUntil.Sub(clock.Now()), 10*time.Second; got != want {
+		t.Fatalf("unhinted cooldown = %v, want %v", got, want)
+	}
+}
+
+func TestEndpointOverloadCooldownTracker_IndependentFailureLanes(t *testing.T) {
+	clock := newLifecycleTestClock(time.Unix(100, 0))
+	tracker := newEndpointOverloadCooldownTrackerWithOptions(
+		10*time.Second, time.Minute, 10*time.Minute, clock.Now,
+		func(int64) int64 { return 0 },
+	)
+	hint := 100 * time.Millisecond
+	tracker.recordFailureWithStatus("replica-a:443", codes.ResourceExhausted, &hint)
+	ignoredHint := time.Hour
+	tracker.recordFailureWithStatus("replica-a:443", codes.Unavailable, &ignoredHint)
+	state := tracker.entries["replica-a:443"]
+	if state.overloadFailures != 1 || state.unavailableFailures != 1 {
+		t.Fatalf("failure lanes = (%d, %d), want (1, 1)", state.overloadFailures, state.unavailableFailures)
+	}
+	clock.Advance(100 * time.Millisecond)
+	if !tracker.isCoolingDown("replica-a:443") {
+		t.Fatal("unavailable lane ended with hinted overload lane")
+	}
+	clock.Advance(4900 * time.Millisecond)
+	if tracker.isCoolingDown("replica-a:443") {
+		t.Fatal("unavailable cooldown did not use independent unhinted backoff")
+	}
+}
+
+func TestEndpointOverloadCooldownTracker_ThreeSuccessesRepairBothLanes(t *testing.T) {
+	clock := newLifecycleTestClock(time.Unix(100, 0))
+	tracker := newEndpointOverloadCooldownTrackerWithOptions(
+		10*time.Second, time.Minute, 10*time.Minute, clock.Now,
+		func(int64) int64 { return 0 },
+	)
+	hint := 100 * time.Millisecond
+	tracker.recordFailureWithStatus("replica-a:443", codes.ResourceExhausted, &hint)
+	tracker.recordFailureWithStatus("replica-a:443", codes.ResourceExhausted, &hint)
+	tracker.recordFailureWithStatus("replica-a:443", codes.Unavailable, nil)
+	before := tracker.entries["replica-a:443"]
+	tracker.recordSuccess("replica-a:443")
+	tracker.recordSuccess("replica-a:443")
+	tracker.recordSuccess("replica-a:443")
+	after := tracker.entries["replica-a:443"]
+	if after.overloadFailures != 1 || after.unavailableFailures != 0 || after.successesTowardRepair != 0 {
+		t.Fatalf("repaired state = %+v", after)
+	}
+	if !after.overloadUntil.Equal(before.overloadUntil) || !after.unavailableUntil.Equal(before.unavailableUntil) {
+		t.Fatal("repair shortened active cooldown deadline")
+	}
+}
+
+func TestEndpointOverloadCooldownTracker_RepairDeletesZeroTierExpiredEntry(t *testing.T) {
+	clock := newLifecycleTestClock(time.Unix(100, 0))
+	tracker := newEndpointOverloadCooldownTrackerWithOptions(
+		10*time.Second, time.Minute, 10*time.Minute, clock.Now,
+		func(int64) int64 { return 0 },
+	)
+	hint := 100 * time.Millisecond
+	tracker.recordFailureWithStatus("replica-a:443", codes.ResourceExhausted, &hint)
+	clock.Advance(hint)
+	for i := 0; i < defaultEndpointCooldownSuccessesToRepair; i++ {
+		tracker.recordSuccess("replica-a:443")
+	}
+	if _, ok := tracker.entries["replica-a:443"]; ok {
+		t.Fatal("zero-tier expired entry was retained")
+	}
+}
+
+func TestEndpointOverloadCooldownTracker_FailureResetsRepairAndIdleResetsLanes(t *testing.T) {
+	clock := newLifecycleTestClock(time.Unix(100, 0))
+	tracker := newEndpointOverloadCooldownTrackerWithOptions(
+		10*time.Second, time.Minute, 10*time.Minute, clock.Now,
+		func(int64) int64 { return 0 },
+	)
+	hint := 100 * time.Millisecond
+	tracker.recordFailureWithStatus("replica-a:443", codes.ResourceExhausted, &hint)
+	tracker.recordSuccess("replica-a:443")
+	tracker.recordSuccess("replica-a:443")
+	tracker.recordFailureWithStatus("replica-a:443", codes.Unavailable, nil)
+	if got := tracker.entries["replica-a:443"].successesTowardRepair; got != 0 {
+		t.Fatalf("successesTowardRepair = %d, want 0", got)
+	}
+
+	tracker.recordFailureWithStatus("replica-a:443", codes.ResourceExhausted, &hint)
+	tracker.recordFailureWithStatus("replica-a:443", codes.Unavailable, nil)
+	clock.Advance(10 * time.Minute)
+	tracker.recordFailureWithStatus("replica-a:443", codes.ResourceExhausted, &hint)
+	state := tracker.entries["replica-a:443"]
+	if state.overloadFailures != 1 || state.unavailableFailures != 0 {
+		t.Fatalf("post-idle lanes = (%d, %d), want (1, 0)", state.overloadFailures, state.unavailableFailures)
+	}
+	clock.Advance(10 * time.Minute)
+	tracker.recordSuccess("replica-a:443")
+	if _, ok := tracker.entries["replica-a:443"]; ok {
+		t.Fatal("idle entry was repaired instead of removed")
+	}
+}
+
+func TestEndpointOverloadCooldownTracker_ProbeReservation(t *testing.T) {
+	clock := newLifecycleTestClock(time.Unix(100, 0))
+	tracker := newEndpointOverloadCooldownTrackerWithOptions(
+		10*time.Second, time.Minute, 10*time.Minute, clock.Now,
+		func(int64) int64 { return 0 },
+	)
+	hint := 100 * time.Millisecond
+	for i := 0; i < defaultEndpointCooldownMaxTier; i++ {
+		tracker.recordFailureWithStatus("replica-a:443", codes.ResourceExhausted, &hint)
+	}
+	clock.Advance(99 * time.Millisecond)
+	if tracker.tryReserveProbe("replica-a:443") {
+		t.Fatal("probe reserved before server delay")
+	}
+	clock.Advance(time.Millisecond)
+	if !tracker.tryReserveProbe("replica-a:443") || tracker.tryReserveProbe("replica-a:443") {
+		t.Fatal("probe reservation was not exclusive")
+	}
+	clock.Advance(249 * time.Millisecond)
+	if tracker.tryReserveProbe("replica-a:443") {
+		t.Fatal("probe reservation expired early")
+	}
+	clock.Advance(time.Millisecond)
+	if !tracker.tryReserveProbe("replica-a:443") {
+		t.Fatal("probe reservation did not reopen")
+	}
+}
+
+func TestEndpointOverloadCooldownTracker_UnavailablePreventsProbeAndUnknownStatusIgnored(t *testing.T) {
+	clock := newLifecycleTestClock(time.Unix(100, 0))
+	tracker := newEndpointOverloadCooldownTrackerWithOptions(
+		10*time.Second, time.Minute, 10*time.Minute, clock.Now,
+		func(int64) int64 { return 0 },
+	)
+	hint := 100 * time.Millisecond
+	tracker.recordFailureWithStatus("replica-a:443", codes.Aborted, &hint)
+	if _, ok := tracker.entries["replica-a:443"]; ok {
+		t.Fatal("untracked status created state")
+	}
+	for i := 0; i < defaultEndpointCooldownMaxTier; i++ {
+		tracker.recordFailureWithStatus("replica-a:443", codes.ResourceExhausted, &hint)
+	}
+	tracker.recordFailureWithStatus("replica-a:443", codes.Unavailable, nil)
+	clock.Advance(100 * time.Millisecond)
+	if tracker.tryReserveProbe("replica-a:443") {
+		t.Fatal("unavailable lane allowed early overload probe")
+	}
+}
 
 func TestEndpointOverloadCooldownTracker_SuccessDoesNotClearFailureState(t *testing.T) {
 	clock := newLifecycleTestClock(time.Unix(100, 0))
@@ -71,7 +259,7 @@ func TestEndpointOverloadCooldownTracker_UsesFullJitterWithinCooldownRange(t *te
 	tracker.recordFailure("replica-a:443")
 
 	state := tracker.entries["replica-a:443"]
-	got := state.cooldownUntil.Sub(clock.Now())
+	got := state.overloadUntil.Sub(clock.Now())
 	if got != 5*time.Second {
 		t.Fatalf("cooldown = %v, want %v from deterministic jitter floor", got, 5*time.Second)
 	}
@@ -116,15 +304,15 @@ func TestEndpointOverloadCooldownTracker_ResetsPenaltyOnlyAfterQuietWindow(t *te
 	clock.Advance(2 * time.Minute)
 	tracker.recordFailure("replica-a:443")
 	second := tracker.entries["replica-a:443"]
-	if second.consecutiveFailures != first.consecutiveFailures+1 {
-		t.Fatalf("consecutiveFailures = %d, want %d", second.consecutiveFailures, first.consecutiveFailures+1)
+	if second.overloadFailures != first.overloadFailures+1 {
+		t.Fatalf("consecutiveFailures = %d, want %d", second.overloadFailures, first.overloadFailures+1)
 	}
 
 	clock.Advance(11 * time.Minute)
 	tracker.recordFailure("replica-a:443")
 	third := tracker.entries["replica-a:443"]
-	if third.consecutiveFailures != 1 {
-		t.Fatalf("expected quiet window to reset failure count, got %d", third.consecutiveFailures)
+	if third.overloadFailures != 1 {
+		t.Fatalf("expected quiet window to reset failure count, got %d", third.overloadFailures)
 	}
 }
 

--- a/spanner/key_range_cache.go
+++ b/spanner/key_range_cache.go
@@ -93,10 +93,6 @@ type routeSelectionState struct {
 	hasUnroutableReplica     bool
 }
 
-func (s routeSelectionState) allCoolingDown() bool {
-	return s.sawMatchingReplica && s.sawCoolingDownReplica && !s.sawNonCoolingDownReplica
-}
-
 type cachedGroup struct {
 	groupUID uint64
 
@@ -1207,9 +1203,9 @@ func (g *cachedGroup) fillRoutingHintWithCooldownTracker(ctx context.Context, en
 	if selected != nil {
 		return selected.pick(hint)
 	}
-	if state.allCoolingDown() {
+	if state.sawCoolingDownReplica {
 		g.mu.RLock()
-		selected = g.selectCoolingDownTabletLocked(endpointCache, deterministicRandom, preferLeader, directedReadOptions, hint)
+		selected = g.selectCoolingDownTabletLocked(endpointCache, preferLeader, directedReadOptions, hint, cooldowns)
 		if selected != nil {
 			g.recordKnownTransientFailuresLocked(endpointCache, lifecycleManager, selected, directedReadOptions, hint, cooldowns, skippedTabletUIDsFromHint(hint))
 			g.mu.RUnlock()
@@ -1223,11 +1219,11 @@ func (g *cachedGroup) fillRoutingHintWithCooldownTracker(ctx context.Context, en
 	warmPendingEndpoints(ctx, endpointCache, pendingCreations)
 	selected, state = g.fillRoutingHintAttempt(endpointCache, lifecycleManager, deterministicRandom, preferLeader, directedReadOptions, hint, cooldowns, nil)
 	if selected == nil {
-		if !state.allCoolingDown() {
+		if !state.sawCoolingDownReplica {
 			return nil
 		}
 		g.mu.RLock()
-		selected = g.selectCoolingDownTabletLocked(endpointCache, deterministicRandom, preferLeader, directedReadOptions, hint)
+		selected = g.selectCoolingDownTabletLocked(endpointCache, preferLeader, directedReadOptions, hint, cooldowns)
 		if selected == nil {
 			g.mu.RUnlock()
 			return nil
@@ -1310,12 +1306,15 @@ func (g *cachedGroup) selectScoreAwareTabletLocked(endpointCache channelEndpoint
 	return selected.tablet
 }
 
-func (g *cachedGroup) selectCoolingDownTabletLocked(endpointCache channelEndpointCache, deterministicRandom bool, preferLeader bool, directedReadOptions *sppb.DirectedReadOptions, hint *sppb.RoutingHint) *cachedTablet {
+func (g *cachedGroup) selectCoolingDownTabletLocked(endpointCache channelEndpointCache, preferLeader bool, directedReadOptions *sppb.DirectedReadOptions, hint *sppb.RoutingHint, cooldowns *endpointOverloadCooldownTracker) *cachedTablet {
+	if cooldowns == nil {
+		return nil
+	}
 	hasDirectedReadOptions := directedReadOptions != nil && directedReadOptions.GetReplicas() != nil
 	preferredLeader := g.localLeaderForScoreBiasLocked(hasDirectedReadOptions)
 	candidates := make([]eligibleReplica, 0, len(g.tablets))
 	for _, tablet := range g.tablets {
-		if tablet == nil || !tablet.matches(directedReadOptions) || tablet.skip || tablet.serverAddress == "" {
+		if tablet == nil || !tablet.matches(directedReadOptions) || tablet.skip || tablet.serverAddress == "" || !cooldowns.isCoolingDown(tablet.serverAddress) {
 			continue
 		}
 		endpoint := tablet.getOrLoadEndpointIfPresent(endpointCache)
@@ -1328,11 +1327,26 @@ func (g *cachedGroup) selectCoolingDownTabletLocked(endpointCache channelEndpoin
 			selectionCost: selectionCostForTablet(routingOperationUID(hint), preferLeader, endpoint, tablet, preferredLeader),
 		})
 	}
-	selected := selectEligibleReplica(candidates, deterministicRandom)
-	if selected == nil {
-		return nil
+	sort.SliceStable(candidates, func(i, j int) bool {
+		firstFailure := cooldowns.lastOverloadFailure(candidates[i].tablet.serverAddress)
+		secondFailure := cooldowns.lastOverloadFailure(candidates[j].tablet.serverAddress)
+		if firstFailure.IsZero() {
+			return false
+		}
+		if secondFailure.IsZero() {
+			return true
+		}
+		if !firstFailure.Equal(secondFailure) {
+			return firstFailure.Before(secondFailure)
+		}
+		return candidates[i].selectionCost < candidates[j].selectionCost
+	})
+	for _, candidate := range candidates {
+		if cooldowns.tryReserveProbe(candidate.tablet.serverAddress) {
+			return candidate.tablet
+		}
 	}
-	return selected.tablet
+	return nil
 }
 
 func (g *cachedGroup) localLeaderForScoreBiasLocked(hasDirectedReadOptions bool) *cachedTablet {

--- a/spanner/key_range_cache.go
+++ b/spanner/key_range_cache.go
@@ -73,6 +73,12 @@ type cachedTablet struct {
 	endpoint atomic.Pointer[cachedTabletEndpointRef]
 }
 
+type tabletFreshnessBaseline struct {
+	incarnation                             []byte
+	serverAddress                           string
+	requiresNewerIncarnationForFirstAddress bool
+}
+
 type eligibleReplica struct {
 	tablet        *cachedTablet
 	endpoint      channelEndpoint
@@ -94,10 +100,11 @@ func (s routeSelectionState) allCoolingDown() bool {
 type cachedGroup struct {
 	groupUID uint64
 
-	mu         sync.RWMutex
-	generation []byte
-	tablets    []*cachedTablet
-	leaderIdx  int
+	mu                           sync.RWMutex
+	generation                   []byte
+	tablets                      []*cachedTablet
+	leaderIdx                    int
+	freshnessBaselineByTabletUID map[uint64]tabletFreshnessBaseline
 }
 
 type cachedTabletEndpointRef struct {
@@ -179,8 +186,11 @@ func (c *keyRangeCache) setMinEntriesForRandomPick(value int) {
 
 func (c *keyRangeCache) setLifecycleManager(lifecycleManager *endpointLifecycleManager) {
 	c.configMu.Lock()
-	defer c.configMu.Unlock()
 	c.lifecycleManager = lifecycleManager
+	c.configMu.Unlock()
+	if lifecycleManager != nil {
+		lifecycleManager.updateActiveAddresses(activeAddressesInState(c.loadState()))
+	}
 }
 
 func (c *keyRangeCache) recordReplicaLatency(operationUID uint64, address string, latency time.Duration) {
@@ -227,10 +237,15 @@ func cloneCachedGroup(group *cachedGroup) *cachedGroup {
 	group.mu.RLock()
 	defer group.mu.RUnlock()
 	cloned := &cachedGroup{
-		groupUID:   group.groupUID,
-		generation: append([]byte(nil), group.generation...),
-		leaderIdx:  group.leaderIdx,
-		tablets:    make([]*cachedTablet, 0, len(group.tablets)),
+		groupUID:                     group.groupUID,
+		generation:                   append([]byte(nil), group.generation...),
+		leaderIdx:                    group.leaderIdx,
+		tablets:                      make([]*cachedTablet, 0, len(group.tablets)),
+		freshnessBaselineByTabletUID: make(map[uint64]tabletFreshnessBaseline, len(group.freshnessBaselineByTabletUID)),
+	}
+	for tabletUID, baseline := range group.freshnessBaselineByTabletUID {
+		baseline.incarnation = append([]byte(nil), baseline.incarnation...)
+		cloned.freshnessBaselineByTabletUID[tabletUID] = baseline
 	}
 	for _, tablet := range group.tablets {
 		if tablet == nil {
@@ -330,7 +345,9 @@ func (c *keyRangeCache) addRanges(cacheUpdate *sppb.CacheUpdate) {
 	for _, group := range newGroups {
 		builder.unrefGroup(group)
 	}
-	c.state.Store(builder.snapshot())
+	snapshot := builder.snapshot()
+	c.state.Store(snapshot)
+	c.syncLifecycleActiveAddresses(snapshot)
 }
 
 func (c *keyRangeCache) fillRoutingHint(ctx context.Context, preferLeader bool, mode rangeMode, directedReadOptions *sppb.DirectedReadOptions, hint *sppb.RoutingHint) channelEndpoint {
@@ -367,8 +384,46 @@ func (c *keyRangeCache) fillRoutingHintWithCooldownTracker(ctx context.Context, 
 func (c *keyRangeCache) clear() {
 	c.updateMu.Lock()
 	defer c.updateMu.Unlock()
-	c.state.Store(&keyRangeCacheState{})
+	state := &keyRangeCacheState{}
+	c.state.Store(state)
 	c.accessCounter.Store(0)
+	c.syncLifecycleActiveAddresses(state)
+}
+
+func (c *keyRangeCache) syncLifecycleActiveAddresses(state *keyRangeCacheState) {
+	c.configMu.RLock()
+	lifecycleManager := c.lifecycleManager
+	c.configMu.RUnlock()
+	if lifecycleManager != nil {
+		lifecycleManager.updateActiveAddresses(activeAddressesInState(state))
+	}
+}
+
+func activeAddressesInState(state *keyRangeCacheState) map[string]struct{} {
+	addresses := make(map[string]struct{})
+	if state == nil {
+		return addresses
+	}
+	groupUIDs := make(map[uint64]struct{})
+	for _, partition := range state.partitions {
+		for _, cachedRange := range partition.ranges {
+			groupUIDs[cachedRange.groupUID] = struct{}{}
+		}
+	}
+	for groupUID := range groupUIDs {
+		group := state.findGroup(groupUID)
+		if group == nil {
+			continue
+		}
+		group.mu.RLock()
+		for _, tablet := range group.tablets {
+			if tablet != nil && tablet.serverAddress != "" {
+				addresses[tablet.serverAddress] = struct{}{}
+			}
+		}
+		group.mu.RUnlock()
+	}
+	return addresses
 }
 
 func (c *keyRangeCache) size() int {
@@ -482,8 +537,10 @@ func (c *keyRangeCache) shrinkTo(newSize int) {
 	defer c.updateMu.Unlock()
 	builder := c.cloneState()
 	if newSize <= 0 {
-		c.state.Store(&keyRangeCacheState{})
+		state := &keyRangeCacheState{}
+		c.state.Store(state)
 		c.accessCounter.Store(0)
+		c.syncLifecycleActiveAddresses(state)
 		return
 	}
 	if newSize >= builder.rangeCount {
@@ -525,7 +582,9 @@ func (c *keyRangeCache) shrinkTo(newSize int) {
 	builder.recordTouchedPartitions(0, len(builder.partitions))
 	builder.partitions = buildRangePartitions(kept)
 	builder.rangeCount = len(allRanges) - numToShrink
-	c.state.Store(builder.snapshot())
+	snapshot := builder.snapshot()
+	c.state.Store(snapshot)
+	c.syncLifecycleActiveAddresses(snapshot)
 }
 
 func (c *keyRangeCache) accessTimeNow() int64 {
@@ -767,9 +826,6 @@ func (b *keyRangeCacheStateBuilder) findGroup(groupUID uint64) *cachedGroup {
 
 func (t *cachedTablet) update(tabletIn *sppb.Tablet) {
 	if tabletIn == nil {
-		return
-	}
-	if t.tabletUID > 0 && bytes.Compare(t.incarnation, tabletIn.GetIncarnation()) > 0 {
 		return
 	}
 	t.tabletUID = tabletIn.GetTabletUid()
@@ -1024,45 +1080,110 @@ func (g *cachedGroup) update(groupIn *sppb.Group) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
-	if bytes.Compare(groupIn.GetGeneration(), g.generation) > 0 {
+	generationCmp := bytes.Compare(groupIn.GetGeneration(), g.generation)
+	// Response-carried updates may arrive out of order. Reject the entire stale
+	// group so it cannot restore tablet membership from an older generation.
+	if generationCmp < 0 {
+		return
+	}
+
+	if generationCmp > 0 {
 		g.generation = append([]byte(nil), groupIn.GetGeneration()...)
+		g.freshnessBaselineByTabletUID = make(map[uint64]tabletFreshnessBaseline, len(groupIn.GetTablets()))
 		if idx := int(groupIn.GetLeaderIndex()); idx >= 0 && idx < len(groupIn.GetTablets()) {
 			g.leaderIdx = idx
 		} else {
 			g.leaderIdx = -1
 		}
 	}
-
-	if len(g.tablets) == len(groupIn.GetTablets()) {
-		mismatch := false
-		for i := range g.tablets {
-			if g.tablets[i].tabletUID != groupIn.GetTablets()[i].GetTabletUid() {
-				mismatch = true
-				break
-			}
-		}
-		if !mismatch {
-			for i := range g.tablets {
-				g.tablets[i].update(groupIn.GetTablets()[i])
-			}
-			return
-		}
+	if g.freshnessBaselineByTabletUID == nil {
+		g.freshnessBaselineByTabletUID = make(map[uint64]tabletFreshnessBaseline)
 	}
 
-	tabletByUID := make(map[uint64]*cachedTablet, len(g.tablets))
+	if generationCmp > 0 {
+		g.tablets = make([]*cachedTablet, 0, len(groupIn.GetTablets()))
+		for _, tabletIn := range groupIn.GetTablets() {
+			tablet := &cachedTablet{}
+			tablet.update(tabletIn)
+			g.tablets = append(g.tablets, tablet)
+			g.rememberFreshnessBaselineLocked(tablet)
+		}
+		return
+	}
+
+	g.mergeEqualGenerationTabletsLocked(groupIn)
+}
+
+func (g *cachedGroup) mergeEqualGenerationTabletsLocked(groupIn *sppb.Group) {
+	currentByUID := make(map[uint64]*cachedTablet, len(g.tablets))
 	for _, tablet := range g.tablets {
-		tabletByUID[tablet.tabletUID] = tablet
+		currentByUID[tablet.tabletUID] = tablet
 	}
-	newTablets := make([]*cachedTablet, 0, len(groupIn.GetTablets()))
+
+	tablets := make([]*cachedTablet, 0, len(groupIn.GetTablets()))
 	for _, tabletIn := range groupIn.GetTablets() {
-		tablet := tabletByUID[tabletIn.GetTabletUid()]
-		if tablet == nil {
-			tablet = &cachedTablet{}
+		incoming := &cachedTablet{}
+		incoming.update(tabletIn)
+		previous := currentByUID[incoming.tabletUID]
+		baseline, hasBaseline := g.freshnessBaselineByTabletUID[incoming.tabletUID]
+		incarnationCmp := 1
+		if hasBaseline {
+			incarnationCmp = bytes.Compare(incoming.incarnation, baseline.incarnation)
 		}
-		tablet.update(tabletIn)
-		newTablets = append(newTablets, tablet)
+		makesRoutable := !incoming.skip && incoming.serverAddress != ""
+		hasNewerIncarnation := hasBaseline && len(incoming.incarnation) > 0 && incarnationCmp > 0
+		hasOlderFirstAddress := hasBaseline && baseline.serverAddress == "" && incarnationCmp < 0
+		changesProvenAddress := hasBaseline && baseline.serverAddress != "" && incoming.serverAddress != baseline.serverAddress
+		requiresFreshFirstAddress := hasBaseline && baseline.serverAddress == "" && baseline.requiresNewerIncarnationForFirstAddress
+		latchesFirstAddressFreshness := hasBaseline && baseline.serverAddress == "" && incoming.skip && incoming.serverAddress == "" && incarnationCmp >= 0
+		// Equal-generation availability can flap between frontends. Preserve a
+		// proven address or skip-and-empty state until incarnation advances.
+		refusesStaleAddressChange := makesRoutable && (hasOlderFirstAddress || ((changesProvenAddress || requiresFreshFirstAddress) && !hasNewerIncarnation))
+		if refusesStaleAddressChange {
+			if previous != nil {
+				tablets = append(tablets, previous)
+			}
+			continue
+		}
+
+		if previous != nil {
+			previous.update(tabletIn)
+			incoming = previous
+		}
+		tablets = append(tablets, incoming)
+		if !hasBaseline || makesRoutable || hasNewerIncarnation || latchesFirstAddressFreshness {
+			g.rememberFreshnessBaselineLocked(incoming)
+		}
 	}
-	g.tablets = newTablets
+	g.tablets = tablets
+}
+
+func (g *cachedGroup) rememberFreshnessBaselineLocked(tablet *cachedTablet) {
+	baseline, hasBaseline := g.freshnessBaselineByTabletUID[tablet.tabletUID]
+	incarnationCmp := 1
+	if hasBaseline {
+		incarnationCmp = bytes.Compare(tablet.incarnation, baseline.incarnation)
+	}
+	hasNewerIncarnation := incarnationCmp > 0
+	incarnation := baseline.incarnation
+	if hasNewerIncarnation {
+		incarnation = append([]byte(nil), tablet.incarnation...)
+	}
+	serverAddress := baseline.serverAddress
+	requiresNewerIncarnationForFirstAddress := hasBaseline && baseline.requiresNewerIncarnationForFirstAddress
+	if tablet.serverAddress != "" && incarnationCmp >= 0 {
+		serverAddress = tablet.serverAddress
+		requiresNewerIncarnationForFirstAddress = false
+	} else if hasNewerIncarnation {
+		requiresNewerIncarnationForFirstAddress = tablet.skip
+	} else if serverAddress == "" && tablet.skip && tablet.serverAddress == "" && incarnationCmp == 0 {
+		requiresNewerIncarnationForFirstAddress = true
+	}
+	g.freshnessBaselineByTabletUID[tablet.tabletUID] = tabletFreshnessBaseline{
+		incarnation:                             incarnation,
+		serverAddress:                           serverAddress,
+		requiresNewerIncarnationForFirstAddress: requiresNewerIncarnationForFirstAddress,
+	}
 }
 
 func (g *cachedGroup) hasLeaderLocked() bool {

--- a/spanner/key_range_cache.go
+++ b/spanner/key_range_cache.go
@@ -1330,6 +1330,9 @@ func (g *cachedGroup) selectCoolingDownTabletLocked(endpointCache channelEndpoin
 	sort.SliceStable(candidates, func(i, j int) bool {
 		firstFailure := cooldowns.lastOverloadFailure(candidates[i].tablet.serverAddress)
 		secondFailure := cooldowns.lastOverloadFailure(candidates[j].tablet.serverAddress)
+		if firstFailure.IsZero() && secondFailure.IsZero() {
+			return candidates[i].selectionCost < candidates[j].selectionCost
+		}
 		if firstFailure.IsZero() {
 			return false
 		}

--- a/spanner/key_range_cache_test.go
+++ b/spanner/key_range_cache_test.go
@@ -250,6 +250,40 @@ func TestCachedGroupFillRoutingHintReservesHintedOverloadProbe(t *testing.T) {
 	}
 }
 
+func TestCachedGroupCoolingDownCandidatesWithoutFailureTimesOrderByCost(t *testing.T) {
+	withIsolatedEndpointLatencyRegistry(t)
+	endpointCache := newTestEndpointCache()
+	expensive := endpointCache.Get(context.Background(), "expensive:443")
+	endpointCache.Get(context.Background(), "cheap:443")
+	expensive.IncrementActiveRequests()
+	group := &cachedGroup{
+		leaderIdx: -1,
+		tablets: []*cachedTablet{
+			{tabletUID: 1, serverAddress: "expensive:443", incarnation: []byte("1")},
+			{tabletUID: 2, serverAddress: "cheap:443", incarnation: []byte("1")},
+		},
+	}
+	clock := newLifecycleTestClock(time.Unix(100, 0))
+	cooldowns := newEndpointOverloadCooldownTrackerWithOptions(
+		10*time.Second, time.Minute, 10*time.Minute, clock.Now,
+		func(int64) int64 { return 0 },
+	)
+	state := cooldowns.emptyState(clock.Now())
+	state.overloadFailures = 1
+	state.overloadUntil = clock.Now().Add(time.Minute)
+	cooldowns.mu.Lock()
+	cooldowns.storeEntryLocked("expensive:443", state)
+	cooldowns.storeEntryLocked("cheap:443", state)
+	cooldowns.mu.Unlock()
+
+	selected := group.selectCoolingDownTabletLocked(
+		endpointCache, false, nil, &sppb.RoutingHint{OperationUid: 987654321}, cooldowns,
+	)
+	if selected == nil || selected.serverAddress != "cheap:443" {
+		t.Fatalf("selected cooling-down tablet = %#v, want cheap:443", selected)
+	}
+}
+
 func TestKeyRangeCache_FillRoutingHintSkipsUnhealthyCachedTablet(t *testing.T) {
 	endpointCache := newTestEndpointCache()
 	cache := newKeyRangeCache(endpointCache)

--- a/spanner/key_range_cache_test.go
+++ b/spanner/key_range_cache_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package spanner
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"sync/atomic"
@@ -304,6 +305,7 @@ func TestKeyRangeCache_FillRoutingHintSkipsTransientFailureTablet(t *testing.T) 
 
 	endpointCache.Get(context.Background(), "server1")
 	endpointCache.Get(context.Background(), "server2")
+	manager.recordRealTraffic("server1")
 	endpointCache.setHealthy("server1", false)
 	endpointCache.setTransientFailure("server1", true)
 
@@ -724,6 +726,99 @@ func TestKeyRangeCache_GetActiveAddresses(t *testing.T) {
 	}
 	if _, ok := addresses["server-b"]; !ok {
 		t.Fatal("expected server-b to be active")
+	}
+}
+
+func TestCachedGroupUpdateIgnoresStaleGeneration(t *testing.T) {
+	group := &cachedGroup{groupUID: 5, leaderIdx: -1}
+	group.update(testRoutingGroup("2",
+		&sppb.Tablet{TabletUid: 1, Skip: true},
+		&sppb.Tablet{TabletUid: 2, ServerAddress: "survivor", Incarnation: []byte("2")},
+	))
+	group.update(testRoutingGroup("1",
+		&sppb.Tablet{TabletUid: 1, ServerAddress: "isolated-dead", Incarnation: []byte("1")},
+		&sppb.Tablet{TabletUid: 2, ServerAddress: "survivor", Incarnation: []byte("1")},
+	))
+
+	group.mu.RLock()
+	defer group.mu.RUnlock()
+	if got := group.generation; !bytes.Equal(got, []byte("2")) {
+		t.Fatalf("generation = %q, want 2", got)
+	}
+	if got := group.tablets[0].serverAddress; got != "" {
+		t.Fatalf("stale update restored tablet address %q", got)
+	}
+	if !group.tablets[0].skip {
+		t.Fatal("stale update cleared tablet skip state")
+	}
+}
+
+func TestCachedGroupUpdateEqualGenerationRetainsSkippedEmptyTablet(t *testing.T) {
+	group := &cachedGroup{groupUID: 5, leaderIdx: -1}
+	group.update(testRoutingGroup("1",
+		&sppb.Tablet{TabletUid: 1, Skip: true, Incarnation: []byte("1")},
+	))
+	group.update(testRoutingGroup("1",
+		&sppb.Tablet{TabletUid: 1, ServerAddress: "isolated-dead", Incarnation: []byte("1")},
+	))
+
+	group.mu.RLock()
+	defer group.mu.RUnlock()
+	if got := group.tablets[0].serverAddress; got != "" {
+		t.Fatalf("equal-incarnation update restored tablet address %q", got)
+	}
+	if !group.tablets[0].skip {
+		t.Fatal("equal-incarnation update cleared tablet skip state")
+	}
+}
+
+func TestCachedGroupUpdateEqualGenerationAllowsNewerIncarnationRecovery(t *testing.T) {
+	group := &cachedGroup{groupUID: 5, leaderIdx: -1}
+	group.update(testRoutingGroup("1",
+		&sppb.Tablet{TabletUid: 1, Skip: true, Incarnation: []byte("1")},
+	))
+	group.update(testRoutingGroup("1",
+		&sppb.Tablet{TabletUid: 1, ServerAddress: "recovered", Incarnation: []byte("2")},
+	))
+
+	group.mu.RLock()
+	defer group.mu.RUnlock()
+	if got := group.tablets[0].serverAddress; got != "recovered" {
+		t.Fatalf("newer-incarnation tablet address = %q, want recovered", got)
+	}
+	if group.tablets[0].skip {
+		t.Fatal("newer-incarnation update did not clear tablet skip state")
+	}
+}
+
+func TestCachedGroupUpdateEqualGenerationSkipDoesNotLaunderIncarnation(t *testing.T) {
+	group := &cachedGroup{groupUID: 5, leaderIdx: -1}
+	group.update(testRoutingGroup("1",
+		&sppb.Tablet{TabletUid: 1, ServerAddress: "healthy", Incarnation: []byte("1")},
+	))
+	group.update(testRoutingGroup("1",
+		&sppb.Tablet{TabletUid: 1, Skip: true},
+	))
+	group.update(testRoutingGroup("1",
+		&sppb.Tablet{TabletUid: 1, ServerAddress: "replayed", Incarnation: []byte("1")},
+	))
+
+	group.mu.RLock()
+	defer group.mu.RUnlock()
+	if got := group.tablets[0].serverAddress; got != "" {
+		t.Fatalf("replayed tablet address = %q, want empty", got)
+	}
+	if !group.tablets[0].skip {
+		t.Fatal("replayed update cleared tablet skip state")
+	}
+}
+
+func testRoutingGroup(generation string, tablets ...*sppb.Tablet) *sppb.Group {
+	return &sppb.Group{
+		GroupUid:    5,
+		Generation:  []byte(generation),
+		LeaderIndex: 0,
+		Tablets:     tablets,
 	}
 }
 

--- a/spanner/key_range_cache_test.go
+++ b/spanner/key_range_cache_test.go
@@ -26,6 +26,7 @@ import (
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
 )
 
@@ -206,6 +207,46 @@ func TestCachedGroupFillRoutingHint_PreferLeaderDisabledByDirectedReadOptions(t 
 	)
 	if endpoint == nil || endpoint.Address() != "replica" {
 		t.Fatalf("expected directed read to route to replica, got %#v", endpoint)
+	}
+}
+
+func TestCachedGroupFillRoutingHintReservesHintedOverloadProbe(t *testing.T) {
+	endpointCache := newTestEndpointCache()
+	endpointCache.Get(context.Background(), "replica:443")
+	group := &cachedGroup{
+		leaderIdx: 0,
+		tablets: []*cachedTablet{{
+			tabletUID:     1,
+			serverAddress: "replica:443",
+			incarnation:   []byte("1"),
+		}},
+	}
+	clock := newLifecycleTestClock(time.Unix(100, 0))
+	cooldowns := newEndpointOverloadCooldownTrackerWithOptions(
+		10*time.Second, time.Minute, 10*time.Minute, clock.Now,
+		func(int64) int64 { return 0 },
+	)
+	hintDelay := 100 * time.Millisecond
+	for i := 0; i < defaultEndpointCooldownMaxTier; i++ {
+		cooldowns.recordFailureWithStatus("replica:443", codes.ResourceExhausted, &hintDelay)
+	}
+
+	selectEndpoint := func() channelEndpoint {
+		return group.fillRoutingHintWithCooldownTracker(
+			context.Background(), endpointCache, nil, true, false,
+			&sppb.DirectedReadOptions{}, &sppb.RoutingHint{}, cooldowns,
+		)
+	}
+	clock.Advance(99 * time.Millisecond)
+	if endpoint := selectEndpoint(); endpoint != nil {
+		t.Fatalf("selected endpoint before probe delay: %v", endpoint.Address())
+	}
+	clock.Advance(time.Millisecond)
+	if endpoint := selectEndpoint(); endpoint == nil || endpoint.Address() != "replica:443" {
+		t.Fatalf("reserved probe endpoint = %v, want replica:443", endpoint)
+	}
+	if endpoint := selectEndpoint(); endpoint != nil {
+		t.Fatalf("selected duplicate reserved probe: %v", endpoint.Address())
 	}
 }
 

--- a/spanner/location_aware_client.go
+++ b/spanner/location_aware_client.go
@@ -18,12 +18,15 @@ package spanner
 
 import (
 	"context"
+	"errors"
+	"io"
 	"sync"
 	"time"
 
 	vkit "cloud.google.com/go/spanner/apiv1"
 	"cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/googleapis/gax-go/v2"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -158,8 +161,50 @@ func (c *locationAwareSpannerClient) maybeMarkEndpointCoolingDown(ep channelEndp
 		return
 	}
 	if c.endpointCooldowns != nil {
-		c.endpointCooldowns.recordFailure(ep.Address())
+		c.endpointCooldowns.recordFailureWithStatus(ep.Address(), status.Code(err), endpointCooldownRetryDelay(err))
 	}
+}
+
+func (c *locationAwareSpannerClient) recordEndpointSuccess(ep channelEndpoint) {
+	if c == nil || ep == nil || ep.Address() == c.defaultEndpointAddress || c.endpointCooldowns == nil {
+		return
+	}
+	c.endpointCooldowns.recordSuccess(ep.Address())
+}
+
+func endpointCooldownRetryDelay(err error) *time.Duration {
+	if err == nil {
+		return nil
+	}
+	var grpcStatus *status.Status
+	var spannerErr *Error
+	if errors.As(err, &spannerErr) {
+		grpcStatus = status.Convert(spannerErr.Unwrap())
+	} else {
+		grpcStatus = status.Convert(err)
+	}
+	if grpcStatus == nil {
+		return nil
+	}
+	var largest *time.Duration
+	for _, detail := range grpcStatus.Proto().GetDetails() {
+		if !detail.MessageIs(&errdetails.RetryInfo{}) {
+			continue
+		}
+		retryInfo := &errdetails.RetryInfo{}
+		if err := detail.UnmarshalTo(retryInfo); err != nil || retryInfo.GetRetryDelay() == nil || !retryInfo.GetRetryDelay().IsValid() {
+			continue
+		}
+		delay := retryInfo.GetRetryDelay().AsDuration()
+		if delay < 0 {
+			continue
+		}
+		if largest == nil || delay > *largest {
+			candidate := delay
+			largest = &candidate
+		}
+	}
+	return largest
 }
 
 func shouldCooldownEndpointOnRetry(code codes.Code) bool {
@@ -213,26 +258,6 @@ func (c *locationAwareSpannerClient) reroutedCallOptions(base []gax.CallOption, 
 		opts = append(opts, suppressResourceExhaustedRetryOption)
 	}
 	return opts
-}
-
-func (c *locationAwareSpannerClient) maybeWaitForReroute(ctx context.Context, ep channelEndpoint, lastRoutedAddress string) (bool, error) {
-	if c == nil || lastRoutedAddress == "" {
-		return false, nil
-	}
-	if c.endpointCooldowns == nil {
-		return false, nil
-	}
-	if ep != nil && (ep.Address() == "" || ep.Address() != lastRoutedAddress) {
-		return false, nil
-	}
-	wait := c.endpointCooldowns.remainingCooldown(lastRoutedAddress)
-	if wait <= 0 {
-		return false, nil
-	}
-	if err := gax.Sleep(ctx, wait); err != nil {
-		return true, err
-	}
-	return true, nil
 }
 
 func (c *locationAwareSpannerClient) observeExecuteSQLResponse(req *spannerpb.ExecuteSqlRequest, resp *spannerpb.ResultSet, ep channelEndpoint) {
@@ -367,15 +392,9 @@ func (c *locationAwareSpannerClient) StreamingRead(ctx context.Context, req *spa
 	logicalRequestKey := logicalRequestKeyFromCallOptions(opts)
 	cooldowns := c.endpointCooldowns
 	preferLeader := preferLeaderFromSelector(req.GetTransaction())
-	lastRoutedAddress := ""
 	for attempt := uint32(1); ; attempt++ {
 		ep := c.router.prepareReadRequestWithCooldownTracker(ctx, req, cooldowns)
 		operationUID := req.GetRoutingHint().GetOperationUid()
-		if waited, err := c.maybeWaitForReroute(ctx, ep, lastRoutedAddress); err != nil {
-			return nil, err
-		} else if waited {
-			continue
-		}
 		client := c.clientForEndpoint(ep)
 		usedDefaultEndpoint := client == c.defaultClient
 		markRetryableError := c.rerouteErrorMarker(ep, operationUID, preferLeader)
@@ -397,6 +416,11 @@ func (c *locationAwareSpannerClient) StreamingRead(ctx context.Context, req *spa
 				func() { c.recordEndpointLatency(ep, operationUID, preferLeader, startedAt) },
 				markRetryableError,
 				func() {
+					if !usedDefaultEndpoint {
+						c.recordEndpointSuccess(ep)
+					}
+				},
+				func() {
 					if ep != nil {
 						ep.DecrementActiveRequests()
 					}
@@ -410,7 +434,6 @@ func (c *locationAwareSpannerClient) StreamingRead(ctx context.Context, req *spa
 		if !shouldCooldownEndpointOnRetry(status.Code(err)) || ep == nil || usedDefaultEndpoint {
 			return nil, err
 		}
-		lastRoutedAddress = ep.Address()
 	}
 }
 
@@ -418,15 +441,9 @@ func (c *locationAwareSpannerClient) Read(ctx context.Context, req *spannerpb.Re
 	logicalRequestKey := logicalRequestKeyFromCallOptions(opts)
 	cooldowns := c.endpointCooldowns
 	preferLeader := preferLeaderFromSelector(req.GetTransaction())
-	lastRoutedAddress := ""
 	for attempt := uint32(1); ; attempt++ {
 		ep := c.router.prepareReadRequestWithCooldownTracker(ctx, req, cooldowns)
 		operationUID := req.GetRoutingHint().GetOperationUid()
-		if waited, err := c.maybeWaitForReroute(ctx, ep, lastRoutedAddress); err != nil {
-			return nil, err
-		} else if waited {
-			continue
-		}
 		client := c.clientForEndpoint(ep)
 		usedDefaultEndpoint := client == c.defaultClient
 		markRetryableError := c.rerouteErrorMarker(ep, operationUID, preferLeader)
@@ -440,6 +457,9 @@ func (c *locationAwareSpannerClient) Read(ctx context.Context, req *spannerpb.Re
 			ep.DecrementActiveRequests()
 		}
 		if err == nil {
+			if !usedDefaultEndpoint {
+				c.recordEndpointSuccess(ep)
+			}
 			c.recordEndpointLatency(ep, operationUID, preferLeader, startedAt)
 			c.observeReadResponse(req, resp, ep)
 			return resp, nil
@@ -448,7 +468,6 @@ func (c *locationAwareSpannerClient) Read(ctx context.Context, req *spannerpb.Re
 		if !shouldCooldownEndpointOnRetry(status.Code(err)) || ep == nil || usedDefaultEndpoint {
 			return nil, err
 		}
-		lastRoutedAddress = ep.Address()
 	}
 }
 
@@ -456,15 +475,9 @@ func (c *locationAwareSpannerClient) ExecuteStreamingSql(ctx context.Context, re
 	logicalRequestKey := logicalRequestKeyFromCallOptions(opts)
 	cooldowns := c.endpointCooldowns
 	preferLeader := preferLeaderFromSelector(req.GetTransaction())
-	lastRoutedAddress := ""
 	for attempt := uint32(1); ; attempt++ {
 		ep := c.router.prepareExecuteSQLRequestWithCooldownTracker(ctx, req, cooldowns)
 		operationUID := req.GetRoutingHint().GetOperationUid()
-		if waited, err := c.maybeWaitForReroute(ctx, ep, lastRoutedAddress); err != nil {
-			return nil, err
-		} else if waited {
-			continue
-		}
 		client := c.clientForEndpoint(ep)
 		usedDefaultEndpoint := client == c.defaultClient
 		markRetryableError := c.rerouteErrorMarker(ep, operationUID, preferLeader)
@@ -486,6 +499,11 @@ func (c *locationAwareSpannerClient) ExecuteStreamingSql(ctx context.Context, re
 				func() { c.recordEndpointLatency(ep, operationUID, preferLeader, startedAt) },
 				markRetryableError,
 				func() {
+					if !usedDefaultEndpoint {
+						c.recordEndpointSuccess(ep)
+					}
+				},
+				func() {
 					if ep != nil {
 						ep.DecrementActiveRequests()
 					}
@@ -499,7 +517,6 @@ func (c *locationAwareSpannerClient) ExecuteStreamingSql(ctx context.Context, re
 		if !shouldCooldownEndpointOnRetry(status.Code(err)) || ep == nil || usedDefaultEndpoint {
 			return nil, err
 		}
-		lastRoutedAddress = ep.Address()
 	}
 }
 
@@ -507,15 +524,9 @@ func (c *locationAwareSpannerClient) ExecuteSql(ctx context.Context, req *spanne
 	logicalRequestKey := logicalRequestKeyFromCallOptions(opts)
 	cooldowns := c.endpointCooldowns
 	preferLeader := preferLeaderFromSelector(req.GetTransaction())
-	lastRoutedAddress := ""
 	for attempt := uint32(1); ; attempt++ {
 		ep := c.router.prepareExecuteSQLRequestWithCooldownTracker(ctx, req, cooldowns)
 		operationUID := req.GetRoutingHint().GetOperationUid()
-		if waited, err := c.maybeWaitForReroute(ctx, ep, lastRoutedAddress); err != nil {
-			return nil, err
-		} else if waited {
-			continue
-		}
 		client := c.clientForEndpoint(ep)
 		usedDefaultEndpoint := client == c.defaultClient
 		markRetryableError := c.rerouteErrorMarker(ep, operationUID, preferLeader)
@@ -529,6 +540,9 @@ func (c *locationAwareSpannerClient) ExecuteSql(ctx context.Context, req *spanne
 			ep.DecrementActiveRequests()
 		}
 		if err == nil {
+			if !usedDefaultEndpoint {
+				c.recordEndpointSuccess(ep)
+			}
 			c.recordEndpointLatency(ep, operationUID, preferLeader, startedAt)
 			c.observeExecuteSQLResponse(req, resp, ep)
 			return resp, nil
@@ -537,7 +551,6 @@ func (c *locationAwareSpannerClient) ExecuteSql(ctx context.Context, req *spanne
 		if !shouldCooldownEndpointOnRetry(status.Code(err)) || ep == nil || usedDefaultEndpoint {
 			return nil, err
 		}
-		lastRoutedAddress = ep.Address()
 	}
 }
 
@@ -546,14 +559,8 @@ func (c *locationAwareSpannerClient) BeginTransaction(ctx context.Context, req *
 	cooldowns := c.endpointCooldowns
 	preferLeader := preferLeaderFromTransactionOptions(req.GetOptions())
 	operationUID := req.GetRoutingHint().GetOperationUid()
-	lastRoutedAddress := ""
 	for attempt := uint32(1); ; attempt++ {
 		ep := c.router.prepareBeginTransactionRequestWithCooldownTracker(ctx, req, cooldowns)
-		if waited, err := c.maybeWaitForReroute(ctx, ep, lastRoutedAddress); err != nil {
-			return nil, err
-		} else if waited {
-			continue
-		}
 		client := c.clientForEndpoint(ep)
 		usedDefaultEndpoint := client == c.defaultClient
 		markRetryableError := c.rerouteErrorMarker(ep, operationUID, preferLeader)
@@ -567,6 +574,9 @@ func (c *locationAwareSpannerClient) BeginTransaction(ctx context.Context, req *
 			ep.DecrementActiveRequests()
 		}
 		if err == nil {
+			if !usedDefaultEndpoint {
+				c.recordEndpointSuccess(ep)
+			}
 			c.recordEndpointLatency(ep, operationUID, preferLeader, startedAt)
 			c.observeBeginTransactionResponse(req, resp, ep)
 			return resp, nil
@@ -575,7 +585,6 @@ func (c *locationAwareSpannerClient) BeginTransaction(ctx context.Context, req *
 		if !shouldCooldownEndpointOnRetry(status.Code(err)) || ep == nil || usedDefaultEndpoint {
 			return nil, err
 		}
-		lastRoutedAddress = ep.Address()
 	}
 }
 
@@ -591,8 +600,12 @@ func (c *locationAwareSpannerClient) Commit(ctx context.Context, req *spannerpb.
 	}
 	markRetryableError := c.rerouteErrorMarker(ep, 0, false)
 	client := c.clientForEndpoint(ep)
+	usedDefaultEndpoint := client == c.defaultClient
 	resp, err := client.Commit(ctx, req, appendResourceExhaustedMarkerOptions(opts, markRetryableError, true)...)
 	markRetryableError(err)
+	if err == nil && !usedDefaultEndpoint {
+		c.recordEndpointSuccess(ep)
+	}
 	c.router.observeCommitResponse(resp)
 	c.router.clearTransactionAffinity(string(req.GetTransactionId()))
 	return resp, err
@@ -602,8 +615,12 @@ func (c *locationAwareSpannerClient) Rollback(ctx context.Context, req *spannerp
 	ep := c.affinityEndpoint(req.GetTransactionId(), c.endpointCooldowns)
 	markRetryableError := c.rerouteErrorMarker(ep, 0, false)
 	client := c.clientForEndpoint(ep)
+	usedDefaultEndpoint := client == c.defaultClient
 	err := client.Rollback(ctx, req, appendResourceExhaustedMarkerOptions(opts, markRetryableError, true)...)
 	markRetryableError(err)
+	if err == nil && !usedDefaultEndpoint {
+		c.recordEndpointSuccess(ep)
+	}
 	c.router.clearTransactionAffinity(string(req.GetTransactionId()))
 	return err
 }
@@ -625,6 +642,7 @@ type affinityTrackingStream struct {
 	inner              streamingClient
 	onFirstResponse    func()
 	onError            func(error)
+	onSuccess          func()
 	onDone             func()
 }
 
@@ -652,6 +670,7 @@ func newAffinityTrackingStream(
 	trackAffinity bool,
 	onFirstResponse func(),
 	onError func(error),
+	onSuccess func(),
 	onDone func(),
 ) *affinityTrackingStream {
 	return &affinityTrackingStream{
@@ -664,6 +683,7 @@ func newAffinityTrackingStream(
 		inner:              inner,
 		onFirstResponse:    onFirstResponse,
 		onError:            onError,
+		onSuccess:          onSuccess,
 		onDone:             onDone,
 	}
 }
@@ -672,6 +692,12 @@ func (s *affinityTrackingStream) Recv() (*spannerpb.PartialResultSet, error) {
 	prs, err := s.inner.Recv()
 	if err != nil {
 		s.finish()
+		if errors.Is(err, io.EOF) {
+			if s.onSuccess != nil {
+				s.onSuccess()
+			}
+			return nil, err
+		}
 		s.errorOnce.Do(func() {
 			if s.onError != nil {
 				s.onError(err)

--- a/spanner/location_aware_client.go
+++ b/spanner/location_aware_client.go
@@ -166,7 +166,7 @@ func (c *locationAwareSpannerClient) maybeMarkEndpointCoolingDown(ep channelEndp
 }
 
 func (c *locationAwareSpannerClient) recordEndpointSuccess(ep channelEndpoint) {
-	if c == nil || ep == nil || ep.Address() == c.defaultEndpointAddress || c.endpointCooldowns == nil {
+	if c.endpointCooldowns == nil || ep.Address() == c.defaultEndpointAddress {
 		return
 	}
 	c.endpointCooldowns.recordSuccess(ep.Address())
@@ -179,6 +179,8 @@ func endpointCooldownRetryDelay(err error) *time.Duration {
 	var grpcStatus *status.Status
 	var spannerErr *Error
 	if errors.As(err, &spannerErr) {
+		// Error.GRPCStatus rebuilds the status from its code and description,
+		// dropping rich status details such as RetryInfo. Convert its cause.
 		grpcStatus = status.Convert(spannerErr.Unwrap())
 	} else {
 		grpcStatus = status.Convert(err)

--- a/spanner/location_aware_client_test.go
+++ b/spanner/location_aware_client_test.go
@@ -19,6 +19,7 @@ package spanner
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -405,6 +406,24 @@ func TestEndpointCooldownRetryDelayUsesLargestValidRichStatusDetail(t *testing.T
 	delay := endpointCooldownRetryDelay(err)
 	if delay == nil || *delay != 200*time.Millisecond {
 		t.Fatalf("retry delay = %v, want 200ms", delay)
+	}
+}
+
+func TestEndpointCooldownRetryDelayUnwrapsSpannerErrorToPreserveRichDetails(t *testing.T) {
+	retryInfo := &errdetails.RetryInfo{RetryDelay: durationpb.New(250 * time.Millisecond)}
+	richStatus, err := status.New(codes.ResourceExhausted, "busy").WithDetails(retryInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spannerErr := &Error{Code: codes.ResourceExhausted, Desc: "busy", err: richStatus.Err()}
+	wrapped := fmt.Errorf("outer: %w", spannerErr)
+	if got := len(status.Convert(wrapped).Proto().GetDetails()); got != 0 {
+		t.Fatalf("direct status conversion retained %d details; simplify endpointCooldownRetryDelay", got)
+	}
+
+	delay := endpointCooldownRetryDelay(wrapped)
+	if delay == nil || *delay != 250*time.Millisecond {
+		t.Fatalf("retry delay = %v, want 250ms", delay)
 	}
 }
 

--- a/spanner/location_aware_client_test.go
+++ b/spanner/location_aware_client_test.go
@@ -735,6 +735,7 @@ func TestLocationAwareSpannerClient_AffinityClientRequestsLifecycleRecreationFor
 		time.Now,
 	)
 	defer router.lifecycleManager.shutdown()
+	router.lifecycleManager.updateActiveAddresses(map[string]struct{}{"replica-2:443": {}})
 
 	unhealthyEndpoint := &mockEndpoint{address: "replica-2:443", healthy: false}
 	router.setTransactionAffinity("tx-unhealthy", unhealthyEndpoint)

--- a/spanner/location_aware_client_test.go
+++ b/spanner/location_aware_client_test.go
@@ -28,11 +28,15 @@ import (
 	vkit "cloud.google.com/go/spanner/apiv1"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/googleapis/gax-go/v2"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
 	structpb "google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -376,6 +380,101 @@ func TestLocationAwareSpannerClient_UsesCacheDefaultChannelForAffinityFallback(t
 	}
 	if lac.defaultEndpointAddress != "spanner.googleapis.com:443" {
 		t.Fatalf("defaultEndpointAddress = %q, want %q", lac.defaultEndpointAddress, "spanner.googleapis.com:443")
+	}
+}
+
+func TestEndpointCooldownRetryDelayUsesLargestValidRichStatusDetail(t *testing.T) {
+	malformed := &anypb.Any{TypeUrl: "type.googleapis.com/google.rpc.RetryInfo", Value: []byte{0xff}}
+	short, err := anypb.New(&errdetails.RetryInfo{RetryDelay: durationpb.New(100 * time.Millisecond)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	long, err := anypb.New(&errdetails.RetryInfo{RetryDelay: durationpb.New(200 * time.Millisecond)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	negative, err := anypb.New(&errdetails.RetryInfo{RetryDelay: durationpb.New(-time.Second)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = status.FromProto(&statuspb.Status{
+		Code:    int32(codes.ResourceExhausted),
+		Message: "busy",
+		Details: []*anypb.Any{malformed, short, negative, long},
+	}).Err()
+	delay := endpointCooldownRetryDelay(err)
+	if delay == nil || *delay != 200*time.Millisecond {
+		t.Fatalf("retry delay = %v, want 200ms", delay)
+	}
+}
+
+func TestLocationAwareSpannerClientCooldownCallSiteClassifiesFailureAndRepairsSuccess(t *testing.T) {
+	clock := newLifecycleTestClock(time.Unix(100, 0))
+	tracker := newEndpointOverloadCooldownTrackerWithOptions(
+		10*time.Second, time.Minute, 10*time.Minute, clock.Now,
+		func(int64) int64 { return 0 },
+	)
+	lac := &locationAwareSpannerClient{
+		defaultEndpointAddress: "default:443",
+		endpointCooldowns:      tracker,
+	}
+	ep := &mockEndpoint{address: "replica:443", healthy: true}
+	retryInfo := &errdetails.RetryInfo{RetryDelay: durationpb.New(100 * time.Millisecond)}
+	grpcStatus, err := status.New(codes.ResourceExhausted, "busy").WithDetails(retryInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lac.maybeMarkEndpointCoolingDown(ep, grpcStatus.Err())
+	state := tracker.entries[ep.Address()]
+	if state.overloadFailures != 1 {
+		t.Fatalf("overload state = %+v", state)
+	}
+	if got := state.overloadUntil.Sub(clock.Now()); got != 100*time.Millisecond {
+		t.Fatalf("overload state = %+v", state)
+	}
+	lac.maybeMarkEndpointCoolingDown(ep, status.Error(codes.Unavailable, "down"))
+	if got := tracker.entries[ep.Address()].unavailableFailures; got != 1 {
+		t.Fatalf("unavailableFailures = %d, want 1", got)
+	}
+	for i := 0; i < defaultEndpointCooldownSuccessesToRepair; i++ {
+		lac.recordEndpointSuccess(ep)
+	}
+	state = tracker.entries[ep.Address()]
+	if state.overloadFailures != 0 || state.unavailableFailures != 0 {
+		t.Fatalf("success did not repair lanes: %+v", state)
+	}
+}
+
+func TestLocationAwareSpannerClientSuccessfulRoutedCallAdvancesCooldownRepair(t *testing.T) {
+	defaultClient := &mockSpannerClient{executeSQLResp: &sppb.ResultSet{}}
+	endpointClient := &mockSpannerClient{executeSQLResp: &sppb.ResultSet{}}
+	epCache := newMockEndpointCache()
+	epCache.defaultEndpoint = &passthroughChannelEndpoint{address: "default:443"}
+	epCache.addEndpoint("replica:443", endpointClient)
+	router := newLocationRouter(epCache)
+	update := createRangeCacheUpdateForHint(&sppb.RoutingHint{Key: []byte("b")})
+	update.Group[0].Tablets[0].ServerAddress = "replica:443"
+	router.observeResultSet(&sppb.ResultSet{CacheUpdate: update})
+	waitForAsyncRoutingUpdate(t, func() bool {
+		return router.prepareExecuteSQLRequest(context.Background(), executeSQLWithKeyAndSelector("b", nil)) != nil
+	})
+
+	clock := newLifecycleTestClock(time.Unix(100, 0))
+	tracker := newEndpointOverloadCooldownTrackerWithOptions(
+		10*time.Second, time.Minute, 10*time.Minute, clock.Now,
+		func(int64) int64 { return 0 },
+	)
+	hint := 100 * time.Millisecond
+	tracker.recordFailureWithStatus("replica:443", codes.ResourceExhausted, &hint)
+	clock.Advance(hint)
+	lac := newLocationAwareSpannerClient(defaultClient, router, epCache)
+	lac.endpointCooldowns = tracker
+	if _, err := lac.ExecuteSql(context.Background(), executeSQLWithKeyAndSelector("b", nil)); err != nil {
+		t.Fatal(err)
+	}
+	state := tracker.entries["replica:443"]
+	if state.successesTowardRepair != 1 {
+		t.Fatalf("successesTowardRepair = %d, want 1", state.successesTowardRepair)
 	}
 }
 


### PR DESCRIPTION
Ignore whole group updates from older generations. At equal generation, retain unavailable tablet freshness baselines until a newer incarnation permits recovery.

Refuse endpoint recreation for addresses absent from active finder membership, and serialize endpoint publication reconciliation with active-address removal.

Related Java PR https://github.com/googleapis/google-cloud-java/pull/13803