### PR TITLE
feat(bigtable/bttest): honor the table's timestamp granularity

### DIFF
--- a/bigtable/bttest/inmem.go
+++ b/bigtable/bttest/inmem.go
@@ -1222,11 +1222,9 @@ func applyMutations(tbl *table, r *row, muts []*btpb.Mutation, fs map[string]*co
 			if cf.valueType == nil || cf.valueType.GetAggregateType() == nil {
 				return fmt.Errorf("illegal attempt to use AddToCell on non-aggregate cell")
 			}
+			// The timestamp must be non-negative and match the table's
+			// granularity.
 			ts := add.Timestamp.GetRawTimestampMicros()
-			if ts < 0 {
-				return fmt.Errorf("AddToCell must set timestamp >= 0")
-			}
-			// The timestamp must match the table's granularity.
 			if !tbl.validTimestamp(ts) {
 				return tbl.invalidTimestampError(ts)
 			}
@@ -1255,11 +1253,9 @@ func applyMutations(tbl *table, r *row, muts []*btpb.Mutation, fs map[string]*co
 			if cf.valueType == nil || cf.valueType.GetAggregateType() == nil {
 				return fmt.Errorf("illegal attempt to use MergeToCell on non-aggregate cell")
 			}
+			// The timestamp must be non-negative and match the table's
+			// granularity.
 			ts := add.Timestamp.GetRawTimestampMicros()
-			if ts < 0 {
-				return fmt.Errorf("MergeToCell must set timestamp >= 0")
-			}
-			// The timestamp must match the table's granularity.
 			if !tbl.validTimestamp(ts) {
 				return tbl.invalidTimestampError(ts)
 			}
@@ -1297,7 +1293,7 @@ func applyMutations(tbl *table, r *row, muts []*btpb.Mutation, fs map[string]*co
 						return tbl.invalidTimestampError(tsr.EndTimestampMicros)
 					}
 					if tsr.StartTimestampMicros >= tsr.EndTimestampMicros && tsr.EndTimestampMicros != 0 {
-						return fmt.Errorf("inverted or invalid timestamp range [%d, %d]", tsr.StartTimestampMicros, tsr.EndTimestampMicros)
+						return status.Errorf(codes.InvalidArgument, "inverted or invalid timestamp range [%d, %d]", tsr.StartTimestampMicros, tsr.EndTimestampMicros)
 					}
 
 					// Find half-open interval to remove.
@@ -1695,7 +1691,7 @@ func (t *table) invalidTimestampError(ts int64) error {
 // It is used for server-side (client-unspecified) timestamps, which are
 // truncated rather than rejected.
 func (t *table) newTimestamp() int64 {
-	ts := time.Now().UnixNano() / 1e3
+	ts := time.Now().UnixMicro()
 	unit := t.timestampUnit()
 	return ts - ts%unit
 }

--- a/bigtable/bttest/inmem.go
+++ b/bigtable/bttest/inmem.go
@@ -89,6 +89,11 @@ const (
 	// Must match the max value of type TimestampMicros (int64)
 	// truncated to the millis granularity by subtracting a remainder of 1000.
 	maxValidMilliSeconds = math.MaxInt64 - math.MaxInt64%1000
+
+	// Number of microseconds in the smallest representable unit of each
+	// supported table timestamp granularity.
+	microsPerMilli = 1000
+	microsPerMicro = 1
 )
 
 var validLabelTransformer = regexp.MustCompile(`[a-z0-9\-]{1,15}`)
@@ -203,24 +208,27 @@ func (s *Server) Close() {
 func (s *server) CreateTable(ctx context.Context, req *btapb.CreateTableRequest) (*btapb.Table, error) {
 	tbl := req.Parent + "/tables/" + req.TableId
 
+	switch g := req.GetTable().GetGranularity(); g {
+	case btapb.Table_TIMESTAMP_GRANULARITY_UNSPECIFIED, btapb.Table_MILLIS, btapb.Table_MICROS:
+	default:
+		return nil, status.Errorf(codes.InvalidArgument, "unknown timestamp granularity %v", g)
+	}
+
 	s.mu.Lock()
 	if _, ok := s.tables[tbl]; ok {
 		s.mu.Unlock()
 		return nil, status.Errorf(codes.AlreadyExists, "table %q already exists", tbl)
 	}
-	s.tables[tbl] = newTable(req)
+	t := newTable(req)
+	s.tables[tbl] = t
 	s.mu.Unlock()
 
-	ct := &btapb.Table{
+	return &btapb.Table{
 		Name:               tbl,
 		ColumnFamilies:     req.GetTable().GetColumnFamilies(),
-		Granularity:        req.GetTable().GetGranularity(),
+		Granularity:        t.granularity,
 		DeletionProtection: req.GetTable().GetDeletionProtection(),
-	}
-	if ct.Granularity == 0 {
-		ct.Granularity = btapb.Table_MILLIS
-	}
-	return ct, nil
+	}, nil
 }
 
 func (s *server) CreateTableFromSnapshot(context.Context, *btapb.CreateTableFromSnapshotRequest) (*longrunning.Operation, error) {
@@ -255,6 +263,7 @@ func (s *server) GetTable(ctx context.Context, req *btapb.GetTableRequest) (*bta
 	return &btapb.Table{
 		Name:               tbl,
 		ColumnFamilies:     toColumnFamilies(tblIns.columnFamilies()),
+		Granularity:        tblIns.granularity,
 		DeletionProtection: tblIns.isProtected,
 	}, nil
 }
@@ -421,7 +430,7 @@ func (s *server) ModifyColumnFamilies(ctx context.Context, req *btapb.ModifyColu
 	return &btapb.Table{
 		Name:           req.Name,
 		ColumnFamilies: toColumnFamilies(tbl.families),
-		Granularity:    btapb.Table_TimestampGranularity(btapb.Table_MILLIS),
+		Granularity:    tbl.granularity,
 	}, nil
 }
 
@@ -1190,10 +1199,13 @@ func applyMutations(tbl *table, r *row, muts []*btpb.Mutation, fs map[string]*co
 			}
 			ts := set.TimestampMicros
 			if ts == -1 { // bigtable.ServerTime
-				ts = newTimestamp()
+				// Server-side timestamps are generated, not user-provided, so
+				// they are truncated to the table's granularity instead of
+				// being rejected.
+				ts = tbl.newTimestamp()
 			}
 			if !tbl.validTimestamp(ts) {
-				return fmt.Errorf("invalid timestamp %d", ts)
+				return tbl.invalidTimestampError(ts)
 			}
 			fam := set.FamilyName
 			col := string(set.ColumnQualifier)
@@ -1213,6 +1225,10 @@ func applyMutations(tbl *table, r *row, muts []*btpb.Mutation, fs map[string]*co
 			ts := add.Timestamp.GetRawTimestampMicros()
 			if ts < 0 {
 				return fmt.Errorf("AddToCell must set timestamp >= 0")
+			}
+			// The timestamp must match the table's granularity.
+			if !tbl.validTimestamp(ts) {
+				return tbl.invalidTimestampError(ts)
 			}
 
 			fam := add.FamilyName
@@ -1243,6 +1259,10 @@ func applyMutations(tbl *table, r *row, muts []*btpb.Mutation, fs map[string]*co
 			if ts < 0 {
 				return fmt.Errorf("MergeToCell must set timestamp >= 0")
 			}
+			// The timestamp must match the table's granularity.
+			if !tbl.validTimestamp(ts) {
+				return tbl.invalidTimestampError(ts)
+			}
 
 			fam := add.FamilyName
 			col := string(add.GetColumnQualifier().GetRawValue())
@@ -1271,10 +1291,10 @@ func applyMutations(tbl *table, r *row, muts []*btpb.Mutation, fs map[string]*co
 				if del.TimeRange != nil {
 					tsr := del.TimeRange
 					if !tbl.validTimestamp(tsr.StartTimestampMicros) {
-						return fmt.Errorf("invalid timestamp %d", tsr.StartTimestampMicros)
+						return tbl.invalidTimestampError(tsr.StartTimestampMicros)
 					}
 					if !tbl.validTimestamp(tsr.EndTimestampMicros) && tsr.EndTimestampMicros != 0 {
-						return fmt.Errorf("invalid timestamp %d", tsr.EndTimestampMicros)
+						return tbl.invalidTimestampError(tsr.EndTimestampMicros)
 					}
 					if tsr.StartTimestampMicros >= tsr.EndTimestampMicros && tsr.EndTimestampMicros != 0 {
 						return fmt.Errorf("inverted or invalid timestamp range [%d, %d]", tsr.StartTimestampMicros, tsr.EndTimestampMicros)
@@ -1328,12 +1348,6 @@ func maxTimestamp(x, y int64) int64 {
 	return y
 }
 
-func newTimestamp() int64 {
-	ts := time.Now().UnixNano() / 1e3
-	ts -= ts % 1000 // round to millisecond granularity
-	return ts
-}
-
 func appendOrReplaceCell(cs []cell, newCell cell, cf *columnFamily) []cell {
 	replaced := false
 	for i, cell := range cs {
@@ -1384,7 +1398,7 @@ func (s *server) ReadModifyWriteRow(ctx context.Context, req *btpb.ReadModifyWri
 		cs := f.cells[col]
 		isEmpty = len(cs) == 0
 
-		ts := newTimestamp()
+		ts := tbl.newTimestamp()
 		var newCell, prevCell cell
 		if !isEmpty {
 			cells := r.families[fam].cells[col]
@@ -1557,11 +1571,12 @@ func (s *server) gcloop(done <-chan int) {
 
 type table struct {
 	mu          sync.RWMutex
-	counter     uint64                   // increment by 1 when a new family is created
-	families    map[string]*columnFamily // keyed by plain family name
-	rows        *btree.BTree             // indexed by row key
-	partitions  []*btpb.RowRange         // partitions used in change stream
-	isProtected bool                     // whether this table has deletion protection
+	counter     uint64                           // increment by 1 when a new family is created
+	families    map[string]*columnFamily         // keyed by plain family name
+	rows        *btree.BTree                     // indexed by row key
+	partitions  []*btpb.RowRange                 // partitions used in change stream
+	isProtected bool                             // whether this table has deletion protection
+	granularity btapb.Table_TimestampGranularity // timestamp granularity accepted by this table
 }
 
 const btreeDegree = 16
@@ -1626,16 +1641,63 @@ func newTable(ctr *btapb.CreateTableRequest) *table {
 		rows:        btree.New(btreeDegree),
 		partitions:  rowRanges,
 		isProtected: ctr.GetTable().GetDeletionProtection(),
+		granularity: normalizeGranularity(ctr.GetTable().GetGranularity()),
 	}
 }
 
+// normalizeGranularity resolves an unspecified granularity to the default,
+// millisecond granularity.
+func normalizeGranularity(g btapb.Table_TimestampGranularity) btapb.Table_TimestampGranularity {
+	if g == btapb.Table_TIMESTAMP_GRANULARITY_UNSPECIFIED {
+		return btapb.Table_MILLIS
+	}
+	return g
+}
+
+// timestampUnit returns the size, in microseconds, of the smallest timestamp
+// unit the table accepts. Every timestamp stored in the table must be a
+// multiple of it.
+func (t *table) timestampUnit() int64 {
+	if t.granularity == btapb.Table_MICROS {
+		return microsPerMicro
+	}
+	return microsPerMilli
+}
+
+// maxValidTimestamp is the largest timestamp the table accepts: the max value
+// of TimestampMicros (int64) truncated down to the table's granularity.
+func (t *table) maxValidTimestamp() int64 {
+	unit := t.timestampUnit()
+	return math.MaxInt64 - math.MaxInt64%unit
+}
+
 func (t *table) validTimestamp(ts int64) bool {
-	if ts < minValidMilliSeconds || ts > maxValidMilliSeconds {
+	if ts < minValidMilliSeconds || ts > t.maxValidTimestamp() {
 		return false
 	}
 
-	// Assume millisecond granularity is required.
-	return ts%1000 == 0
+	// A microsecond-granularity table accepts any microsecond timestamp; a
+	// millisecond-granularity one only accepts millisecond-aligned values.
+	return ts%t.timestampUnit() == 0
+}
+
+// invalidTimestampError explains why ts is not acceptable for this table.
+func (t *table) invalidTimestampError(ts int64) error {
+	if unit := t.timestampUnit(); ts%unit != 0 && ts >= minValidMilliSeconds && ts <= t.maxValidTimestamp() {
+		return status.Errorf(codes.InvalidArgument,
+			"Timestamp granularity mismatch: timestamp %d is not a multiple of %d microseconds, as required by the table's %s granularity",
+			ts, unit, normalizeGranularity(t.granularity))
+	}
+	return status.Errorf(codes.InvalidArgument, "invalid timestamp %d", ts)
+}
+
+// newTimestamp returns the current time, truncated to the table's granularity.
+// It is used for server-side (client-unspecified) timestamps, which are
+// truncated rather than rejected.
+func (t *table) newTimestamp() int64 {
+	ts := time.Now().UnixNano() / 1e3
+	unit := t.timestampUnit()
+	return ts - ts%unit
 }
 
 func (t *table) columnFamilies() map[string]*columnFamily {

--- a/bigtable/bttest/timestamp_test.go
+++ b/bigtable/bttest/timestamp_test.go
@@ -14,11 +14,16 @@
 package bttest
 
 import (
+	"context"
 	"math"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/bigtable"
+	btapb "cloud.google.com/go/bigtable/admin/apiv2/adminpb"
+	btpb "cloud.google.com/go/bigtable/apiv2/bigtablepb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestTimestampConversion(t *testing.T) {
@@ -48,5 +53,254 @@ func TestTimestampConversion(t *testing.T) {
 	want3 := time.Date(2016, time.October, 3, 14, 7, 7, 0, time.UTC)
 	if !want3.Equal(got3) {
 		t.Errorf("Mismatched time got %v wanted %v", got3, want3)
+	}
+}
+
+// newGranularityServer creates a server holding a single table with the given
+// timestamp granularity, and returns the server and the table's name.
+func newGranularityServer(t *testing.T, g btapb.Table_TimestampGranularity) (*server, string) {
+	t.Helper()
+	s := &server{tables: make(map[string]*table)}
+	tblInfo, err := s.CreateTable(context.Background(), &btapb.CreateTableRequest{
+		Parent:  "cluster",
+		TableId: "t",
+		Table: &btapb.Table{
+			ColumnFamilies: map[string]*btapb.ColumnFamily{"cf": {}},
+			Granularity:    g,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Creating table: %v", err)
+	}
+	if got := tblInfo.Granularity; got != wantGranularity(g) {
+		t.Fatalf("CreateTable granularity: got %v, want %v", got, wantGranularity(g))
+	}
+	return s, tblInfo.Name
+}
+
+func wantGranularity(g btapb.Table_TimestampGranularity) btapb.Table_TimestampGranularity {
+	if g == btapb.Table_TIMESTAMP_GRANULARITY_UNSPECIFIED {
+		return btapb.Table_MILLIS
+	}
+	return g
+}
+
+func setCell(tableName string, ts int64) *btpb.MutateRowRequest {
+	return &btpb.MutateRowRequest{
+		TableName: tableName,
+		RowKey:    []byte("row"),
+		Mutations: []*btpb.Mutation{{
+			Mutation: &btpb.Mutation_SetCell_{SetCell: &btpb.Mutation_SetCell{
+				FamilyName:      "cf",
+				ColumnQualifier: []byte("col"),
+				TimestampMicros: ts,
+				Value:           []byte("v"),
+			}},
+		}},
+	}
+}
+
+// readCellTimestamps returns the timestamps of every cell in the table.
+func readCellTimestamps(t *testing.T, s *server, tableName string) []int64 {
+	t.Helper()
+	mock := &MockReadRowsServer{}
+	if err := s.ReadRows(&btpb.ReadRowsRequest{TableName: tableName}, mock); err != nil {
+		t.Fatalf("ReadRows: %v", err)
+	}
+	var got []int64
+	for _, resp := range mock.responses {
+		for _, chunk := range resp.Chunks {
+			got = append(got, chunk.TimestampMicros)
+		}
+	}
+	return got
+}
+
+// TestSetCellTimestampGranularity checks that a microsecond-granularity table
+// accepts microsecond timestamps while a millisecond-granularity one rejects
+// them.
+func TestSetCellTimestampGranularity(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		desc        string
+		granularity btapb.Table_TimestampGranularity
+		ts          int64
+		wantErr     bool
+	}{
+		{"millis table, millis timestamp", btapb.Table_MILLIS, 2000, false},
+		{"millis table, micros timestamp", btapb.Table_MILLIS, 2001, true},
+		{"micros table, millis timestamp", btapb.Table_MICROS, 2000, false},
+		{"micros table, micros timestamp", btapb.Table_MICROS, 2001, false},
+		{"unspecified table, millis timestamp", btapb.Table_TIMESTAMP_GRANULARITY_UNSPECIFIED, 2000, false},
+		{"unspecified table, micros timestamp", btapb.Table_TIMESTAMP_GRANULARITY_UNSPECIFIED, 2001, true},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			s, name := newGranularityServer(t, tc.granularity)
+			_, err := s.MutateRow(ctx, setCell(name, tc.ts))
+			if gotErr := err != nil; gotErr != tc.wantErr {
+				t.Fatalf("MutateRow(ts=%d) error = %v, wantErr = %v", tc.ts, err, tc.wantErr)
+			}
+			if tc.wantErr {
+				if got := status.Code(err); got != codes.InvalidArgument {
+					t.Errorf("MutateRow error code = %v, want %v", got, codes.InvalidArgument)
+				}
+				return
+			}
+			if got := readCellTimestamps(t, s, name); len(got) != 1 || got[0] != tc.ts {
+				t.Errorf("stored timestamps = %v, want [%d]", got, tc.ts)
+			}
+		})
+	}
+}
+
+// TestMaxTimestampGranularity checks the upper bound on timestamps for each
+// granularity.
+func TestMaxTimestampGranularity(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		desc        string
+		granularity btapb.Table_TimestampGranularity
+		wantMax     int64
+	}{
+		{"millis", btapb.Table_MILLIS, math.MaxInt64 - math.MaxInt64%1000},
+		{"micros", btapb.Table_MICROS, math.MaxInt64},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			s, name := newGranularityServer(t, tc.granularity)
+			if _, err := s.MutateRow(ctx, setCell(name, tc.wantMax)); err != nil {
+				t.Fatalf("MutateRow(ts=%d) unexpected error: %v", tc.wantMax, err)
+			}
+			// One unit past the max overflows int64 and so must be rejected as
+			// a negative timestamp.
+			if _, err := s.MutateRow(ctx, setCell(name, tc.wantMax+1)); err == nil {
+				t.Fatalf("MutateRow(ts=%d) got no error, want rejection", tc.wantMax+1)
+			}
+		})
+	}
+}
+
+// TestServerTimestampIsTruncated checks that server-generated timestamps are
+// truncated to the table's granularity rather than rejected.
+func TestServerTimestampIsTruncated(t *testing.T) {
+	ctx := context.Background()
+
+	// On a millis table, the generated timestamp must be millis-aligned.
+	s, name := newGranularityServer(t, btapb.Table_MILLIS)
+	before := time.Now().UnixNano() / 1e3
+	if _, err := s.MutateRow(ctx, setCell(name, -1)); err != nil {
+		t.Fatalf("MutateRow(ServerTime): %v", err)
+	}
+	after := time.Now().UnixNano() / 1e3
+	got := readCellTimestamps(t, s, name)
+	if len(got) != 1 {
+		t.Fatalf("stored timestamps = %v, want one cell", got)
+	}
+	if got[0]%1000 != 0 {
+		t.Errorf("server timestamp %d is not truncated to millisecond granularity", got[0])
+	}
+	if got[0] < before-1000 || got[0] > after {
+		t.Errorf("server timestamp %d outside [%d, %d]", got[0], before-1000, after)
+	}
+
+	// On a micros table, the generated timestamp keeps microsecond precision.
+	// It is unit-tested directly since a wall-clock reading happens to be
+	// millis-aligned once every thousand times.
+	microsTbl := &table{granularity: btapb.Table_MICROS}
+	if got, want := microsTbl.timestampUnit(), int64(1); got != want {
+		t.Errorf("micros table timestampUnit() = %d, want %d", got, want)
+	}
+	if ts := microsTbl.newTimestamp(); !microsTbl.validTimestamp(ts) {
+		t.Errorf("micros table newTimestamp() = %d, which is not a valid timestamp", ts)
+	}
+}
+
+// TestDeleteFromColumnTimestampGranularity checks that the timestamp range of
+// a DeleteFromColumn mutation is validated against the table's granularity.
+func TestDeleteFromColumnTimestampGranularity(t *testing.T) {
+	ctx := context.Background()
+
+	deleteRange := func(name string, start, end int64) *btpb.MutateRowRequest {
+		return &btpb.MutateRowRequest{
+			TableName: name,
+			RowKey:    []byte("row"),
+			Mutations: []*btpb.Mutation{{
+				Mutation: &btpb.Mutation_DeleteFromColumn_{DeleteFromColumn: &btpb.Mutation_DeleteFromColumn{
+					FamilyName:      "cf",
+					ColumnQualifier: []byte("col"),
+					TimeRange: &btpb.TimestampRange{
+						StartTimestampMicros: start,
+						EndTimestampMicros:   end,
+					},
+				}},
+			}},
+		}
+	}
+
+	// A millis table rejects a micros-granularity delete range.
+	s, name := newGranularityServer(t, btapb.Table_MILLIS)
+	if _, err := s.MutateRow(ctx, setCell(name, 2000)); err != nil {
+		t.Fatalf("MutateRow: %v", err)
+	}
+	if _, err := s.MutateRow(ctx, deleteRange(name, 1001, 3000)); err == nil {
+		t.Error("DeleteFromColumn with micros range on a millis table got no error, want rejection")
+	}
+
+	// A micros table accepts it, and the delete takes effect.
+	s, name = newGranularityServer(t, btapb.Table_MICROS)
+	if _, err := s.MutateRow(ctx, setCell(name, 2001)); err != nil {
+		t.Fatalf("MutateRow: %v", err)
+	}
+	if _, err := s.MutateRow(ctx, deleteRange(name, 2001, 2002)); err != nil {
+		t.Fatalf("DeleteFromColumn with micros range on a micros table: %v", err)
+	}
+	if got := readCellTimestamps(t, s, name); len(got) != 0 {
+		t.Errorf("stored timestamps after delete = %v, want none", got)
+	}
+}
+
+// TestGranularityReportedByAdminAPIs checks that the table's granularity
+// survives round-tripping through the admin surface.
+func TestGranularityReportedByAdminAPIs(t *testing.T) {
+	ctx := context.Background()
+	for _, g := range []btapb.Table_TimestampGranularity{btapb.Table_MILLIS, btapb.Table_MICROS} {
+		t.Run(g.String(), func(t *testing.T) {
+			s, name := newGranularityServer(t, g)
+
+			gt, err := s.GetTable(ctx, &btapb.GetTableRequest{Name: name})
+			if err != nil {
+				t.Fatalf("GetTable: %v", err)
+			}
+			if gt.Granularity != g {
+				t.Errorf("GetTable granularity = %v, want %v", gt.Granularity, g)
+			}
+
+			mt, err := s.ModifyColumnFamilies(ctx, &btapb.ModifyColumnFamiliesRequest{
+				Name: name,
+				Modifications: []*btapb.ModifyColumnFamiliesRequest_Modification{{
+					Id:  "cf2",
+					Mod: &btapb.ModifyColumnFamiliesRequest_Modification_Create{Create: &btapb.ColumnFamily{}},
+				}},
+			})
+			if err != nil {
+				t.Fatalf("ModifyColumnFamilies: %v", err)
+			}
+			if mt.Granularity != g {
+				t.Errorf("ModifyColumnFamilies granularity = %v, want %v", mt.Granularity, g)
+			}
+		})
+	}
+}
+
+// TestCreateTableRejectsUnknownGranularity checks that an unrecognized
+// granularity is rejected at table creation.
+func TestCreateTableRejectsUnknownGranularity(t *testing.T) {
+	s := &server{tables: make(map[string]*table)}
+	_, err := s.CreateTable(context.Background(), &btapb.CreateTableRequest{
+		Parent:  "cluster",
+		TableId: "t",
+		Table:   &btapb.Table{Granularity: btapb.Table_TimestampGranularity(99)},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("CreateTable error = %v, want InvalidArgument", err)
 	}
 }

--- a/bigtable/bttest/timestamp_test.go
+++ b/bigtable/bttest/timestamp_test.go
@@ -186,11 +186,11 @@ func TestServerTimestampIsTruncated(t *testing.T) {
 
 	// On a millis table, the generated timestamp must be millis-aligned.
 	s, name := newGranularityServer(t, btapb.Table_MILLIS)
-	before := time.Now().UnixNano() / 1e3
+	before := time.Now().UnixMicro()
 	if _, err := s.MutateRow(ctx, setCell(name, -1)); err != nil {
 		t.Fatalf("MutateRow(ServerTime): %v", err)
 	}
-	after := time.Now().UnixNano() / 1e3
+	after := time.Now().UnixMicro()
 	got := readCellTimestamps(t, s, name)
 	if len(got) != 1 {
 		t.Fatalf("stored timestamps = %v, want one cell", got)


### PR DESCRIPTION
## Problem

The emulator accepted `Granularity` on `CreateTable` but discarded it, and `validTimestamp` unconditionally required `ts % 1000 == 0`. A `MICROS` table therefore behaved exactly like a `MILLIS` one: microsecond-precision writes were rejected, and `GetTable` reported the wrong granularity.

## Change

`table` now carries the granularity (unspecified → `MILLIS`, immutable after creation), and timestamps are validated against it:

- **Server-generated timestamps are truncated, not rejected.** `TimestampMicros == -1` (`bigtable.ServerTime`) and the timestamps `ReadModifyWriteRow` mints go through `(*table).newTimestamp()`, which truncates to the table's granularity — so a `MICROS` table keeps microsecond precision where a `MILLIS` table still rounds down.
- **User-provided timestamps that don't match the granularity are rejected.** This covers `SetCell`, `DeleteFromColumn`'s `TimeRange`, and `AddToCell`/`MergeToCell`. The latter two previously only checked `ts >= 0`, despite the proto stating the timestamp "must be a `raw_timestamp_micros` that matches the table's `granularity`".
- **The upper bound is per-granularity.** `MICROS` tables accept the full `int64` range instead of `MaxInt64` truncated to a multiple of 1000.

Two smaller correctness fixes came along with it:

- Rejections return `InvalidArgument` (matching the service) instead of a bare `fmt.Errorf` that surfaced as `Unknown`, and a granularity mismatch gets a distinct message from an out-of-range value.
- `CreateTable` rejects unrecognized granularity enum values, and `GetTable`/`ModifyColumnFamilies` report the table's real granularity instead of hard-coding `MILLIS`.

## Deliberately out of scope

The read path (`timestamp_range_filter`) is still not validated against granularity, matching existing emulator behavior — tightening it would break tests that pass arbitrary microsecond filters. `UpdateTable` still can't change granularity, matching the real service.

## Testing

New coverage in `bttest/timestamp_test.go`: accept/reject across both granularities, the max-timestamp bound per granularity, server-time truncation, `DeleteFromColumn` ranges, admin round-tripping, and unknown-granularity rejection.

`go build ./...`, `go vet ./bttest/`, and `go test ./bttest/` all pass. The remaining failures in the wider `bigtable` module (`TestConformance`, `TestIntegration_SessionVRpc_DeadlineExceeded`, `TestTableImpl_BypassesDivertibleGate`) are pre-existing and reproduce identically on the base commit.