### PR TITLE
fix(bigtable): scope session pool maintenance loops to the pool, not the client

### DIFF
--- a/bigtable/internal/session/client.go
+++ b/bigtable/internal/session/client.go
@@ -100,9 +100,19 @@ type Config struct {
 	// classic/session traffic split follows the server's directive.
 	SessionLoadListener func(load float64)
 
-	// BackgroundCtx is the parent context passed to each per-pool
-	// Start(ctx) call. Cancelled by Client teardown so every pool's
-	// Tick + AFE prune loops unwind together.
+	// BackgroundCtx is the parent context for the Client's own
+	// process-lifetime loops (today: ClientConfigurationManager polling).
+	// Cancelled by Client teardown.
+	//
+	// Deliberately NOT handed to session pools. A pool's lifetime is a
+	// strict subset of this Client's: Close() closes every pool, and
+	// session.TableCache also evicts + Closes individual pools while the
+	// Client keeps running. So this ctx is always too coarse to scope
+	// pool-owned work — it can only ever fire after the pool is already
+	// gone (client shutdown), or never at all (TTL eviction). Either way
+	// the pool's loops outlive its Close, and since each loop closure
+	// captures the pool, the pool itself stays reachable. Pools scope
+	// their own goroutines; see SessionPoolImpl.Start / maintCtx.
 	BackgroundCtx context.Context
 
 	// EnableDebug controls whether the pools this Client mints will
@@ -567,8 +577,8 @@ func (sc *sessionClient) OpenMaterializedView(view string) TableAPI {
 // firing against half-dead pools:
 //  1. Stop config polling — no more UpdateConfig can fire after.
 //  2. Close every session pool (per-pool listeners already detached).
-//  3. Cancel the background ctx we constructed (unwinds heartbeat /
-//     AFE-prune / scaling loops parented on it).
+//  3. Cancel the background ctx we constructed (unwinds the
+//     client-scoped loops parented on it).
 //  4. managed.Close() stops the DynamicScaleMonitor + ConnectionRecycler
 //     wired by btransport.CreateAndStartManagedChannelPool, then closes
 //     the underlying pool — in that order, so no scale-up / recycle tick
@@ -754,7 +764,6 @@ func (sc *sessionClient) createSessionPool(
 	mp := &managedSessionPool{id: id, key: key, pool: pool}
 	sc.sessionPools[id] = mp
 	configManager := sc.configManager
-	backgroundCtx := sc.cfg.BackgroundCtx
 	sc.sessionPoolsMu.Unlock()
 
 	if configManager != nil {
@@ -771,7 +780,7 @@ func (sc *sessionClient) createSessionPool(
 		}
 	}
 
-	pool.Start(backgroundCtx)
+	pool.Start()
 	return pool, sc.releasePoolByID(id)
 }
 

--- a/bigtable/internal/transport/session_pool.go
+++ b/bigtable/internal/transport/session_pool.go
@@ -172,6 +172,17 @@ type SessionPoolImpl struct {
 	poolCtx    context.Context
 	poolCancel context.CancelFunc
 
+	// maintCtx scopes the background maintenance loops started by Start
+	// (AFE prune, WaitServerClose sweep, slow metrics). Child of poolCtx
+	// so it can never outlive the pool, but cancelled separately in
+	// Close's Phase 1 — ahead of poolCancel — so no maintenance tick runs
+	// against a pool that's mid-teardown. Each loop closure captures p,
+	// so a loop that survives Close pins the whole pool on the heap;
+	// that's what leaked under session.TableCache TTL eviction, which
+	// Closes pools continuously over a long-lived process's life.
+	maintCtx    context.Context
+	maintCancel context.CancelFunc
+
 	// debugEnabled mirrors session.Config.EnableDebug via
 	// NewSessionPoolImpl. Immutable after construction (no atomic
 	// needed). When false, every allocating debug recorder in
@@ -207,6 +218,7 @@ func (p *SessionPoolImpl) noteVRpcOutcome(sh *SessionHandle, e2e, backend time.D
 // defaultPoolConfig() values (currently 5/400).
 func NewSessionPoolImpl(id uint64, poolName string, streamFactory func(ctx context.Context) (Stream, error), openSessionRequest *spb.OpenSessionRequest, md metadata.MD, sessionType SessionType, debugEnabled bool) *SessionPoolImpl {
 	poolCtx, poolCancel := context.WithCancel(context.Background())
+	maintCtx, maintCancel := context.WithCancel(poolCtx)
 	pool := &SessionPoolImpl{
 		poolName:           poolName,
 		poolID:             id,
@@ -218,6 +230,8 @@ func NewSessionPoolImpl(id uint64, poolName string, streamFactory func(ctx conte
 		waiters:            list.New(),
 		poolCtx:            poolCtx,
 		poolCancel:         poolCancel,
+		maintCtx:           maintCtx,
+		maintCancel:        maintCancel,
 		sl:                 newSessionList(),
 		debugEnabled:       debugEnabled,
 	}

--- a/bigtable/internal/transport/session_pool_lifecycle.go
+++ b/bigtable/internal/transport/session_pool_lifecycle.go
@@ -151,8 +151,17 @@ func (p *SessionPoolImpl) snapshotCloseReasons() map[string]int64 {
 // per-session graceful Close returns (or the bounded ctx fires). Only
 // after the WaitGroup completes do we cancel poolCtx, which tears down
 // any remaining session goroutines.
+//
+// Close is the ONLY teardown entry point. When it returns, every
+// goroutine the pool owns has been cancelled and the pool is
+// unreachable — sessions and createSession workers are joined outright,
+// maintenance loops are cancelled and unwind on their own. That is what
+// lets session.TableCache evict pools without leaking them.
 func (p *SessionPoolImpl) Close() error {
-	// Phase 1: mark closed so no new sessions are admitted.
+	// Phase 1: mark closed so no new sessions are admitted, and stop the
+	// background maintenance loops. maintCancel runs here rather than
+	// riding on Phase 4's poolCancel so no prune / sweep / metrics tick
+	// fires against a pool that's mid-teardown.
 	p.mu.Lock()
 	if p.closed {
 		p.mu.Unlock()
@@ -160,6 +169,7 @@ func (p *SessionPoolImpl) Close() error {
 	}
 	p.closed = true
 	p.mu.Unlock()
+	p.maintCancel()
 
 	// Drain parked waiters with ErrPoolClosed. Without this, long-poll
 	// callers with context.Background hang past Close: only ctx-cancel
@@ -233,6 +243,14 @@ func (p *SessionPoolImpl) Close() error {
 	// error paths touch package-level metric state, so without this wait
 	// they can outlive Close and race the next test's metrics init.
 	p.spawns.Wait()
+
+	// The maintenance loops cancelled in Phase 1 are deliberately NOT
+	// waited on. They park on a select, so cancel releases the pool
+	// immediately; joining them would only close a microsecond-wide
+	// window in which an already-running tick body finishes after Close
+	// returns. Not worth blocking for — Close runs inline on the
+	// TableCache sweeper (sweepOnce closes evicted handles serially), so
+	// a wedged tick body would stall eviction for every table.
 
 	// Phase 6: wait for every Session's goroutines to unwind. Re-snapshot
 	// AFTER spawns.Wait to catch sessions that reached sl during the tail
@@ -480,37 +498,54 @@ const slowMetricsInterval = 1 * time.Minute
 //   - CheckoutSession → spawnTickOnce          (waiter park on empty)
 //   - UpdateConfig → spawnTickOnce             (server-driven min/max bump)
 //
-// The pre-start Tick above (line: p.spawnTickOnce(ctx)) covers the
+// The pre-start Tick above (line: p.spawnTickOnce) covers the
 // cold-start MinSessions seed; everything after is event-driven.
 // Matches java-bigtable's fully event-driven poolSizer (no periodic
 // timer for sizing).
-func (p *SessionPoolImpl) Start(ctx context.Context) {
+//
+// Start takes no ctx on purpose. Everything it launches is scoped to
+// the pool's own poolCtx / maintCtx, so Close alone is sufficient to
+// unwind it. Threading a caller ctx here previously outlived Close
+// (which cancels poolCtx, not the caller's) and leaked the loops.
+func (p *SessionPoolImpl) Start() {
 	p.startOnce.Do(func() {
-		p.spawnTickOnce(ctx)
-		p.startAfePruneLoop(ctx)
-		p.startSweepStuckSessionsLoop(ctx)
-		p.startSlowMetricsLoop(ctx)
+		p.spawnTickOnce(p.poolCtx)
+		p.startAfePruneLoop()
+		p.startSweepStuckSessionsLoop()
+		p.startSlowMetricsLoop()
 	})
 }
 
-// startSlowMetricsLoop runs recordTimeSeries + sampleActiveUptimes
-// every slowMetricsInterval until ctx cancels. Decoupled from Tick so
-// Tick's per-second cadence doesn't drag ~60× extra OTel histogram
-// writes onto sessionUptime.
-func (p *SessionPoolImpl) startSlowMetricsLoop(ctx context.Context) {
+// startMaintenanceLoop starts one ticker-driven maintenance goroutine
+// scoped to p.maintCtx, which Close cancels in Phase 1. No closed-check
+// is needed: a Start racing Close either sees a live maintCtx and is
+// cancelled a moment later, or sees a cancelled one and exits on the
+// first select.
+func (p *SessionPoolImpl) startMaintenanceLoop(interval time.Duration, fn func()) {
 	go func() {
-		ticker := time.NewTicker(slowMetricsInterval)
+		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
+
 		for {
 			select {
-			case <-ctx.Done():
+			case <-p.maintCtx.Done():
 				return
 			case <-ticker.C:
-				p.recordTimeSeries()
-				p.sampleActiveUptimes(ctx)
+				fn()
 			}
 		}
 	}()
+}
+
+// startSlowMetricsLoop runs recordTimeSeries + sampleActiveUptimes
+// every slowMetricsInterval until the pool closes. Decoupled from Tick
+// so Tick's per-second cadence doesn't drag ~60× extra OTel histogram
+// writes onto sessionUptime.
+func (p *SessionPoolImpl) startSlowMetricsLoop() {
+	p.startMaintenanceLoop(slowMetricsInterval, func() {
+		p.recordTimeSeries()
+		p.sampleActiveUptimes(p.maintCtx)
+	})
 }
 
 // tickOnce runs one Tick with panic recovery + a debounce gate. The
@@ -549,23 +584,11 @@ func (p *SessionPoolImpl) spawnTickOnce(ctx context.Context) {
 	}()
 }
 
-// startAfePruneLoop runs sl.Prune on afePruneMaxIdle cadence until ctx
-// cancels — deliberately OFF the tickInterval so sl.mu held during the
-// map walk can't contend with serving-path Checkouts.
-func (p *SessionPoolImpl) startAfePruneLoop(ctx context.Context) {
-	go func() {
-		ticker := time.NewTicker(afePruneMaxIdle)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				p.pruneOnce()
-			}
-		}
-	}()
+// startAfePruneLoop runs sl.Prune on afePruneMaxIdle cadence until the
+// pool closes — deliberately OFF the tickInterval so sl.mu held during
+// the map walk can't contend with serving-path Checkouts.
+func (p *SessionPoolImpl) startAfePruneLoop() {
+	p.startMaintenanceLoop(afePruneMaxIdle, p.pruneOnce)
 }
 
 // pruneOnce runs one sl.Prune with panic recovery per iteration.
@@ -579,25 +602,13 @@ func (p *SessionPoolImpl) pruneOnce() {
 }
 
 // startSweepStuckSessionsLoop runs sweepStuckSessions on
-// sweepStuckSessionsInterval cadence until ctx cancels. Deliberately
-// OFF the 1s Tick — a stuck WaitServerClose session only becomes
-// actionable after waitServerCloseGrace has elapsed, so checking more
-// often just burns CPU walking sl.AllHandles. Worst-case detection is
-// waitServerCloseGrace + sweepStuckSessionsInterval.
-func (p *SessionPoolImpl) startSweepStuckSessionsLoop(ctx context.Context) {
-	go func() {
-		ticker := time.NewTicker(sweepStuckSessionsInterval)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				p.sweepStuckSessionsOnce()
-			}
-		}
-	}()
+// sweepStuckSessionsInterval cadence until the pool closes.
+// Deliberately OFF the 1s Tick — a stuck WaitServerClose session only
+// becomes actionable after waitServerCloseGrace has elapsed, so
+// checking more often just burns CPU walking sl.AllHandles. Worst-case
+// detection is waitServerCloseGrace + sweepStuckSessionsInterval.
+func (p *SessionPoolImpl) startSweepStuckSessionsLoop() {
+	p.startMaintenanceLoop(sweepStuckSessionsInterval, p.sweepStuckSessionsOnce)
 }
 
 // sweepStuckSessionsOnce runs one sweepStuckSessions with panic

--- a/bigtable/internal/transport/session_pool_lifecycle_test.go
+++ b/bigtable/internal/transport/session_pool_lifecycle_test.go
@@ -17,9 +17,13 @@ package internal
 import (
 	"errors"
 	"fmt"
+	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	spb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
 )
 
 // --- close-reason ledger ---------------------------------------------------
@@ -429,5 +433,122 @@ func TestOnStart_NoOp(t *testing.T) {
 	p.onStart(nil)
 	if got := p.m.sessionsOpened.Load(); got != before {
 		t.Errorf("OnStart mutated sessionsOpened: %d → %d", before, got)
+	}
+}
+
+// --- maintenance-loop lifetime ---------------------------------------------
+
+// countMaintenanceLoops reports how many startMaintenanceLoop goroutines are
+// currently alive process-wide. Matching on the frame name rather than a raw
+// runtime.NumGoroutine delta keeps the assertion immune to unrelated
+// goroutines (readLoops, OTel exporters) that other tests leave running.
+func countMaintenanceLoops() int {
+	buf := make([]byte, 1<<20)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			buf = buf[:n]
+			break
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+	return strings.Count(string(buf), "(*SessionPoolImpl).startMaintenanceLoop.func")
+}
+
+// awaitMaintenanceLoops polls countMaintenanceLoops until it reaches want,
+// returning the last observed value. Close cancels the loops but does not
+// join them, and Start launches them asynchronously, so both directions
+// need a settle window.
+func awaitMaintenanceLoops(t *testing.T, want int) int {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	got := countMaintenanceLoops()
+	for got != want && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+		got = countMaintenanceLoops()
+	}
+	return got
+}
+
+// TestPoolClose_UnwindsMaintenanceLoops is the regression test for the
+// pool-eviction goroutine leak.
+//
+// Start's three maintenance loops (AFE prune, WaitServerClose sweep, slow
+// metrics) used to select on a ctx handed in by the caller — in production the
+// session Client's process-lifetime BackgroundCtx — while Close only cancelled
+// the pool's own poolCtx. Nothing ever cancelled the loops, so every pool
+// teardown leaked three goroutines, and because each loop closure captures p,
+// each leaked goroutine pinned an entire SessionPoolImpl (metrics ring
+// buffers, sessionList) on the heap. session.TableCache TTL eviction Closes
+// pools continuously, so the leak grew without bound over a process's life.
+//
+// Closing pools in a loop here means a regression shows up as growth, not just
+// a single stuck goroutine.
+func TestPoolClose_UnwindsMaintenanceLoops(t *testing.T) {
+	const (
+		wantPerPool = 3 // prune + stuck-session sweep + slow metrics
+		iterations  = 3
+	)
+
+	baseline := countMaintenanceLoops()
+
+	for i := 0; i < iterations; i++ {
+		factory, closeStreams := newStubStreamFactory()
+		p := NewSessionPoolImpl(
+			uint64(i+1),
+			"maint-loop-pool",
+			factory,
+			&spb.OpenSessionRequest{ProtocolVersion: 1},
+			nil,
+			SessionTypeTable, true,
+		)
+
+		p.Start()
+		if got := awaitMaintenanceLoops(t, baseline+wantPerPool); got != baseline+wantPerPool {
+			t.Fatalf("iteration %d: after Start, %d maintenance goroutines, want %d "+
+				"(test is only meaningful if Start actually launches them)", i, got, baseline+wantPerPool)
+		}
+
+		// Unblock any readLoop parked on fakeStream.Recv first, or Close's
+		// Phase-5 spawns.Wait never returns.
+		closeStreams()
+		if err := p.Close(); err != nil {
+			t.Fatalf("iteration %d: Close returned err = %v", i, err)
+		}
+
+		// Close waits on p.maint, so this must already hold; the poll only
+		// absorbs the instant between maint.Done and the goroutine's last
+		// instruction.
+		if got := awaitMaintenanceLoops(t, baseline); got != baseline {
+			t.Fatalf("iteration %d: after Close, %d maintenance goroutines, want %d "+
+				"— pool maintenance loops outlived Close (leak)", i, got, baseline)
+		}
+	}
+}
+
+// TestPoolStart_AfterClose_LoopsExitImmediately guards the Start-after-Close
+// order. maintCtx is already cancelled by then, so any loop Start launches
+// must fall out on its first select rather than tick against a torn-down
+// pool — leaving the count back at baseline.
+func TestPoolStart_AfterClose_LoopsExitImmediately(t *testing.T) {
+	baseline := countMaintenanceLoops()
+
+	factory, closeStreams := newStubStreamFactory()
+	p := NewSessionPoolImpl(
+		uint64(1),
+		"start-after-close-pool",
+		factory,
+		&spb.OpenSessionRequest{ProtocolVersion: 1},
+		nil,
+		SessionTypeTable, true,
+	)
+	closeStreams()
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close returned err = %v", err)
+	}
+
+	p.Start()
+	if got := awaitMaintenanceLoops(t, baseline); got != baseline {
+		t.Errorf("Start after Close launched maintenance loops: %d goroutines, want %d", got, baseline)
 	}
 }

--- a/bigtable/internal/transport/session_pool_lifecycle_test.go
+++ b/bigtable/internal/transport/session_pool_lifecycle_test.go
@@ -516,9 +516,8 @@ func TestPoolClose_UnwindsMaintenanceLoops(t *testing.T) {
 			t.Fatalf("iteration %d: Close returned err = %v", i, err)
 		}
 
-		// Close waits on p.maint, so this must already hold; the poll only
-		// absorbs the instant between maint.Done and the goroutine's last
-		// instruction.
+		// Close does not wait on the maintenance loops, so we poll here
+		// to allow them to finish unwinding.
 		if got := awaitMaintenanceLoops(t, baseline); got != baseline {
 			t.Fatalf("iteration %d: after Close, %d maintenance goroutines, want %d "+
 				"— pool maintenance loops outlived Close (leak)", i, got, baseline)


### PR DESCRIPTION
## Problem

`SessionPoolImpl.Start(ctx)` launched three background maintenance loops — AFE prune, `WaitServerClose` sweep, slow metrics — that selected on the `ctx` handed in by the caller. The only caller passed the session `Client`'s process-lifetime `BackgroundCtx`, while `Close()` cancels the pool's own `poolCtx`, a **separate tree rooted at `context.Background()`**. Cancellation only flows along derivation edges, so `poolCancel()` had nothing to say to those loops.

This survived review because on the client-shutdown path the loops *do* die — via the client's ctx, not the pool's. `session.TableCache` TTL eviction has no such backstop: it calls `pool.Close()` and nothing else. Every evicted pool leaked three goroutines, and since each loop closure captures `p`, each leaked goroutine pinned an entire `SessionPoolImpl` (metrics ring buffers, `sessionList`) on the heap. With a read and a write pool per table that's **six goroutines and two pinned pools per evicted table**, growing without bound over a long-lived process.

Affects the accelerator daemon and the native Go client alike, since both share this code.

## Fix

- `Start()` takes no ctx. The loops hang off a new pool-owned `maintCtx` (child of `poolCtx`).
- `Close()` cancels `maintCtx` in Phase 1, **ahead of** Phase 4's `poolCancel`, so no prune/sweep/metrics tick fires against a pool that's mid-teardown. `poolCtx` can't be reused for this: Phase 2 derives the 30s session-close RPC context from it, so it has to stay alive through teardown while the loops must stop immediately.
- The three near-identical loop bodies collapse into one `startMaintenanceLoop` helper.

`Close` cancels the loops but deliberately **does not join** them. They park on a select, so cancel releases the pool immediately; joining would only close a microsecond-wide window where an already-running tick body finishes after `Close` returns. Not worth blocking for, because `Close` runs inline on the `TableCache` sweeper (`sweepOnce` closes evicted handles serially) — a wedged tick body would stall eviction for every table, which is strictly worse than the leak being fixed.

## Verification

A/B reproduction against pre- and post-fix builds, counting live maintenance frames via `runtime.Stack`:

**Unit, driving the real eviction chain** (`TableCache.sweepOnce → TableHandle.Close → sessionTable.Close → releaseSessionPool → SessionPoolImpl.Close`), 6 tables × 2 pools × 3 loops × 4 cycles:

| after-evict | c0 | c1 | c2 | c3 |
|---|---|---|---|---|
| pre-fix | +36 | +72 | +108 | **+144** |
| post-fix | 0 | 0 | 0 | **0** |

Worth noting: pre-fix, `livePools` still drained to 0 — eviction *did* reach `releaseSessionPool`/`pool.Close()` and the goroutines survived it anyway. That isolates the bug to ctx wiring.

**Accelerator daemon against a live backend**, 5-minute cache TTL, 3 cycles, frames counted via pprof: pre-fix `24 → 48 → 72`, never reclaiming; post-fix `24 → 0` every cycle.

Cost per leaked pool is ~14 KB (three 4 KB goroutine stacks + ~10 KB pinned pool), so this presents as unbounded **goroutine** growth rather than visibly rising RSS — RSS was noise-dominated in the daemon run.

Regression tests added in `session_pool_lifecycle_test.go`: `TestPoolClose_UnwindsMaintenanceLoops` (3 Start/Close cycles, frame-counted so it's immune to unrelated goroutine noise, and asserts the count *rises* after Start so it can't pass vacuously) and `TestPoolStart_AfterClose_LoopsExitImmediately`.

`gofmt`, `go vet`, and the full `internal/transport` + `internal/session` suites pass under `-race`.