### PR TITLE
fix(bigtable): measure real scheduling delay in pacemaker_delays

### DIFF
--- a/bigtable/internal/transport/pacemaker.go
+++ b/bigtable/internal/transport/pacemaker.go
@@ -114,7 +114,7 @@ func (p *Pacemaker) recordTick(ctx context.Context, scheduled, now time.Time) {
 	if delay < 0 {
 		delay = 0
 	}
-	p.histogram.Record(ctx, float64(delay.Nanoseconds())/1e3, p.attrs)
+	p.histogram.Record(ctx, float64(delay)/float64(time.Microsecond), p.attrs)
 }
 
 // Stop acts as a cleanup method. no-op

--- a/bigtable/internal/transport/pacemaker.go
+++ b/bigtable/internal/transport/pacemaker.go
@@ -24,9 +24,15 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
-// Pacemaker monitors the runtime scheduling delay
-// It measures the time difference between when a ticker was scheduled to fire
-// and when the ticker actually fires.
+// pacemakerInterval is how often the pacemaker goroutine wakes up. It only
+// sets the sampling rate: the delay reported per tick is independent of it.
+const pacemakerInterval = 100 * time.Millisecond
+
+// Pacemaker monitors the runtime scheduling delay. It measures the time
+// between when a tick was scheduled to fire and when the pacemaker goroutine
+// was actually scheduled to handle it, which is a proxy for how contended the
+// process is -- for CPU (an undersized GOMAXPROCS, or CFS throttling against a
+// cgroup quota), or for the scheduler generally (a stop-the-world pause).
 type Pacemaker struct {
 	meterProvider metric.MeterProvider
 	logger        *log.Logger
@@ -75,32 +81,40 @@ func (p *Pacemaker) Start(ctx context.Context) {
 	}
 
 	go func() {
-		interval := 100 * time.Millisecond
-		ticker := time.NewTicker(interval)
+		ticker := time.NewTicker(pacemakerInterval)
 		defer ticker.Stop()
-
-		lastTick := time.Now()
 
 		for {
 			select {
-			case t := <-ticker.C:
-				actualInterval := t.Sub(lastTick)
-
-				delay := actualInterval - interval
-				if delay < 0 {
-					delay = 0
-				}
-
-				delayUs := float64(delay.Nanoseconds()) / 1e3
-				p.histogram.Record(ctx, delayUs, p.attrs)
-
-				lastTick = t
+			case scheduled := <-ticker.C:
+				p.recordTick(ctx, scheduled, time.Now())
 
 			case <-ctx.Done():
 				return
 			}
 		}
 	}()
+}
+
+// recordTick records how late this goroutine was to handle a tick that was
+// scheduled for the given time.
+//
+// The value a ticker sends on its channel is not the time of delivery: the
+// runtime reconstructs the time the tick was *due* (time.sendTime sends
+// Now().Add(-delta)). So the gap between that and the moment we get around to
+// reading it is exactly the delay we want to report -- the time the goroutine
+// spent waiting for a P, plus any time the tick sat in the channel buffer.
+//
+// Comparing consecutive tick timestamps instead would measure nothing: due
+// times are one interval apart by construction, so the difference is exactly
+// the interval unless the runtime drops a tick entirely. That only registers
+// starvation longer than a whole interval, and only in interval-sized steps.
+func (p *Pacemaker) recordTick(ctx context.Context, scheduled, now time.Time) {
+	delay := now.Sub(scheduled)
+	if delay < 0 {
+		delay = 0
+	}
+	p.histogram.Record(ctx, float64(delay.Nanoseconds())/1e3, p.attrs)
 }
 
 // Stop acts as a cleanup method. no-op

--- a/bigtable/internal/transport/pacemaker_test.go
+++ b/bigtable/internal/transport/pacemaker_test.go
@@ -37,6 +37,76 @@ func findPacemakerMetric(rm metricdata.ResourceMetrics, name string) (metricdata
 	return metricdata.Metrics{}, false
 }
 
