### PR TITLE
feat(bigtable): debug tags for GetClientConfiguration session_configuration state

### DIFF
--- a/bigtable/internal/transport/client_configuration_manager.go
+++ b/bigtable/internal/transport/client_configuration_manager.go
@@ -568,6 +568,14 @@ func (m *ClientConfigurationManager) poll(ctx context.Context) {
 
 	btopt.Debugf(m.logger, "bigtable: successfully polled new client configuration. validityDuration: %v", validityDuration(resp))
 
+	// Surface null SessionConfiguration in the debug-tag counter so
+	// operators can spot instances/app-profiles whose control-plane
+	// config never landed — the poll succeeded, but the response left
+	// session_load, channel/session pool sizing, and LB options at zero.
+	if resp.GetSessionConfiguration() == nil {
+		recordDebugTag(tagClientConfigSessionConfigurationNull)
+	}
+
 	m.mu.Lock()
 	// Always refresh the validity window — the server's reply re-affirms
 	// the current config, so we shouldn't later fall back to default just

--- a/bigtable/internal/transport/client_configuration_manager.go
+++ b/bigtable/internal/transport/client_configuration_manager.go
@@ -574,6 +574,14 @@ func (m *ClientConfigurationManager) poll(ctx context.Context) {
 	// session_load, channel/session pool sizing, and LB options at zero.
 	if resp.GetSessionConfiguration() == nil {
 		recordDebugTag(tagClientConfigSessionConfigurationNull)
+	} else if resp.GetSessionConfiguration().GetSessionLoad() == 0 {
+		// Distinct from the null case: server sent a populated
+		// SessionClientConfiguration but explicitly set session_load=0
+		// (route 0% through session, 100% through classic). Legitimate
+		// operating point, but worth surfacing so operators can spot
+		// instances/app-profiles that are effectively opted out of the
+		// session data path.
+		recordDebugTag(tagClientConfigSessionLoadZero)
 	}
 
 	m.mu.Lock()

--- a/bigtable/internal/transport/client_configuration_manager_test.go
+++ b/bigtable/internal/transport/client_configuration_manager_test.go
@@ -75,35 +75,62 @@ func TestManagerPoll_Success(t *testing.T) {
 	}
 }
 
-// TestManagerPoll_SessionConfigurationNullEmitsDebugTag asserts the
-// tagClientConfigSessionConfigurationNull debug tag fires exactly once
-// when a successful poll returns a response with no SessionConfiguration
-// (e.g. an instance/profile whose control-plane config never landed),
-// and does NOT fire when SessionConfiguration is present.
-func TestManagerPoll_SessionConfigurationNullEmitsDebugTag(t *testing.T) {
-	client := &mockBigtableClient{}
-	manager := NewClientConfigurationManager(client, "instance", "profile", nil, nil)
-
-	// Response with SessionConfiguration unset.
-	client.getConfigFunc = func(ctx context.Context, req *bigtablepb.GetClientConfigurationRequest) (*bigtablepb.ClientConfiguration, error) {
-		return &bigtablepb.ClientConfiguration{}, nil
+// TestManagerPoll_SessionConfigurationDebugTags asserts the two mutually-
+// exclusive debug tags that discriminate SessionClientConfiguration
+// health on a successful poll:
+//   - tagClientConfigSessionConfigurationNull when the response has no
+//     SessionConfiguration at all (e.g. control-plane config never landed).
+//   - tagClientConfigSessionLoadZero when SessionConfiguration is present
+//     but session_load is 0 (explicit opt-out from the session data path).
+//
+// A response with a nonzero session_load must emit neither tag.
+func TestManagerPoll_SessionConfigurationDebugTags(t *testing.T) {
+	tests := []struct {
+		name        string
+		resp        *bigtablepb.ClientConfiguration
+		wantNullTag int64
+		wantZeroTag int64
+	}{
+		{
+			name:        "null_session_configuration",
+			resp:        &bigtablepb.ClientConfiguration{},
+			wantNullTag: 1,
+			wantZeroTag: 0,
+		},
+		{
+			name: "session_load_zero",
+			resp: &bigtablepb.ClientConfiguration{
+				SessionConfiguration: &bigtablepb.SessionClientConfiguration{SessionLoad: 0},
+			},
+			wantNullTag: 0,
+			wantZeroTag: 1,
+		},
+		{
+			name: "session_load_nonzero",
+			resp: &bigtablepb.ClientConfiguration{
+				SessionConfiguration: &bigtablepb.SessionClientConfiguration{SessionLoad: 0.5},
+			},
+			wantNullTag: 0,
+			wantZeroTag: 0,
+		},
 	}
-	resetDebugTagCountsForTest()
-	manager.poll(context.Background())
-	if got := snapshotDebugTagCounts()[tagClientConfigSessionConfigurationNull]; got != 1 {
-		t.Errorf("null SessionConfiguration: %s count = %d, want 1", tagClientConfigSessionConfigurationNull, got)
-	}
-
-	// Response with SessionConfiguration populated must NOT emit the tag.
-	client.getConfigFunc = func(ctx context.Context, req *bigtablepb.GetClientConfigurationRequest) (*bigtablepb.ClientConfiguration, error) {
-		return &bigtablepb.ClientConfiguration{
-			SessionConfiguration: &bigtablepb.SessionClientConfiguration{},
-		}, nil
-	}
-	resetDebugTagCountsForTest()
-	manager.poll(context.Background())
-	if got := snapshotDebugTagCounts()[tagClientConfigSessionConfigurationNull]; got != 0 {
-		t.Errorf("populated SessionConfiguration: %s count = %d, want 0", tagClientConfigSessionConfigurationNull, got)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &mockBigtableClient{}
+			manager := NewClientConfigurationManager(client, "instance", "profile", nil, nil)
+			client.getConfigFunc = func(ctx context.Context, req *bigtablepb.GetClientConfigurationRequest) (*bigtablepb.ClientConfiguration, error) {
+				return tc.resp, nil
+			}
+			resetDebugTagCountsForTest()
+			manager.poll(context.Background())
+			counts := snapshotDebugTagCounts()
+			if got := counts[tagClientConfigSessionConfigurationNull]; got != tc.wantNullTag {
+				t.Errorf("%s: count = %d, want %d", tagClientConfigSessionConfigurationNull, got, tc.wantNullTag)
+			}
+			if got := counts[tagClientConfigSessionLoadZero]; got != tc.wantZeroTag {
+				t.Errorf("%s: count = %d, want %d", tagClientConfigSessionLoadZero, got, tc.wantZeroTag)
+			}
+		})
 	}
 }
 

--- a/bigtable/internal/transport/client_configuration_manager_test.go
+++ b/bigtable/internal/transport/client_configuration_manager_test.go
@@ -75,6 +75,38 @@ func TestManagerPoll_Success(t *testing.T) {
 	}
 }
 
