### PR TITLE
feat(bigtable): serve grpc.health.v1.Health from the accelerator daemon

### DIFF
--- a/bigtable/internal/accelerator/health_test.go
+++ b/bigtable/internal/accelerator/health_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package accelerator
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// startHealthTestServer boots a daemon on a temp UDS and returns a client for
+// its health service. The zero-value Channel is deliberate: a health RPC must
+// never reach the Channel, so leaving it unusable means a regression in the
+// isProxied gate shows up as a failure here rather than as a passing test that
+// quietly forwarded the probe to Bigtable.
+func startHealthTestServer(t *testing.T) (healthpb.HealthClient, *Server) {
+	t.Helper()
+	udsPath := filepath.Join(t.TempDir(), "bt_proxy.sock")
+
+	server := NewServer(udsPath, &Channel{}, WithStdinReader(nil))
+	if err := server.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(server.Stop)
+
+	conn, err := grpc.NewClient("unix://"+udsPath, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	return healthpb.NewHealthClient(conn), server
+}
+
+// A unary RPC on a locally-served service reaches its real handler. Without the
+// isProxied gate the proxy interceptor would swallow this and try to forward it
+// to Bigtable, since it never calls the next handler.
+func TestServer_HealthCheck(t *testing.T) {
+	client, _ := startHealthTestServer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := client.Check(ctx, &healthpb.HealthCheckRequest{})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if resp.GetStatus() != healthpb.HealthCheckResponse_SERVING {
+		t.Errorf("status = %v, want SERVING", resp.GetStatus())
+	}
+}
+
+// The same, for the streaming half of the gate: Health/Watch is a locally
+// served server-streaming method, so proxyStreamInterceptor must hand it off
+// rather than opening a Channel stream for it.
+func TestServer_HealthWatch(t *testing.T) {
+	client, _ := startHealthTestServer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	stream, err := client.Watch(ctx, &healthpb.HealthCheckRequest{})
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv: %v", err)
+	}
+	if resp.GetStatus() != healthpb.HealthCheckResponse_SERVING {
+		t.Errorf("first status = %v, want SERVING", resp.GetStatus())
+	}
+}
+
+// A caller watching the daemon is told it is going away, rather than being left
+// to infer it from the connection dropping.
+func TestServer_HealthNotServingOnStop(t *testing.T) {
+	client, server := startHealthTestServer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	stream, err := client.Watch(ctx, &healthpb.HealthCheckRequest{})
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	if resp, err := stream.Recv(); err != nil {
+		t.Fatalf("Recv (initial): %v", err)
+	} else if resp.GetStatus() != healthpb.HealthCheckResponse_SERVING {
+		t.Fatalf("first status = %v, want SERVING", resp.GetStatus())
+	}
+
+	go server.Stop()
+
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv (after Stop): %v", err)
+	}
+	if resp.GetStatus() != healthpb.HealthCheckResponse_NOT_SERVING {
+		t.Errorf("status after Stop = %v, want NOT_SERVING", resp.GetStatus())
+	}
+}
+
+func TestIsProxied(t *testing.T) {
+	for _, tc := range []struct {
+		method string
+		want   bool
+	}{
+		{"/google.bigtable.v2.Bigtable/ReadRows", true},
+		{"/google.bigtable.v2.Bigtable/MutateRow", true},
+		{"/grpc.health.v1.Health/Check", false},
+		{"/grpc.health.v1.Health/Watch", false},
+		{"/grpc.reflection.v1.ServerReflection/ServerReflectionInfo", false},
+		// The trailing slash in the prefix is load-bearing: a different service
+		// whose name merely starts with "Bigtable" is not ours to forward.
+		{"/google.bigtable.v2.BigtableAdmin/CreateTable", false},
+		// Admin lives under a different package entirely and is not proxied.
+		{"/google.bigtable.admin.v2.BigtableTableAdmin/CreateTable", false},
+		{"", false},
+		{"/", false},
+		{"/google.bigtable.v2.Bigtable", false},
+	} {
+		if got := isProxied(tc.method); got != tc.want {
+			t.Errorf("isProxied(%q) = %v, want %v", tc.method, got, tc.want)
+		}
+	}
+}

