### PR TITLE
test(bigtable): fakeStream.Recv observes ctx.Done to fix pool-Close deadlock

### DIFF
--- a/bigtable/internal/transport/session_pool_lifecycle_test.go
+++ b/bigtable/internal/transport/session_pool_lifecycle_test.go
@@ -525,6 +525,86 @@ func TestPoolClose_UnwindsMaintenanceLoops(t *testing.T) {
 	}
 }
 
+// TestPoolClose_UnblocksReadLoopsViaCtxCancel is the regression test for the
+// 44-minute Close deadlock on TestPool_LeastInFlight_FansOutAcrossAFEs and
+// its siblings — surfaced in CI as a `spawns.Wait` stack parked on
+// `Session.WaitGoroutines → readLoop → fakeStream.Recv (chan receive)`.
+//
+// In the failure, a Tick-spawned createSession had a readLoop parked on
+// fakeStream.Recv (a plain <-f.recv), which does not observe context
+// cancellation. When Close reached Phase-5 spawns.Wait, its Phase-4
+// poolCancel had already fired — but the newTestPool poolCtx.Done →
+// closeStreams bridge is asynchronous, and any timing where its close hadn't
+// reached every stream still had readLoops parked forever. Result: 44 min
+// hang until the test framework killed the process.
+//
+// The fix binds dialCtx (derived from poolCtx) into every fakeStream and
+// makes fakeStream.Recv select on that ctx alongside its recv chan — so a
+// poolCancel synchronously unblocks every readLoop regardless of whether
+// the bridge has scheduled yet. This test forces the exact CI scenario:
+// a real Tick-spawned createSession + readLoop, then Close called
+// WITHOUT the newTestPool cleanup bridge in the loop, and asserts Close
+// returns well under the pool's 30-second internal budget.
+func TestPoolClose_UnblocksReadLoopsViaCtxCancel(t *testing.T) {
+	factory, closeStreams := newStubStreamFactory()
+	// Cleanup on error / t.Fatal path — the happy path proves Close alone
+	// is sufficient.
+	t.Cleanup(closeStreams)
+
+	p := NewSessionPoolImpl(
+		uint64(1),
+		"ctx-unblock-pool",
+		factory,
+		&spb.OpenSessionRequest{ProtocolVersion: 1},
+		nil,
+		SessionTypeTable, true,
+	)
+	// Configure a small pool so Tick fires createSessions we can wait for.
+	p.sizer.UpdateConfig(&spb.SessionClientConfiguration_SessionPoolConfiguration{
+		MinSessionCount: 3, MaxSessionCount: 10,
+	})
+
+	// Kick Tick synchronously so we know its spawns have been Added
+	// before Close begins.
+	p.Tick(p.poolCtx)
+
+	// Wait until at least one createSession has entered startingSessions —
+	// that means s.Start returned, which means readLoop is spawned and
+	// parked on fakeStream.Recv. Sessions never reach Ready in this test
+	// (nothing feeds an OpenSessionResponse into the fake), so we key on
+	// the starting-set, not sl.
+	countStarting := func() int {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		return len(p.startingSessions)
+	}
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if countStarting() >= 1 {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if got := countStarting(); got == 0 {
+		t.Fatalf("no session reached startingSessions within 500ms — Tick did not spawn a readLoop, test is vacuous")
+	}
+
+	// Close with a tight timeout: pre-fix this parks for the pool's full
+	// 30s Phase-3 budget and then hangs indefinitely on Phase-5. Post-fix
+	// it returns essentially immediately.
+	done := make(chan error, 1)
+	go func() { done <- p.Close() }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Close returned err = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Close did not return within 5s — poolCancel failed to unblock readLoops parked on fakeStream.Recv")
+	}
+}
+
 // TestPoolStart_AfterClose_LoopsExitImmediately guards the Start-after-Close
 // order. maintCtx is already cancelled by then, so any loop Start launches
 // must fall out on its first select rather than tick against a torn-down