+// TestManagerPoll_SessionConfigurationNullEmitsDebugTag asserts the
+// tagClientConfigSessionConfigurationNull debug tag fires exactly once
+// when a successful poll returns a response with no SessionConfiguration
+// (e.g. an instance/profile whose control-plane config never landed),
+// and does NOT fire when SessionConfiguration is present.
+func TestManagerPoll_SessionConfigurationNullEmitsDebugTag(t *testing.T) {
+	client := &mockBigtableClient{}
+	manager := NewClientConfigurationManager(client, "instance", "profile", nil, nil)
+
+	// Response with SessionConfiguration unset.
+	client.getConfigFunc = func(ctx context.Context, req *bigtablepb.GetClientConfigurationRequest) (*bigtablepb.ClientConfiguration, error) {
+		return &bigtablepb.ClientConfiguration{}, nil
+	}
+	resetDebugTagCountsForTest()
+	manager.poll(context.Background())
+	if got := snapshotDebugTagCounts()[tagClientConfigSessionConfigurationNull]; got != 1 {
+		t.Errorf("null SessionConfiguration: %s count = %d, want 1", tagClientConfigSessionConfigurationNull, got)
+	}
+
+	// Response with SessionConfiguration populated must NOT emit the tag.
+	client.getConfigFunc = func(ctx context.Context, req *bigtablepb.GetClientConfigurationRequest) (*bigtablepb.ClientConfiguration, error) {
+		return &bigtablepb.ClientConfiguration{
+			SessionConfiguration: &bigtablepb.SessionClientConfiguration{},
+		}, nil
+	}
+	resetDebugTagCountsForTest()
+	manager.poll(context.Background())
+	if got := snapshotDebugTagCounts()[tagClientConfigSessionConfigurationNull]; got != 0 {
+		t.Errorf("populated SessionConfiguration: %s count = %d, want 0", tagClientConfigSessionConfigurationNull, got)
+	}
+}
+
 func TestManagerPoll_FailureKeepsOldConfig(t *testing.T) {
 	client := &mockBigtableClient{}
 	manager := NewClientConfigurationManager(client, "instance", "profile", nil, nil)

--- a/bigtable/internal/transport/debug_tracer.go
+++ b/bigtable/internal/transport/debug_tracer.go
@@ -174,6 +174,14 @@ const (
 	// whose control-plane config never landed. Distinct from a poll
 	// error (that path emits tagClientConfigPollFailed).
 	tagClientConfigSessionConfigurationNull = "client_config_session_configuration_null"
+	// tagClientConfigSessionLoadZero fires when a successful poll returns
+	// a populated SessionClientConfiguration whose session_load is 0
+	// (explicit "route 0% through session, 100% through classic"). A
+	// legitimate operating point, but worth surfacing so ops can spot
+	// instances/app-profiles effectively opted out of the session data
+	// path. Distinct from the null-config case, which emits
+	// tagClientConfigSessionConfigurationNull.
+	tagClientConfigSessionLoadZero = "client_config_session_load_zero"
 )
 
 var (

--- a/bigtable/internal/transport/debug_tracer.go
+++ b/bigtable/internal/transport/debug_tracer.go
@@ -166,6 +166,14 @@ const (
 	// Client configuration polling.
 	tagClientConfigPollFailed     = "client_config_poll_failed"
 	tagClientConfigPollCtxExpired = "client_config_poll_ctx_expired"
+	// tagClientConfigSessionConfigurationNull fires when a successful
+	// GetClientConfiguration response arrives with SessionConfiguration
+	// unset. That leaves session_load, channel/session pool sizing, and
+	// LB options at zero — the manager falls back to the default config,
+	// but the missed signal is worth surfacing so ops can spot instances
+	// whose control-plane config never landed. Distinct from a poll
+	// error (that path emits tagClientConfigPollFailed).
+	tagClientConfigSessionConfigurationNull = "client_config_session_configuration_null"
 )
 
 var (


### PR DESCRIPTION
## Summary
Two new debug-tag emissions from the successful-poll branch of \`ClientConfigurationManager\`, distinguishing the two ways a poll can succeed but still leave the client without a working \`session_load\`:

- \`client_config_session_configuration_null\` — response arrived with \`SessionConfiguration\` unset (control-plane config never landed).
- \`client_config_session_load_zero\` — \`SessionConfiguration\` is populated but \`session_load == 0\` (explicit "route 0% through session, 100% through classic"). Legitimate operating point, but worth surfacing so ops can spot instances/app-profiles opted out of the session data path.

Tags are mutually exclusive by construction. Failed polls still route through the existing \`client_config_poll_failed\` counter — no overlap.

## Motivation
Under investigation of a real instance (\`sushanb-cache\`), every GetClientConfiguration poll returns the same instance-level defaults regardless of app profile. The client silently accepts this and falls back to defaults — no operator-visible signal. These tags close that gap so dashboards can plot the rate of null/zero responses across instances.

## Test plan
- [x] \`go test ./internal/transport/ -run TestManagerPoll_SessionConfigurationDebugTags -count=1\` — table-driven suite covering all three branches (null, zero, nonzero).
- [x] \`go test ./internal/transport/ ./internal/session/ -count=1 -short\` — full smoke.