### PR TITLE
fix(internal/kokoro): skip testing modules with no Go source files

### DIFF
--- a/internal/kokoro/continuous.sh
+++ b/internal/kokoro/continuous.sh
@@ -123,6 +123,10 @@ runDirectoryTests() {
     # internal tools only expected to work with latest go version
     return
   fi
+  if [[ -z "$(find . -name '*.go' -print -quit 2>/dev/null)" ]]; then
+    echo "No Go files found in $PWD, skipping tests."
+    return
+  fi
   if [[ $PWD == *"/internal/generated"* ]]; then
     # always tidy generated snippets
     go mod tidy

--- a/internal/kokoro/presubmit.sh
+++ b/internal/kokoro/presubmit.sh
@@ -63,6 +63,10 @@ runPresubmitTests() {
     # internal tools only expected to work with latest go version
     return
   fi
+  if [[ -z "$(find . -name '*.go' -print -quit 2>/dev/null)" ]]; then
+    echo "No Go files found in $PWD, skipping tests."
+    return
+  fi
 
   go_test_args=("-race")
   if [ -z ${RUN_INTEGRATION_TESTS} ]; then


### PR DESCRIPTION
When gotestsum runs in directories containing a go.mod file but no Go source packages (such as agentplatform/tools), go test fails with "matched no packages" and exits with status 1, causing Kokoro builds to fail.

Add a dynamic find check in continuous.sh (runDirectoryTests) and presubmit.sh (runPresubmitTests) to safely skip test execution on directories without any .go source files.