### PR TITLE
chore: temporarily disable staticcheck

### DIFF
--- a/.github/workflows/vet.sh
+++ b/.github/workflows/vet.sh
@@ -79,12 +79,13 @@ golint ./... 2>&1 | (
 ) |
   tee /dev/stderr | (! read)
 
-staticcheck -go 1.25 ./... 2>&1 | (
-  grep -v SA1019 |
-    grep -v internal/btree/btree.go |
-    grep -v httpreplay/internal/proxy/debug.go |
-    grep -v third_party/pkgsite/synopsis.go
-) |
-  tee /dev/stderr | (! read)
+# TODO: re-enable after go127 migration
+#staticcheck -go 1.25 ./... 2>&1 | (
+#  grep -v SA1019 |
+#    grep -v internal/btree/btree.go |
+#    grep -v httpreplay/internal/proxy/debug.go |
+#    grep -v third_party/pkgsite/synopsis.go
+#) |
+#  tee /dev/stderr | (! read)
 
 echo "Done vetting!"


### PR DESCRIPTION
This PR disables staticcheck, there's a bad interaction with go 1.27 we're still working through.