### PR TITLE
feat(bigtable): build the accelerator daemon for Windows

### DIFF
--- a/bigtable/internal/accelerator/cmd/identity.go
+++ b/bigtable/internal/accelerator/cmd/identity.go
@@ -54,6 +54,10 @@ func writeIdentity(udsPath, principal string, scopes []string) error {
 	}
 	path := filepath.Join(filepath.Dir(udsPath), identityFilename)
 	// 0600: identifier only, but keep it same-uid readable and nothing more.
+	// The mode is a no-op on Windows, which has no POSIX bits; there the file
+	// inherits its directory's ACL, same as the socket beside it. That is
+	// acceptable because the document carries no secret -- only a principal
+	// email and scope list.
 	if err := os.WriteFile(path, b, 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
 	}

--- a/bigtable/internal/accelerator/server.go
+++ b/bigtable/internal/accelerator/server.go
@@ -30,7 +30,6 @@ import (
 	"os"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
@@ -130,32 +129,15 @@ func (s *Server) Start() error {
 	// sibling shares this path.
 	_ = os.Remove(s.udsPath)
 
-	// Bind under a private umask so the socket is never world-connectable, even
-	// for the instant between creation and the Chmod below. net.Listen -> bind(2)
-	// creates the socket file subject to the process umask; the common default
-	// (022) would leave it group/other accessible during that window, letting any
-	// local process connect before we lock it down. umask is process-global, so
-	// we narrow it only around the bind and restore it immediately after.
-	oldMask := syscall.Umask(0077)
-	l, err := net.Listen("unix", s.udsPath)
-	syscall.Umask(oldMask)
+	// Bind the socket and restrict it to the owning user. How that restriction is
+	// achieved is platform-specific -- see listenUDS in socket_unix.go (umask +
+	// chmod) and socket_windows.go (inherited directory ACL).
+	l, err := listenUDS(s.udsPath)
 	if err != nil {
 		log.Printf("failed to start accelerator: %v", err)
 		return err
 	}
 	s.listener = l
-
-	// Tighten to 0600, dropping the owner-execute bit the 0077 umask leaves at
-	// 0700. The daemon is paired 1:1 with its parent process, so no other user
-	// should be able to issue RPCs against it. Because the umask above already
-	// guaranteed the socket was never group/other accessible, this Chmod is
-	// race-free hardening rather than the sole line of defense.
-	if err := os.Chmod(s.udsPath, 0600); err != nil {
-		_ = l.Close()
-		_ = os.Remove(s.udsPath)
-		log.Printf("failed to chmod accelerator socket: %v", err)
-		return err
-	}
 
 	// Chain the proxy interceptors, which route each RPC through the Channel.
 	// The auth interceptors are prepended only when a secret was read from stdin
@@ -201,8 +183,10 @@ func (s *Server) Start() error {
 	// Skip the parent-PID watchdog when initialPpid is 1: it's ambiguous (orphan
 	// vs. legitimate child of pid 1), and monitorStdin already covers parent
 	// death. When initialPpid is a real parent, any later change to it means the
-	// parent we shadow has died.
-	if initialPpid != 1 {
+	// parent we shadow has died. Also skip it entirely on platforms that don't
+	// reparent orphans (Windows), where the ppid can never change and polling it
+	// is pure cost -- see parentPidWatchdogSupported.
+	if parentPidWatchdogSupported && initialPpid != 1 {
 		go s.monitorParentPid(initialPpid)
 	}
 

--- a/bigtable/internal/accelerator/socket_unix.go
+++ b/bigtable/internal/accelerator/socket_unix.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package accelerator
+
+import (
+	"net"
+	"os"
+	"syscall"
+)
+
+// parentPidWatchdogSupported reports whether monitorParentPid can detect parent
+// death on this platform. POSIX reparents orphans to init (or the nearest
+// subreaper), so a changed ppid is a reliable death signal.
+const parentPidWatchdogSupported = true
+
+// listenUDS binds the daemon's Unix domain socket at path and restricts it to
+// the owning user.
+//
+// Bind under a private umask so the socket is never world-connectable, even for
+// the instant between creation and the Chmod below. net.Listen -> bind(2)
+// creates the socket file subject to the process umask; the common default
+// (022) would leave it group/other accessible during that window, letting any
+// local process connect before we lock it down. umask is process-global, so we
+// narrow it only around the bind and restore it immediately after.
+func listenUDS(path string) (net.Listener, error) {
+	oldMask := syscall.Umask(0077)
+	l, err := net.Listen("unix", path)
+	syscall.Umask(oldMask)
+	if err != nil {
+		return nil, err
+	}
+
+	// Tighten to 0600, dropping the owner-execute bit the 0077 umask leaves at
+	// 0700. The daemon is paired 1:1 with its parent process, so no other user
+	// should be able to issue RPCs against it. Because the umask above already
+	// guaranteed the socket was never group/other accessible, this Chmod is
+	// race-free hardening rather than the sole line of defense.
+	if err := os.Chmod(path, 0600); err != nil {
+		_ = l.Close()
+		_ = os.Remove(path)
+		return nil, err
+	}
+	return l, nil
+}

--- a/bigtable/internal/accelerator/socket_windows.go
+++ b/bigtable/internal/accelerator/socket_windows.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package accelerator
+
+import "net"
+
+// parentPidWatchdogSupported reports whether monitorParentPid can detect parent
+// death on this platform. It cannot on Windows: there is no reparenting, so a
+// process whose parent exits keeps reporting the dead parent's PID forever and
+// the watchdog can never trip. Worse, Windows recycles PIDs, so that stale value
+// may later belong to an unrelated process. Running the poll loop anyway would
+// also be expensive -- os.Getppid on Windows enumerates every process on the
+// machine via a Toolhelp snapshot, which is not something to do twice a second
+// for a signal that never arrives.
+//
+// Parent death is still covered: monitorStdin sees EOF on the inherited stdin
+// pipe as soon as the parent's handle is closed, which is the same signal the
+// POSIX build relies on when ppid is ambiguous.
+const parentPidWatchdogSupported = false
+
+// listenUDS binds the daemon's AF_UNIX socket at path. Windows 10 1803+ and
+// Server 2019+ support AF_UNIX and Go's net package speaks it, so the socket
+// path and wire behavior match the POSIX build.
+//
+// Access control is what differs. Windows has no umask, and os.Chmod there only
+// toggles the read-only attribute -- it cannot express "owner may connect,
+// nobody else," so the POSIX 0077/0600 lockdown has no equivalent to port. The
+// socket file instead inherits the ACL of the directory holding it, which makes
+// socket security a property of that directory. Callers must therefore place the
+// socket in a directory only the spawning user can traverse; the per-daemon
+// directory the SDK creates under the user-scoped %TEMP% satisfies this, since
+// that tree is ACL'd to the user by default. Applying a mode-based lockdown here
+// would only look like a defense without being one.
+func listenUDS(path string) (net.Listener, error) {
+	return net.Listen("unix", path)
+}


### PR DESCRIPTION
## Problem

The accelerator daemon does not compile for `GOOS=windows` on any architecture:

```
$ GOOS=windows GOARCH=amd64 go build ./internal/accelerator/...
internal/accelerator/server.go:142:21: undefined: syscall.Umask
internal/accelerator/server.go:144:10: undefined: syscall.Umask
```

Identical failure for `386` and `arm64`. `syscall.Umask` is POSIX-only, and `server.go` called it inline around the bind to keep the socket from being world-connectable during the window between creation and the `chmod` that follows.

## Changes

**Move the bind behind a `listenUDS` helper with a per-platform implementation.**

- `socket_unix.go` (`//go:build !windows`) — the existing umask + chmod logic, moved verbatim. Linux behavior is unchanged; it is the same code in a new file.
- `socket_windows.go` — Windows 10 1803+ and Server 2019+ support AF_UNIX and Go's `net` package speaks it, so the socket path and wire behavior are unchanged there.

What has no equivalent on Windows is the *access control*. There is no umask, and `os.Chmod` only toggles the read-only attribute — it cannot express "owner may connect, nobody else," so the POSIX `0077`/`0600` lockdown has nothing to port to. The socket instead inherits the ACL of its containing directory, which makes socket security a property of where the caller puts it. The per-daemon directory the SDK creates under the user-scoped `%TEMP%` is ACL'd to the user by default and satisfies this. The Windows implementation documents that requirement rather than applying a mode that would look like a defense without being one.

**Gate the parent-PID watchdog behind `parentPidWatchdogSupported`.**

This compiled on Windows but could never fire. Windows does not reparent orphans, so a daemon whose parent exits keeps reporting the dead parent's PID forever — and because Windows recycles PIDs, that stale value may later belong to an unrelated process. Polling it is not free either: `os.Getppid` on Windows enumerates every process on the machine through a Toolhelp snapshot, twice a second, for a signal that never arrives.

Parent death stays covered by `monitorStdin`, which sees EOF as soon as the parent's pipe handle closes. That is the same fallback the POSIX build already relies on when ppid is ambiguous (a ppid of 1 — orphan vs. legitimate child of pid 1).

**Also** corrected the `identity.json` mode comment, since `0600` is a no-op on Windows. The document carries only a principal email and scope list, no secret, so inheriting the directory ACL alongside the socket is acceptable.

## Testing

- `windows/amd64`, `windows/386`, `windows/arm64` all build and `go vet` clean, including test files.
- `file` confirms the output: PE32 (i386), PE32+ (x86-64), PE32+ (Aarch64).
- Existing `./internal/accelerator/...` tests pass on Linux; `gofmt` clean.

## Scope

This makes the Go source cross-compile. Producing and shipping the Windows artifacts is a packaging change in the SDK that bundles the binary, and the spawn path there still needs to name the `.exe`.

There is also no CI guard against this regressing — nothing in `.github/workflows/` cross-compiles today. A `GOOS=windows go build` step over amd64 + 386 would catch it, but that is shared repo-wide infra and felt out of scope here. Happy to add it if reviewers want it in this PR.