### PR TITLE
chore(go): inject server.address, add exemplar support, standardize metric names

### DIFF
--- a/storage/grpc_reader_multi_range.go
+++ b/storage/grpc_reader_multi_range.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"log"
 	"sync"
+	"sync/atomic"
 
 	"cloud.google.com/go/storage/internal/apiv2/storagepb"
 	"google.golang.org/grpc"
@@ -58,6 +59,7 @@ type internalMultiRangeDownloader interface {
 	getHandle() []byte
 	getPermanentError() error
 	getSpanCtx() context.Context
+	getBytesRead() int64
 }
 
 // streamPickerStrategy is an interface which each stream picker must implement.
@@ -369,6 +371,7 @@ type multiRangeDownloaderManager struct {
 	wg           sync.WaitGroup // syncs completion of event loop.
 	cmds         chan mrdCommand
 	sessionResps chan mrdSessionResult
+	bytesRead    int64
 
 	// State
 	mu                 sync.Mutex
@@ -516,6 +519,10 @@ func (m *multiRangeDownloaderManager) getPermanentError() error {
 
 func (m *multiRangeDownloaderManager) getSpanCtx() context.Context {
 	return m.spanCtx
+}
+
+func (m *multiRangeDownloaderManager) getBytesRead() int64 {
+	return atomic.LoadInt64(&m.bytesRead)
 }
 
 func (m *multiRangeDownloaderManager) runCallback(origOffset, numBytes int64, err error, cb func(int64, int64, error)) {
@@ -1065,6 +1072,7 @@ func (m *multiRangeDownloaderManager) processDataRanges(result mrdSessionResult,
 
 		written, _, err := result.decoder.writeToAndUpdateCRC(req.output, readID, nil)
 		req.bytesWritten += written
+		atomic.AddInt64(&m.bytesRead, written)
 		mrdStream.updateCapacity(m, 0, -written)
 		if err != nil {
 			m.failRange(mrdStream, req, err)

--- a/storage/integration_test.go
+++ b/storage/integration_test.go
@@ -1357,7 +1357,7 @@ func TestIntegration_OtelMetricsEnablement(t *testing.T) {
 			}
 			expectedSums := []string{
 				"gcp.storage.client.operations",
-				"gcp.storage.client.active_requests",
+				"gcp.storage.client.request.active",
 			}
 			expectedNetworkMetrics := []string{
 				"gcp.storage.client.network.tcp.connect.duration",

--- a/storage/metrics.go
+++ b/storage/metrics.go
@@ -645,7 +645,7 @@ func (cm *clientMetrics) recordRPC(ctx context.Context, method, target string, d
 	logicalMethod := methodName
 	if state != nil {
 		logicalMethod = state.method
-		state.target = target
+		state.setTarget(target)
 	}
 	attemptAttrs := make([]attribute.KeyValue, 0, 5)
 	attemptAttrs = append(attemptAttrs,
@@ -848,7 +848,7 @@ func (rt *metricsRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 	if rt.metrics != nil {
 		state := metricsStateFromContext(req.Context())
 		if state != nil {
-			state.target = req.URL.Host
+			state.setTarget(req.URL.Host)
 		}
 		// Record attempt.
 		attemptAttrs := make([]attribute.KeyValue, 0, 4)
@@ -1196,12 +1196,31 @@ func injectAPIMethod(ctx context.Context, attrs []attribute.KeyValue) []attribut
 }
 
 type metricsState struct {
+	mu        sync.Mutex
 	method    string
 	startTime time.Time
 	metrics   *clientMetrics
 	isHTTP    bool
 	target    string
 	record    func(error)
+}
+
+func (s *metricsState) setTarget(t string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.target = t
+}
+
+func (s *metricsState) getTarget() string {
+	if s == nil {
+		return ""
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.target
 }
 
 func contextWithMetricsState(ctx context.Context, state *metricsState) context.Context {
@@ -1244,7 +1263,7 @@ func (cm *clientMetrics) startOperation(ctx context.Context, method string, isHT
 
 			attrs := []attribute.KeyValue{
 				attribute.String("rpc.method", method),
-				attribute.String("server.address", stripPort(state.target)),
+				attribute.String("server.address", stripPort(state.getTarget())),
 				attribute.String("error.type", errorType),
 			}
 			opts := metric.WithAttributes(injectAPIMethod(ctx, attrs)...)

--- a/storage/metrics.go
+++ b/storage/metrics.go
@@ -39,6 +39,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/exemplar"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
 
@@ -203,6 +204,7 @@ func initMetrics(ctx context.Context, projectID string, config *storageConfig) (
 		provider = sdkmetric.NewMeterProvider(
 			sdkmetric.WithReader(reader),
 			sdkmetric.WithResource(res),
+			sdkmetric.WithExemplarFilter(exemplar.TraceBasedFilter),
 			sdkmetric.WithView(
 				sdkmetric.NewView(
 					sdkmetric.Instrument{Name: "rpc.client.call.duration", Kind: sdkmetric.InstrumentKindHistogram},
@@ -643,12 +645,14 @@ func (cm *clientMetrics) recordRPC(ctx context.Context, method, target string, d
 	logicalMethod := methodName
 	if state != nil {
 		logicalMethod = state.method
+		state.target = target
 	}
 	attemptAttrs := make([]attribute.KeyValue, 0, 5)
 	attemptAttrs = append(attemptAttrs,
 		attribute.String("rpc.system.name", "grpc"),
 		attribute.String("rpc.method", logicalMethod),
 		attribute.Int64("rpc.grpc.status_code", statusCode),
+		attribute.String("server.address", stripPort(target)),
 		attribute.String("error.type", errorType),
 	)
 	cm.attempts.Add(ctx, 1, metric.WithAttributes(injectAPIMethod(ctx, attemptAttrs)...))
@@ -659,6 +663,7 @@ func (cm *clientMetrics) recordRPC(ctx context.Context, method, target string, d
 		errorAttrs = append(errorAttrs,
 			attribute.String("rpc.system.name", "grpc"),
 			attribute.String("rpc.method", logicalMethod),
+			attribute.String("server.address", stripPort(target)),
 			attribute.String("error.type", errorType),
 		)
 		cm.errors.Add(ctx, 1, metric.WithAttributes(injectAPIMethod(ctx, errorAttrs)...))
@@ -667,7 +672,7 @@ func (cm *clientMetrics) recordRPC(ctx context.Context, method, target string, d
 	// For unary calls, record TTFB equal to the total attempt latency.
 	isStreaming := methodName == "ReadObject" || methodName == "WriteObject" || methodName == "BidiReadObject" || methodName == "BidiWriteObject"
 	if !isStreaming {
-		ttfbAttrs := []attribute.KeyValue{attribute.String("rpc.method", logicalMethod)}
+		ttfbAttrs := []attribute.KeyValue{attribute.String("rpc.method", logicalMethod), attribute.String("server.address", stripPort(target))}
 		cm.ttfb.Record(ctx, duration, metric.WithAttributes(injectAPIMethod(ctx, ttfbAttrs)...))
 	}
 }
@@ -841,12 +846,17 @@ func (rt *metricsRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 	errorType := computeErrorType(err, true, statusCode)
 
 	if rt.metrics != nil {
+		state := metricsStateFromContext(req.Context())
+		if state != nil {
+			state.target = req.URL.Host
+		}
 		// Record attempt.
 		attemptAttrs := make([]attribute.KeyValue, 0, 4)
 		attemptAttrs = append(attemptAttrs,
 			attribute.String("rpc.system.name", "http"),
 			attribute.String("rpc.method", logicalMethod),
 			attribute.Int64("http.response.status_code", statusCode),
+			attribute.String("server.address", stripPort(req.URL.Host)),
 			attribute.String("error.type", errorType),
 		)
 		rt.metrics.attempts.Add(req.Context(), 1, metric.WithAttributes(injectAPIMethod(req.Context(), attemptAttrs)...))
@@ -857,6 +867,7 @@ func (rt *metricsRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 			errorAttrs = append(errorAttrs,
 				attribute.String("rpc.system.name", "http"),
 				attribute.String("rpc.method", logicalMethod),
+				attribute.String("server.address", stripPort(req.URL.Host)),
 				attribute.String("error.type", errorType),
 			)
 			rt.metrics.errors.Add(req.Context(), 1, metric.WithAttributes(injectAPIMethod(req.Context(), errorAttrs)...))
@@ -887,7 +898,7 @@ func (rt *metricsRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 		isResumableInit := req.Method == "POST" && strings.Contains(req.URL.Path, "/upload/") && req.URL.Query().Get("uploadType") == "resumable"
 		if !isDownload || isResumableInit {
 			duration := time.Since(startTime).Seconds()
-			ttfbAttrs := []attribute.KeyValue{attribute.String("rpc.method", logicalMethod)}
+			ttfbAttrs := []attribute.KeyValue{attribute.String("rpc.method", logicalMethod), attribute.String("server.address", stripPort(req.URL.Host))}
 			rt.metrics.ttfb.Record(req.Context(), duration, metric.WithAttributes(injectAPIMethod(req.Context(), ttfbAttrs)...))
 		}
 	}
@@ -1189,6 +1200,7 @@ type metricsState struct {
 	startTime time.Time
 	metrics   *clientMetrics
 	isHTTP    bool
+	target    string
 	record    func(error)
 }
 
@@ -1232,6 +1244,7 @@ func (cm *clientMetrics) startOperation(ctx context.Context, method string, isHT
 
 			attrs := []attribute.KeyValue{
 				attribute.String("rpc.method", method),
+				attribute.String("server.address", stripPort(state.target)),
 				attribute.String("error.type", errorType),
 			}
 			opts := metric.WithAttributes(injectAPIMethod(ctx, attrs)...)

--- a/storage/metrics.go
+++ b/storage/metrics.go
@@ -352,7 +352,7 @@ func initMetrics(ctx context.Context, projectID string, config *storageConfig) (
 
 	if isOtelDebugMetricsEnabled(config) {
 		networkBytesSent, err = meter.Int64Counter(
-			"gcp.storage.client.network.egress_bytes_count",
+			"gcp.storage.client.network.bytes.sent",
 			metric.WithDescription("Total physical bytes sent over the wire socket (gRPC only)."),
 			metric.WithUnit("By"),
 		)
@@ -361,7 +361,7 @@ func initMetrics(ctx context.Context, projectID string, config *storageConfig) (
 		}
 
 		networkBytesReceived, err = meter.Int64Counter(
-			"gcp.storage.client.network.ingress_bytes_count",
+			"gcp.storage.client.network.bytes.received",
 			metric.WithDescription("Total physical bytes received over the wire socket (gRPC only)."),
 			metric.WithUnit("By"),
 		)
@@ -387,7 +387,7 @@ func initMetrics(ctx context.Context, projectID string, config *storageConfig) (
 			return nil, nil, err
 		}
 		activeRequests, err = meter.Int64UpDownCounter(
-			"gcp.storage.client.active_requests",
+			"gcp.storage.client.request.active",
 			metric.WithDescription("Number of active GCS client requests"),
 			metric.WithUnit("1"),
 		)

--- a/storage/metrics.go
+++ b/storage/metrics.go
@@ -1196,12 +1196,11 @@ func injectAPIMethod(ctx context.Context, attrs []attribute.KeyValue) []attribut
 }
 
 type metricsState struct {
-	mu        sync.Mutex
+	target    atomic.Pointer[string]
 	method    string
 	startTime time.Time
 	metrics   *clientMetrics
 	isHTTP    bool
-	target    string
 	record    func(error)
 }
 
@@ -1209,18 +1208,17 @@ func (s *metricsState) setTarget(t string) {
 	if s == nil {
 		return
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.target = t
+	s.target.Store(&t)
 }
 
 func (s *metricsState) getTarget() string {
 	if s == nil {
 		return ""
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.target
+	if p := s.target.Load(); p != nil {
+		return *p
+	}
+	return ""
 }
 
 func contextWithMetricsState(ctx context.Context, state *metricsState) context.Context {

--- a/storage/metrics.go
+++ b/storage/metrics.go
@@ -672,7 +672,7 @@ func (cm *clientMetrics) recordRPC(ctx context.Context, method, target string, d
 	// For unary calls, record TTFB equal to the total attempt latency.
 	isStreaming := methodName == "ReadObject" || methodName == "WriteObject" || methodName == "BidiReadObject" || methodName == "BidiWriteObject"
 	if !isStreaming {
-		ttfbAttrs := []attribute.KeyValue{attribute.String("rpc.method", logicalMethod), attribute.String("server.address", stripPort(target))}
+		ttfbAttrs := []attribute.KeyValue{attribute.String("rpc.system.name", "grpc"), attribute.String("rpc.method", logicalMethod), attribute.String("server.address", stripPort(target))}
 		cm.ttfb.Record(ctx, duration, metric.WithAttributes(injectAPIMethod(ctx, ttfbAttrs)...))
 	}
 }
@@ -898,7 +898,7 @@ func (rt *metricsRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 		isResumableInit := req.Method == "POST" && strings.Contains(req.URL.Path, "/upload/") && req.URL.Query().Get("uploadType") == "resumable"
 		if !isDownload || isResumableInit {
 			duration := time.Since(startTime).Seconds()
-			ttfbAttrs := []attribute.KeyValue{attribute.String("rpc.method", logicalMethod), attribute.String("server.address", stripPort(req.URL.Host))}
+			ttfbAttrs := []attribute.KeyValue{attribute.String("rpc.system.name", "http"), attribute.String("rpc.method", logicalMethod), attribute.String("server.address", stripPort(req.URL.Host))}
 			rt.metrics.ttfb.Record(req.Context(), duration, metric.WithAttributes(injectAPIMethod(req.Context(), ttfbAttrs)...))
 		}
 	}
@@ -949,7 +949,7 @@ func (w *wrappedResponseBody) Read(p []byte) (n int, err error) {
 		if state != nil {
 			logicalMethod = state.method
 		}
-		w.metrics.ttfb.Record(w.req.Context(), duration, metric.WithAttributes(attribute.String("rpc.method", logicalMethod)))
+		w.metrics.ttfb.Record(w.req.Context(), duration, metric.WithAttributes(attribute.String("rpc.system.name", "http"), attribute.String("rpc.method", logicalMethod), attribute.String("server.address", stripPort(w.req.URL.Host))))
 	}
 	n, err = w.ReadCloser.Read(p)
 	if err != nil {
@@ -1180,7 +1180,7 @@ func (w *wrappedClientStream) recordTTFB(m interface{}) {
 		if state != nil {
 			logicalMethod = state.method
 		}
-		w.metrics.ttfb.Record(w.ctx, duration, metric.WithAttributes(attribute.String("rpc.method", logicalMethod)))
+		w.metrics.ttfb.Record(w.ctx, duration, metric.WithAttributes(attribute.String("rpc.system.name", "grpc"), attribute.String("rpc.method", logicalMethod), attribute.String("server.address", stripPort(w.target))))
 	}
 }
 
@@ -1209,6 +1209,16 @@ func (s *metricsState) setTarget(t string) {
 		return
 	}
 	s.target.Store(&t)
+}
+
+func (s *metricsState) getSystemName() string {
+	if s == nil {
+		return ""
+	}
+	if s.isHTTP {
+		return "http"
+	}
+	return "grpc"
 }
 
 func (s *metricsState) getTarget() string {
@@ -1260,6 +1270,7 @@ func (cm *clientMetrics) startOperation(ctx context.Context, method string, isHT
 			errorType := computeErrorType(err, isHTTP, 0)
 
 			attrs := []attribute.KeyValue{
+				attribute.String("rpc.system.name", state.getSystemName()),
 				attribute.String("rpc.method", method),
 				attribute.String("server.address", stripPort(state.getTarget())),
 				attribute.String("error.type", errorType),

--- a/storage/metrics_test.go
+++ b/storage/metrics_test.go
@@ -899,14 +899,14 @@ func TestGRPCMetricsStatsHandler(t *testing.T) {
 	var ingress, egress int64
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {
-			if m.Name == "gcp.storage.client.network.ingress_bytes_count" {
+			if m.Name == "gcp.storage.client.network.bytes.received" {
 				sum := m.Data.(metricdata.Sum[int64])
 				ingress = sum.DataPoints[0].Value
 				if getAttr(sum.DataPoints[0], "rpc.method") != "ReadObject" {
 					t.Errorf("expected rpc.method ReadObject")
 				}
 			}
-			if m.Name == "gcp.storage.client.network.egress_bytes_count" {
+			if m.Name == "gcp.storage.client.network.bytes.sent" {
 				sum := m.Data.(metricdata.Sum[int64])
 				egress = sum.DataPoints[0].Value
 				if getAttr(sum.DataPoints[0], "rpc.method") != "ReadObject" {

--- a/storage/metrics_test.go
+++ b/storage/metrics_test.go
@@ -761,9 +761,6 @@ func TestStandardMetricsRecording(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewMultiRangeDownloader: %v", err)
 	}
-	// override the span context directly on the mocked mrd to use the context from NewMultiRangeDownloader
-	// wait we can't because it's not exported. But we don't need to, the metrics config is inside the context.
-	// Wait, the client wraps it!
 	if err := mrd.Close(); err != nil {
 		t.Fatalf("mrd.Close: %v", err)
 	}

--- a/storage/metrics_test.go
+++ b/storage/metrics_test.go
@@ -600,6 +600,7 @@ type mockStorageClient struct {
 	storageClient
 	getObjectFn  func(ctx context.Context, params *getObjectParams, opts ...storageOption) (*ObjectAttrs, error)
 	newReaderFn  func(ctx context.Context, params *newRangeReaderParams, opts ...storageOption) (*Reader, error)
+	newMRDFn     func(ctx context.Context, params *newMultiRangeDownloaderParams, opts ...storageOption) (*MultiRangeDownloader, error)
 	openWriterFn func(params *openWriterParams, opts ...storageOption) (internalWriter, error)
 }
 
@@ -617,6 +618,26 @@ func (m *mockStorageClient) NewRangeReader(ctx context.Context, params *newRange
 	return nil, nil
 }
 
+type mockInternalMRD struct {
+	bytesRead int64
+	ctx       context.Context
+}
+
+func (m *mockInternalMRD) add(output io.Writer, offset, length int64, callback func(int64, int64, error)) {
+}
+func (m *mockInternalMRD) close(err error) error       { return nil }
+func (m *mockInternalMRD) wait()                       {}
+func (m *mockInternalMRD) getHandle() []byte           { return nil }
+func (m *mockInternalMRD) getPermanentError() error    { return nil }
+func (m *mockInternalMRD) getSpanCtx() context.Context { return m.ctx }
+func (m *mockInternalMRD) getBytesRead() int64         { return m.bytesRead }
+
+func (m *mockStorageClient) NewMultiRangeDownloader(ctx context.Context, params *newMultiRangeDownloaderParams, opts ...storageOption) (*MultiRangeDownloader, error) {
+	if m.newMRDFn != nil {
+		return m.newMRDFn(ctx, params, opts...)
+	}
+	return nil, nil
+}
 func (m *mockStorageClient) OpenWriter(params *openWriterParams, opts ...storageOption) (internalWriter, error) {
 	if m.openWriterFn != nil {
 		return m.openWriterFn(params, opts...)
@@ -730,6 +751,23 @@ func TestStandardMetricsRecording(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
+	// Test MultiRangeDownloader
+	mock.newMRDFn = func(ctx context.Context, params *newMultiRangeDownloaderParams, opts ...storageOption) (*MultiRangeDownloader, error) {
+		return &MultiRangeDownloader{
+			impl: &mockInternalMRD{bytesRead: 42, ctx: ctx},
+		}, nil
+	}
+	mrd, err := client.Bucket("my-bucket").Object("my-object").NewMultiRangeDownloader(ctx)
+	if err != nil {
+		t.Fatalf("NewMultiRangeDownloader: %v", err)
+	}
+	// override the span context directly on the mocked mrd to use the context from NewMultiRangeDownloader
+	// wait we can't because it's not exported. But we don't need to, the metrics config is inside the context.
+	// Wait, the client wraps it!
+	if err := mrd.Close(); err != nil {
+		t.Fatalf("mrd.Close: %v", err)
+	}
+
 	// Collect metrics.
 	var rm metricdata.ResourceMetrics
 	if err := mr.Collect(ctx, &rm); err != nil {
@@ -749,8 +787,8 @@ func TestStandardMetricsRecording(t *testing.T) {
 		t.Errorf("metric gcp.client.request.duration not found")
 	} else {
 		hist := m.Data.(metricdata.Histogram[float64])
-		if len(hist.DataPoints) != 3 {
-			t.Errorf("expected 3 datapoints for gcp.client.request.duration, got %d", len(hist.DataPoints))
+		if len(hist.DataPoints) != 4 {
+			t.Errorf("expected 4 datapoints for gcp.client.request.duration, got %d", len(hist.DataPoints))
 		}
 		methods := make(map[string]bool)
 		for _, dp := range hist.DataPoints {
@@ -770,8 +808,8 @@ func TestStandardMetricsRecording(t *testing.T) {
 		t.Errorf("metric gcp.storage.client.operations not found")
 	} else {
 		sum := m.Data.(metricdata.Sum[int64])
-		if len(sum.DataPoints) != 3 {
-			t.Errorf("expected 3 datapoints for gcp.storage.client.operations, got %d", len(sum.DataPoints))
+		if len(sum.DataPoints) != 4 {
+			t.Errorf("expected 4 datapoints for gcp.storage.client.operations, got %d", len(sum.DataPoints))
 		}
 	}
 
@@ -783,9 +821,8 @@ func TestStandardMetricsRecording(t *testing.T) {
 		if len(hist.DataPoints) != 1 {
 			t.Fatalf("expected 1 datapoint for response body size, got %d", len(hist.DataPoints))
 		}
-		dp := hist.DataPoints[0]
-		if dp.Sum != 5 {
-			t.Errorf("expected sum 5, got %d", dp.Sum)
+		if hist.DataPoints[0].Sum != 47 {
+			t.Errorf("expected total sum 47, got %d", hist.DataPoints[0].Sum)
 		}
 	}
 

--- a/storage/reader.go
+++ b/storage/reader.go
@@ -415,7 +415,7 @@ func (r *Reader) Close() error {
 	if r.metricsState != nil {
 		if r.metricsState.metrics != nil {
 			if total := atomic.SwapInt64(&r.bytesRead, 0); total > 0 {
-				r.metricsState.metrics.responseBodySize.Record(r.ctx, total, metric.WithAttributes(attribute.String("rpc.method", "ReadObject"), attribute.String("server.address", stripPort(r.metricsState.target))))
+				r.metricsState.metrics.responseBodySize.Record(r.ctx, total, metric.WithAttributes(attribute.String("rpc.method", "ReadObject"), attribute.String("server.address", stripPort(r.metricsState.getTarget()))))
 			}
 		}
 		if r.metricsState.record != nil {

--- a/storage/reader.go
+++ b/storage/reader.go
@@ -415,7 +415,7 @@ func (r *Reader) Close() error {
 	if r.metricsState != nil {
 		if r.metricsState.metrics != nil {
 			if total := atomic.SwapInt64(&r.bytesRead, 0); total > 0 {
-				r.metricsState.metrics.responseBodySize.Record(r.ctx, total, metric.WithAttributes(attribute.String("rpc.method", "ReadObject")))
+				r.metricsState.metrics.responseBodySize.Record(r.ctx, total, metric.WithAttributes(attribute.String("rpc.method", "ReadObject"), attribute.String("server.address", stripPort(r.metricsState.target))))
 			}
 		}
 		if r.metricsState.record != nil {

--- a/storage/reader.go
+++ b/storage/reader.go
@@ -415,7 +415,7 @@ func (r *Reader) Close() error {
 	if r.metricsState != nil {
 		if r.metricsState.metrics != nil {
 			if total := atomic.SwapInt64(&r.bytesRead, 0); total > 0 {
-				r.metricsState.metrics.responseBodySize.Record(r.ctx, total, metric.WithAttributes(attribute.String("rpc.method", "ReadObject"), attribute.String("server.address", stripPort(r.metricsState.getTarget()))))
+				r.metricsState.metrics.responseBodySize.Record(r.ctx, total, metric.WithAttributes(attribute.String("rpc.system.name", r.metricsState.getSystemName()), attribute.String("rpc.method", "ReadObject"), attribute.String("server.address", stripPort(r.metricsState.getTarget()))))
 			}
 		}
 		if r.metricsState.record != nil {
@@ -592,7 +592,7 @@ func (mrd *MultiRangeDownloader) Close() error {
 	if state := metricsStateFromContext(mrd.impl.getSpanCtx()); state != nil {
 		if state.metrics != nil {
 			if total := mrd.impl.getBytesRead(); total > 0 {
-				state.metrics.responseBodySize.Record(mrd.impl.getSpanCtx(), total, metric.WithAttributes(attribute.String("rpc.method", "ReadObject"), attribute.String("server.address", stripPort(state.getTarget()))))
+				state.metrics.responseBodySize.Record(mrd.impl.getSpanCtx(), total, metric.WithAttributes(attribute.String("rpc.system.name", state.getSystemName()), attribute.String("rpc.method", "ReadObject"), attribute.String("server.address", stripPort(state.getTarget()))))
 			}
 		}
 		if state.record != nil {

--- a/storage/reader.go
+++ b/storage/reader.go
@@ -589,8 +589,15 @@ func (mrd *MultiRangeDownloader) Add(output io.Writer, offset, length int64, cal
 // it could lead to a deadlock.
 func (mrd *MultiRangeDownloader) Close() error {
 	err := mrd.impl.close(nil)
-	if state := metricsStateFromContext(mrd.impl.getSpanCtx()); state != nil && state.record != nil {
-		state.record(err)
+	if state := metricsStateFromContext(mrd.impl.getSpanCtx()); state != nil {
+		if state.metrics != nil {
+			if total := mrd.impl.getBytesRead(); total > 0 {
+				state.metrics.responseBodySize.Record(mrd.impl.getSpanCtx(), total, metric.WithAttributes(attribute.String("rpc.method", "ReadObject"), attribute.String("server.address", stripPort(state.getTarget()))))
+			}
+		}
+		if state.record != nil {
+			state.record(err)
+		}
 	}
 	endSpan(mrd.impl.getSpanCtx(), err)
 	return err

--- a/storage/writer.go
+++ b/storage/writer.go
@@ -450,7 +450,7 @@ func (w *Writer) markClosed(err error) error {
 
 	if state := metricsStateFromContext(w.ctx); state != nil {
 		if state.metrics != nil && total > 0 {
-			state.metrics.requestBodySize.Record(w.ctx, total, metric.WithAttributes(attribute.String("rpc.method", "WriteObject")))
+			state.metrics.requestBodySize.Record(w.ctx, total, metric.WithAttributes(attribute.String("rpc.method", "WriteObject"), attribute.String("server.address", stripPort(state.target))))
 		}
 		if state.record != nil {
 			state.record(closingErr)

--- a/storage/writer.go
+++ b/storage/writer.go
@@ -450,7 +450,7 @@ func (w *Writer) markClosed(err error) error {
 
 	if state := metricsStateFromContext(w.ctx); state != nil {
 		if state.metrics != nil && total > 0 {
-			state.metrics.requestBodySize.Record(w.ctx, total, metric.WithAttributes(attribute.String("rpc.method", "WriteObject"), attribute.String("server.address", stripPort(state.target))))
+			state.metrics.requestBodySize.Record(w.ctx, total, metric.WithAttributes(attribute.String("rpc.method", "WriteObject"), attribute.String("server.address", stripPort(state.getTarget()))))
 		}
 		if state.record != nil {
 			state.record(closingErr)

--- a/storage/writer.go
+++ b/storage/writer.go
@@ -274,7 +274,11 @@ func (w *Writer) wrapWriteError(n int, err error) (int, error) {
 }
 
 func (w *Writer) isGRPCClient() bool {
-	_, ok := w.o.c.tc.(*grpcStorageClient)
+	tc := w.o.c.tc
+	if mc, ok := tc.(*metricsStorageClient); ok {
+		tc = mc.storageClient
+	}
+	_, ok := tc.(*grpcStorageClient)
 	return ok
 }
 

--- a/storage/writer.go
+++ b/storage/writer.go
@@ -454,7 +454,7 @@ func (w *Writer) markClosed(err error) error {
 
 	if state := metricsStateFromContext(w.ctx); state != nil {
 		if state.metrics != nil && total > 0 {
-			state.metrics.requestBodySize.Record(w.ctx, total, metric.WithAttributes(attribute.String("rpc.method", "WriteObject"), attribute.String("server.address", stripPort(state.getTarget()))))
+			state.metrics.requestBodySize.Record(w.ctx, total, metric.WithAttributes(attribute.String("rpc.system.name", state.getSystemName()), attribute.String("rpc.method", "WriteObject"), attribute.String("server.address", stripPort(state.getTarget()))))
 		}
 		if state.record != nil {
 			state.record(closingErr)


### PR DESCRIPTION
## Description

This PR enhances OpenTelemetry metrics in the Cloud Storage Go client library by adding TraceBased exemplar support, injecting the `server.address` attribute into logical and attempt metric scopes, and aligning metric names with OpenTelemetry semantic conventions.

### Changes Included:

1. **TraceBased Exemplar Support**:
   - Configured `sdkmetric.WithExemplarFilter(exemplar.TraceBasedFilter)` on `MeterProvider` initializations in `storage/metrics.go` so that metrics capture trace context exemplars when active traces are present.

2. **`server.address` Dimension Injection**:
   - Injected `server.address` (with port stripped) into:
     - gRPC and HTTP attempt and error metrics.
     - TTFB (time-to-first-byte) metric recordings.
     - Top-level operation latency scopes in `startOperation` by propagating `target` through `metricsState`.
     - Request body size (`Writer`) and response body size (`Reader`) metrics.

3. **Metric Name Standardization**:
   - Updated metric names to align with standard semantic conventions:
     - `gcp.storage.client.network.egress_bytes_count` → `gcp.storage.client.network.bytes.sent`
     - `gcp.storage.client.network.ingress_bytes_count` → `gcp.storage.client.network.bytes.received`
     - `gcp.storage.client.active_requests` → `gcp.storage.client.request.active`

4. **Testing**:
   - Updated corresponding unit and integration test assertions in `storage/metrics_test.go` and `storage/integration_test.go`.