+// sumPacemakerDelays returns the total of every recorded pacemaker_delays
+// value, in microseconds, along with the number of recordings.
+func sumPacemakerDelays(t *testing.T, reader sdkmetric.Reader) (sum float64, count uint64) {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	m, ok := findPacemakerMetric(rm, "pacemaker_delays")
+	if !ok {
+		t.Fatal("Metric 'pacemaker_delays' not found in exported metrics")
+	}
+	hist, ok := m.Data.(metricdata.Histogram[float64])
+	if !ok {
+		t.Fatalf("Metric data type mismatch: expected Histogram[float64], got %T", m.Data)
+	}
+	for _, dp := range hist.DataPoints {
+		sum += dp.Sum
+		count += dp.Count
+	}
+	return sum, count
+}
+
+// The delay reported for a tick is how late the goroutine was to handle it,
+// measured against the time the tick was due. In particular it does not depend
+// on the previous tick, so starvation shorter than one full interval -- which
+// drops no ticks at all -- is still reported.
+func TestPacemakerRecordTick(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		late   time.Duration
+		wantUs float64
+	}{
+		{name: "on time", late: 0, wantUs: 0},
+		{name: "later than a tick interval", late: 250 * time.Millisecond, wantUs: 250000},
+		{name: "shorter than a tick interval", late: 20 * time.Millisecond, wantUs: 20000},
+		{name: "sub-millisecond", late: 300 * time.Microsecond, wantUs: 300},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reader := sdkmetric.NewManualReader()
+			pm := NewPacemaker(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)), log.New(io.Discard, "", 0))
+
+			now := time.Now()
+			pm.recordTick(context.Background(), now.Add(-tc.late), now)
+
+			got, count := sumPacemakerDelays(t, reader)
+			if count != 1 {
+				t.Fatalf("recorded %d values, want 1", count)
+			}
+			if got != tc.wantUs {
+				t.Errorf("delay = %vus, want %vus", got, tc.wantUs)
+			}
+		})
+	}
+}
+
+// A clock that runs backwards between the due time and the read must not
+// record a negative delay into the histogram.
+func TestPacemakerRecordTickNeverNegative(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	pm := NewPacemaker(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)), log.New(io.Discard, "", 0))
+
+	now := time.Now()
+	pm.recordTick(context.Background(), now.Add(time.Second), now)
+
+	if got, _ := sumPacemakerDelays(t, reader); got != 0 {
+		t.Errorf("delay = %vus, want 0", got)
+	}
+}
+
 func TestPacemakerExporting(t *testing.T) {
 	reader := sdkmetric.NewManualReader()
 	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))


### PR DESCRIPTION
## The bug

`Pacemaker` is meant to report how long its goroutine waits to be scheduled, as a proxy for CPU contention. It computed that as the gap between consecutive tick timestamps, minus the interval:

```go
actualInterval := t.Sub(lastTick)
delay := actualInterval - interval
```

`t` is not the delivery time. `time.sendTime` backdates every tick to the time it was *due*, and the runtime's own comment says why:

```go
// delta is how long ago the channel send was supposed to happen.
// The current time can be arbitrarily far into the future, because the runtime
// can delay a sendTime call until a goroutine tries to receive from
// the channel. Subtract delta to go back to the old time that we used to send.
case c.(chan Time) <- Now().Add(Duration(-delta)):
```

Consecutive due times are exactly one interval apart by construction, so `actualInterval - interval` is zero unless the runtime drops a tick outright. The metric could only see starvation lasting longer than a full 100ms interval, and only in 100ms steps — meaning its eight bucket boundaries below 100ms (100us through 50ms) recorded nothing but timer jitter.

Measured with 32 CPU-bound goroutines on `GOMAXPROCS=1`, comparing what the code recorded against the goroutine's true wait:

```
tick   as-written    receive-vs-due
0      0s            16ms
1      0s            17ms
2      439ns         18ms
3      0s            19ms
4      0s            20ms
...
as-written recorded exactly 0 on 15/30 ticks
```

Up to 20ms of real scheduling delay, reported as 573ns at worst.

## The fix

Compare the due time against the time we actually read the tick. Since the channel value *is* the due time, that difference is the scheduling delay directly — no dependence on dropped ticks, no quantization by the interval. Under the same 32-goroutine workload the metric now reports a mean of **8.7ms**.

The computation moves into a `recordTick` method so the semantics can be tested without timing dependence.

## Note for reviewers

This changes what an existing exported metric reports: `pacemaker_delays` will go from near-zero to real values on any contended client. That is the point of the change, but if anything alerts on this metric today, the thresholds were calibrated against a signal that was always ~0 and will need revisiting.

## Testing

- `TestPacemakerRecordTick` — table test pinning the semantics, including the case the old code could not represent (starvation shorter than one interval, which drops no ticks).
- `TestPacemakerRecordTickNeverNegative` — a due time in the future records 0, not a negative sample.
- Existing `TestPacemakerExporting` still passes; full `go test -race ./internal/transport/` green.