### PR TITLE
chore: update librarian version to v0.42.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: go
-version: v0.40.0
+version: v0.42.0
 repo: googleapis/google-cloud-go
 sources:
   discovery:


### PR DESCRIPTION
Update librarian version to v0.42.0.
### Included Librarian Updates
- googleapis/librarian#7524: chore(main): release 0.42.0
- googleapis/librarian#7473: chore(main): release 0.41.0
- googleapis/librarian#7508: fix(internal/librarian): update bulk release-please config for existing python libraries
- googleapis/librarian#7489: build(.github/workflows): separate java integration test into standalone job
- googleapis/librarian#7491: ci(.github): increase timeout of php integration test
- googleapis/librarian#7487: refactor(internal/config): remove nodejs_apis from NodejsPackage
- googleapis/librarian#7469: build(.github): add test matrix for PHP
- googleapis/librarian#7482: build(deps): bump google.golang.org/grpc from 1.82.1 to 1.83.1