--- a/bigtable/internal/accelerator/health_test.go
+++ b/bigtable/internal/accelerator/health_test.go
@@ -21,8 +21,11 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 // startHealthTestServer boots a daemon on a temp UDS and returns a client for
@@ -116,6 +119,74 @@ func TestServer_HealthNotServingOnStop(t *testing.T) {
 	if resp.GetStatus() != healthpb.HealthCheckResponse_NOT_SERVING {
 		t.Errorf("status after Stop = %v, want NOT_SERVING", resp.GetStatus())
 	}
+}
+
+// The handshake token gates the health service too, deliberately — see
+// authUnaryInterceptor for why those interceptors do not take the !isProxied
+// short-circuit the proxy interceptors do. This test pins that: the shipped
+// daemon always reads a secret, so this, not the auth-less servers the other
+// tests here use, is how health actually runs in production.
+func TestServer_HealthRequiresAuthToken(t *testing.T) {
+	udsPath := filepath.Join(t.TempDir(), "bt_proxy.sock")
+
+	const secret = "correct-secret-token"
+	server, stdinW := newServerWithSecret(t, udsPath, secret)
+	defer stdinW.Close()
+	defer server.Stop()
+
+	conn, err := grpc.NewClient("unix://"+udsPath, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	defer conn.Close()
+	client := healthpb.NewHealthClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	authed := metadata.NewOutgoingContext(ctx, metadata.Pairs("x-accelerator-token", secret))
+
+	// Unary: authUnaryInterceptor. A rejected handshake surfaces as Internal,
+	// not Unauthenticated — see checkAuthToken.
+	t.Run("Check", func(t *testing.T) {
+		if _, err := client.Check(ctx, &healthpb.HealthCheckRequest{}); status.Code(err) != codes.Internal {
+			t.Errorf("without token: got %v, want Internal", status.Code(err))
+		}
+		resp, err := client.Check(authed, &healthpb.HealthCheckRequest{})
+		if err != nil {
+			t.Fatalf("with token: %v", err)
+		}
+		if resp.GetStatus() != healthpb.HealthCheckResponse_SERVING {
+			t.Errorf("status = %v, want SERVING", resp.GetStatus())
+		}
+	})
+
+	// Streaming: authStreamInterceptor. Health/Watch is the only server-streaming
+	// method the daemon serves locally, so without this case the streaming half
+	// of the auth chain is never exercised by any test. Note the rejection lands
+	// on Recv, not on Watch: gRPC does not round-trip to the server until the
+	// stream is read.
+	t.Run("Watch", func(t *testing.T) {
+		stream, err := client.Watch(ctx, &healthpb.HealthCheckRequest{})
+		if err != nil {
+			t.Fatalf("without token, Watch: %v", err)
+		}
+		if _, err := stream.Recv(); status.Code(err) != codes.Internal {
+			t.Errorf("without token, Recv: got %v, want Internal", status.Code(err))
+		}
+
+		stream, err = client.Watch(authed, &healthpb.HealthCheckRequest{})
+		if err != nil {
+			t.Fatalf("with token, Watch: %v", err)
+		}
+		resp, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("with token, Recv: %v", err)
+		}
+		if resp.GetStatus() != healthpb.HealthCheckResponse_SERVING {
+			t.Errorf("status = %v, want SERVING", resp.GetStatus())
+		}
+	})
 }
 
 func TestIsProxied(t *testing.T) {

--- a/bigtable/internal/accelerator/interceptors.go
+++ b/bigtable/internal/accelerator/interceptors.go
@@ -125,6 +125,27 @@ func authFailure(reason string) error {
 	return status.Error(codes.Internal, authRejectMsg)
 }
 
+// bigtableMethodPrefix is the "/<service>/" prefix every RPC the daemon
+// proxies to Bigtable carries. Derived from the generated service descriptor
+// so it cannot drift from the registered service name.
+var bigtableMethodPrefix = "/" + btpb.Bigtable_ServiceDesc.ServiceName + "/"
+
+// isProxied reports whether fullMethod should be forwarded through the Channel
+// to Bigtable, as opposed to being served locally by this process.
+//
+// The proxy interceptors are chained onto the whole server, so without this
+// gate they would swallow every RPC of every registered service -- they never
+// invoke the next handler. Any locally-served service (the health service, and
+// anything added later) therefore has to be excluded here or its RPCs get
+// forwarded to Bigtable, which has never heard of them.
+//
+// The test is deliberately "is this Bigtable?" rather than "is this one of the
+// known-local services": a service we forgot to list then fails with gRPC's own
+// Unimplemented instead of being silently shipped to the backend.
+func isProxied(fullMethod string) bool {
+	return strings.HasPrefix(fullMethod, bigtableMethodPrefix)
+}
+
 // proxyUnaryInterceptor intercepts every incoming unary RPC, allocates the
 // correct response message via the global proto registry, and delegates to the
 // channel's Invoke. The single switch on method name lives in
@@ -134,8 +155,13 @@ func authFailure(reason string) error {
 // effect of importing btpb (the generated init() in the btpb package does the
 // registration), so any RPC defined in the v2 Bigtable service is resolvable
 // without per-method wiring here.
+//
+// Non-Bigtable RPCs are passed to their real handler -- see isProxied.
 func proxyUnaryInterceptor(channel *Channel) grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, _ grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		if !isProxied(info.FullMethod) {
+			return handler(ctx, req)
+		}
 		_, output, err := resolveMethodIO(info.FullMethod)
 		if err != nil {
 			return nil, err
@@ -159,8 +185,17 @@ func proxyUnaryInterceptor(channel *Channel) grpc.UnaryServerInterceptor {
 // Only server-streaming RPCs are handled. Client-streaming and bidi RPCs are
 // rejected with Unimplemented because no Channel method shape
 // supports them today.
+//
+// Non-Bigtable streams are passed to their real handler -- see isProxied. That
+// check comes before the client-streaming rejection below, which is scoped to
+// methods this proxy is actually responsible for: grpc.health.v1.Health/Watch
+// is a legitimate server-streaming method served locally, and a locally-served
+// client-streaming method would be the local handler's business, not ours.
 func proxyStreamInterceptor(channel *Channel) grpc.StreamServerInterceptor {
-	return func(_ interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, _ grpc.StreamHandler) error {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if !isProxied(info.FullMethod) {
+			return handler(srv, ss)
+		}
 		if info.IsClientStream {
 			return status.Errorf(codes.Unimplemented, "accelerator: client-streaming method %s not supported", info.FullMethod)
 		}

--- a/bigtable/internal/accelerator/interceptors.go
+++ b/bigtable/internal/accelerator/interceptors.go
@@ -52,6 +52,24 @@ func newBigtableServerStub() *bigtableServerStub {
 // was read from stdin (see Server.Start); the shipped daemon always reads one,
 // so auth is disabled only in test mode (WithStdinReader(nil)). Mismatches are
 // rejected with codes.Internal (see checkAuthToken for why not Unauthenticated).
+//
+// "Every RPC" is literal, and deliberately so: unlike the proxy interceptors
+// below, this one does not exempt locally-served services via isProxied, even
+// though the health service is served locally. The two interceptors read the
+// same predicate in opposite safety directions. There, a false means "do not
+// forward this to Bigtable" and an unrecognised method falls through to gRPC's
+// own Unimplemented — a loud, harmless failure. Here, a false would mean "serve
+// this without a token", so an unrecognised method would be served unauthenticated.
+// Since isProxied is a Bigtable-prefix test, every service registered later is
+// unrecognised by construction, and would be un-gated by default rather than by
+// decision.
+//
+// Nothing is lost by gating health, either: the token is not a Bigtable
+// credential but a caller-identity check on the socket, and the only legitimate
+// caller — the process that spawned this daemon — builds its health stub on the
+// same connection as its data RPCs and so already attaches the token. Gating it
+// also means a foreign daemon left on a reused socket path fails our probe
+// closed, rather than answering SERVING for a process we are not using.
 func authUnaryInterceptor(secret string) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		if err := checkAuthToken(ctx, secret); err != nil {

--- a/bigtable/internal/accelerator/server.go
+++ b/bigtable/internal/accelerator/server.go
@@ -35,6 +35,8 @@ import (
 
 	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 // defaultHandshakeTimeout bounds how long Start waits for the parent process to
@@ -63,6 +65,7 @@ type Server struct {
 	stdinBuf     *bufio.Reader // wraps stdinReader once in Start(); shared by readSecret + monitorStdin
 	authSecret   string
 	channel      *Channel
+	health       *health.Server
 
 	handshakeTimeout time.Duration // bounds readSecret; defaults to defaultHandshakeTimeout, override with WithHandshakeTimeout.
 }
@@ -181,6 +184,26 @@ func (s *Server) Start() error {
 	// gRPC's registration contract.
 	btpb.RegisterBigtableServer(s.grpcServer, s.service)
 
+	// Register the standard health service. Unlike the Bigtable stub above this
+	// one is served locally -- isProxied keeps the proxy interceptors off it.
+	//
+	// What it is for: the caller needs a way to ask "is the daemon up and
+	// responsive?" that neither consumes a session nor touches the backend. The
+	// latency of a Check is therefore almost entirely this process's own
+	// scheduling delay, which is what makes it a usable starvation signal; the
+	// latency of a real RPC would fold in Bigtable's latency and the network and
+	// tell the caller much less.
+	//
+	// Note the status is a liveness statement, not a load assessment: we report
+	// SERVING whenever the server is up, and leave "is it fast enough?" to the
+	// caller, which can time its own probes. Self-declaring NOT_SERVING under
+	// load would be guesswork against a threshold we cannot pick correctly from
+	// in here, and the client's fallback breaker is permanent -- a daemon that
+	// briefly called itself unhealthy would be abandoned for good.
+	s.health = health.NewServer()
+	healthpb.RegisterHealthServer(s.grpcServer, s.health)
+	s.health.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+
 	go func() {
 		// Serve returns ErrServerStopped on a clean GracefulStop/Stop; anything
 		// else means the server fell over after a successful Listen (e.g. the
@@ -214,6 +237,15 @@ func (s *Server) Start() error {
 func (s *Server) Stop() {
 	s.stopOnce.Do(func() {
 		close(s.shutdownChan)
+
+		// Flip to NOT_SERVING before draining so a caller probing mid-shutdown
+		// gets an honest answer instead of a SERVING reply from a server that is
+		// about to stop accepting RPCs. health.Server.Shutdown also latches, so
+		// any Watch stream still open is notified and later SetServingStatus
+		// calls cannot revive it.
+		if s.health != nil {
+			s.health.Shutdown()
+		}
 
 		if s.grpcServer != nil {
 			// GracefulStop blocks until all in-flight RPCs finish. A wedged or


### PR DESCRIPTION
## Why

The daemon offered its caller no way to ask "are you up and responsive?". The only probe available was a real Bigtable RPC, which consumes a session and whose latency is dominated by the backend and the network — so it says very little about the daemon itself.

A locally-served health check has the opposite property: nothing in a `Check` touches the Channel, a session, or the network, so its latency is almost entirely this process's own scheduling delay. That is what makes it a usable signal for a daemon that has been starved of CPU.

## What

- Register the standard `grpc.health.v1.Health` service. `SERVING` while up, `NOT_SERVING` once `Stop` begins draining, so a caller on `Watch` is told the daemon is going away rather than inferring it from a dropped connection.
- Gate the proxy interceptors with `isProxied`.

The gate is the load-bearing part. `proxyUnaryInterceptor` and `proxyStreamInterceptor` are chained onto the whole server and **never invoke the next handler** — they answer every RPC out of the Channel. So before this change, registering *any* locally-served service would have had its RPCs forwarded to Bigtable. Confirmed by neutering the gate and re-running the new tests:

```
--- FAIL: TestServer_HealthCheck
    Check: rpc error: code = Unimplemented desc = accelerator: method /grpc.health.v1.Health/Check not implemented
--- FAIL: TestServer_HealthWatch
    Recv: rpc error: code = Unimplemented desc = accelerator: streaming method /grpc.health.v1.Health/Watch not implemented
```

`isProxied` is written as "is this a Bigtable method?" rather than as a list of local services to skip, so a service we forget to list fails with gRPC's own `Unimplemented` instead of being silently shipped to a backend that has never heard of it. The trailing slash in the prefix is deliberate and tested — `/google.bigtable.v2.BigtableAdmin/...` must not match.

## What this deliberately does *not* do

The status is a **liveness statement, not a load assessment**. The daemon does not declare itself `NOT_SERVING` when it is slow, for two reasons:

1. There is no threshold we can pick correctly from inside the daemon. The caller can time its own probes and apply whatever policy suits it.
2. The client-side fallback breaker is **permanent** (`AcceleratorBreaker.trip()` in the Python SDK has no recovery path). A daemon that briefly called itself unhealthy — one GC pause — would be abandoned for the remaining lifetime of the table.

Making the breaker windowed and recoverable is a prerequisite for any automatic latency-based fallback, and belongs on the Python side. This change supplies the mechanism; the policy is a separate decision.

## Dependencies

None added. `google.golang.org/grpc/health` is a subpackage of `google.golang.org/grpc`, already a direct requirement. `go.mod`/`go.sum` are untouched.

## Testing

- `TestServer_HealthCheck` / `TestServer_HealthWatch` — end-to-end over the real UDS, covering both the unary and streaming halves of the gate. They use a zero-value `Channel` on purpose: a health RPC must never reach the Channel, so a regression surfaces as a failure rather than a quietly-forwarded probe.
- `TestServer_HealthNotServingOnStop` — a `Watch` stream observes the `NOT_SERVING` transition.
- `TestIsProxied` — table test including the `BigtableAdmin` prefix-lookalike and empty/degenerate method names.
- Full `go test -race ./internal/accelerator/...` green; darwin cross-build OK.