### PR TITLE
fix(profiler): update GCE image family to debian-12

### DIFF
--- a/profiler/integration_test.go
+++ b/profiler/integration_test.go
@@ -281,7 +281,7 @@ func TestAgentIntegration(t *testing.T) {
 				Name:         fmt.Sprintf("profiler-test-go%s-%s", goVersionName, runID),
 				MachineType:  "n1-standard-1",
 				ImageProject: "debian-cloud",
-				ImageFamily:  "debian-11",
+				ImageFamily:  "debian-12",
 			},
 			name:             fmt.Sprintf("profiler-test-go%s", goVersionName),
 			wantProfileTypes: []string{"CPU", "HEAP", "THREADS", "CONTENTION", "HEAP_ALLOC"},
@@ -305,7 +305,7 @@ func TestAgentIntegration(t *testing.T) {
 					MachineType: "n1-highmem-2",
 
 					ImageProject: "debian-cloud",
-					ImageFamily:  "debian-11",
+					ImageFamily:  "debian-12",
 				},
 				name:          fmt.Sprintf("profiler-backoff-test-go%s", goVersionName),
 				goVersion:     goVersion,

--- a/profiler/proftest/proftest.go
+++ b/profiler/proftest/proftest.go
@@ -225,14 +225,14 @@ func (pr *ProfileResponse) HasSourceFile(filename string) error {
 // StartInstance starts a GCE Instance with configs specified by inst,
 // and which runs the startup script specified in inst. If image project
 // is not specified, it defaults to "debian-cloud". If image family is
-// not specified, it defaults to "debian-11".
+// not specified, it defaults to "debian-12".
 func (tr *GCETestRunner) StartInstance(ctx context.Context, inst *InstanceConfig) error {
 	imageProject, imageFamily := inst.ImageProject, inst.ImageFamily
 	if imageProject == "" {
 		imageProject = "debian-cloud"
 	}
 	if imageFamily == "" {
-		imageFamily = "debian-11"
+		imageFamily = "debian-12"
 	}
 	img, err := tr.ComputeService.Images.GetFromFamily(imageProject, imageFamily).Context(ctx).Do()
 	if err != nil {


### PR DESCRIPTION
The `debian-11` image family in project `debian-cloud` was deprecated and removed from GCE, causing profiler integration tests to fail with 404 when attempting to fetch the image family.

Update default image family in `GCETestRunner` and integration test cases to `debian-12`.