--- a/bigtable/internal/transport/session_pool_test.go
+++ b/bigtable/internal/transport/session_pool_test.go
@@ -37,7 +37,7 @@ func newStubStreamFactory() (factory func(context.Context) (Stream, error), clos
 	var mu sync.Mutex
 	var streams []*fakeStream
 	var closed bool
-	factory = func(_ context.Context) (Stream, error) {
+	factory = func(ctx context.Context) (Stream, error) {
 		mu.Lock()
 		defer mu.Unlock()
 		if closed {
@@ -47,7 +47,15 @@ func newStubStreamFactory() (factory func(context.Context) (Stream, error), clos
 			// that leaks its readLoop past p.Close.
 			return nil, errors.New("newStubStreamFactory: closed")
 		}
-		s := newFakeStream()
+		// Bind the dial ctx into the stream so its Recv unblocks with
+		// ctx.Err() when the caller cancels dialCtx — matching real gRPC
+		// stream cancellation semantics. Without this, a Close/cancel
+		// race where the poolCtx.Done→closeStreams bridge hasn't run yet
+		// leaves the stream's Recv parked and Close's Phase-5 spawns.Wait
+		// deadlocks. dialCtx in production is derived from poolCtx, so
+		// this makes readLoop always unblock on Close regardless of the
+		// bridge's scheduling.
+		s := newFakeStream().bindCtx(ctx)
 		streams = append(streams, s)
 		return s, nil
 	}

--- a/bigtable/internal/transport/session_test.go
+++ b/bigtable/internal/transport/session_test.go
@@ -45,6 +45,14 @@ func (s *stubStream) Context() context.Context     { return s.ctx }
 
 // fakeStream implements Stream and exposes channels so tests can drive both
 // sides of the conversation. sendFn allows a test to inject Send failures.
+//
+// Recv selects on ctx.Done() alongside the recv channel — matching real gRPC
+// ClientStream semantics, where Recv returns as soon as the stream's context
+// cancels. Without this, a session pool test that only cancels poolCtx (and
+// forgets to also close every fakeStream) leaves readLoop parked forever, and
+// SessionPoolImpl.Close's Phase 5 spawns.Wait deadlocks. ctx defaults to
+// context.Background(); use bindCtx to link the stream to the dial ctx handed
+// in by the factory.
 type fakeStream struct {
 	sentMu    sync.Mutex
 	sent      []*spb.SessionRequest
@@ -53,6 +61,7 @@ type fakeStream struct {
 	hdrErr    error
 	sendFn    func(*spb.SessionRequest) error
 	closeOnce sync.Once
+	ctx       context.Context
 }
 
 type recvOp struct {
@@ -64,7 +73,19 @@ func newFakeStream() *fakeStream {
 	return &fakeStream{
 		recv: make(chan recvOp, 32),
 		hdr:  metadata.MD{},
+		ctx:  context.Background(),
 	}
+}
+
+// bindCtx links Recv to ctx so Recv unblocks with ctx.Err() when ctx cancels —
+// the fakeStream analogue of a real gRPC stream aborting on ctx cancellation.
+// No-op for nil ctx so callers can pass through the incoming factory ctx
+// unchecked.
+func (f *fakeStream) bindCtx(ctx context.Context) *fakeStream {
+	if ctx != nil {
+		f.ctx = ctx
+	}
+	return f
 }
 
 // Close unblocks Recv() by closing the recv channel. Idempotent so cleanup
@@ -86,15 +107,19 @@ func (f *fakeStream) Send(req *spb.SessionRequest) error {
 }
 
 func (f *fakeStream) Recv() (*spb.SessionResponse, error) {
-	op, ok := <-f.recv
-	if !ok {
-		return nil, fmt.Errorf("stream closed")
+	select {
+	case op, ok := <-f.recv:
+		if !ok {
+			return nil, fmt.Errorf("stream closed")
+		}
+		return op.resp, op.err
+	case <-f.ctx.Done():
+		return nil, f.ctx.Err()
 	}
-	return op.resp, op.err
 }
 
 func (f *fakeStream) Header() (metadata.MD, error) { return f.hdr, f.hdrErr }
-func (f *fakeStream) Context() context.Context     { return context.Background() }
+func (f *fakeStream) Context() context.Context     { return f.ctx }
 
 func (f *fakeStream) snapshotSent() []*spb.SessionRequest {
 	f.sentMu.Lock()


### PR DESCRIPTION
## Summary
Fixes the 45-minute CI hang on \`TestPool_LeastInFlight_FansOutAcrossAFEs\` (and any other pool test whose Tick spawns real createSessions).

## Root cause
\`SessionPoolImpl.Close\`'s Phase-5 \`spawns.Wait\` blocks on every in-flight \`createSession\`, each parked at \`s.WaitGoroutines()\` waiting for the session's \`readLoop\` to exit. In production, dialCtx cancellation aborts the underlying gRPC stream so \`readLoop.Recv\` errors out. In tests, \`fakeStream.Recv\` is a plain \`<-f.recv\` channel receive that does **not** observe context cancellation — nothing wakes it when poolCtx cancels.

\`newTestPool\` has an async \`poolCtx.Done → closeStreams\` bridge that closes every fakeStream when \`poolCancel\` fires, but a Close/cancel race where the bridge hasn't scheduled yet leaves readLoop parked and \`spawns.Wait\` deadlocks. Under CI's slower scheduling and the 900-iteration test load, this hung the full 45-min test timeout.

## Fix
- \`fakeStream\` gains a \`ctx\` field (default \`context.Background\`). \`Recv\` now selects on both \`f.recv\` and \`f.ctx.Done\` — matching real gRPC \`ClientStream\` semantics where Recv aborts on stream ctx cancellation.
- \`newStubStreamFactory\` binds the \`dialCtx\` it receives from the pool into every fakeStream via a new \`bindCtx\` helper. \`dialCtx\` is derived from \`poolCtx\` in production, so \`Close\`'s Phase-4 \`poolCancel\` now synchronously unblocks every readLoop regardless of whether the \`poolCtx.Done\` bridge has scheduled.

## Regression test
\`TestPoolClose_UnblocksReadLoopsViaCtxCancel\` drives the exact CI scenario: build a pool, Tick to spawn real createSession→readLoop, then Close WITHOUT running closeStreams first.

- Pre-fix: hangs past a 5-second deadline (verified locally by stashing the Recv change and re-running — test failed with \`Close did not return within 5s\` in exactly 5.00s).
- Post-fix: returns in ~milliseconds. \`go test -count=100 -race\` on the new test + the original CI-failing test completes in 4s.

## Test plan
- [x] \`go test ./internal/transport/ -run TestPoolClose_UnblocksReadLoopsViaCtxCancel -count=100 -race\` — pass.
- [x] \`go test ./internal/transport/ -run TestPool_LeastInFlight_FansOutAcrossAFEs -count=100 -race\` — pass.
- [x] \`go test ./internal/transport/ ./internal/session/ -count=1 -short -race\` — pass.
- [x] Stash-revert verification: with the Recv change reverted, the new test fails with the exact 5-second hang the CI stack showed.