### PR TITLE
ci: deflake translate test

### DIFF
--- a/translate/translate_test.go
+++ b/translate/translate_test.go
@@ -167,8 +167,8 @@ func TestTranslateOneInput(t *testing.T) {
 	} {
 		// Provide source and format.
 		tr := translate(test.input, test.target, &Options{Source: test.source, Format: Text})
-		if got, want := tr.Source, language.Und; got != want {
-			t.Errorf("source: got %q, wanted %q", got, want)
+		if got := tr.Source; got != language.Und && got != test.source {
+			t.Errorf("source: got %q, wanted %q or %q", got, language.Und, test.source)
 			continue
 		}
 		if got, want := tr.Text, test.output; got != want {


### PR DESCRIPTION
Fixes #20509 

Googlers can see: https://fusion2.corp.google.com/invocations/72c4fa54-0319-4054-b10c-7068368ea0ba/targets/google-cloud-go%2Ftranslate

tl;dr I can reproduce this with Gemini, and see flakes about 5% of the time. With the fix, I had 1000 successful runs.

Aside: arguably we should just delete this test? Why are we verifying service behavior?
Aside 2: why isn't this thing a GAPIC? Why are we maintaining this client?

Here is Gemini's report

---

# Integration Test Failure Investigation: Cloud Translation V2

This report documents the root-cause analysis, empirical findings, and fix implemented for the integration test failure in `TestTranslateOneInput`.

## 1. Issue Overview
We observed a non-deterministic failure in `translate_test.go` on line 171:
```
translate_test.go:171: source: got "fr", wanted "und"
```

## 2. Empirical Findings
To determine if this was a transient flake or a permanent API change, we ran the unmodified test with the original expectations in a loop under project `dbolduc-test` exactly **100 times**:

*   **Total Runs:** 100
*   **Successes:** 95 (Returned `tr.Source` as `language.Und`)
*   **Failures:** 5 (Returned `tr.Source` as `"fr"` or `"en"`)
*   **Failure Rate (Flake Rate):** 5%

## 3. Solid Evidence of Backend Non-Determinism
The official Google Cloud Translation V2 REST API documentation for `detectedSourceLanguage` specifies:

> *"The source language of the initial request, detected automatically, if no source language was passed within the initial request. **If the source language was passed, auto-detection of the language will not occur and this field will be omitted.**"*

However, our empirical loop results provide solid evidence that **the Translation V2 API backend behaves non-deterministically**:
*   In **95% of cases**, the API conforms to the specification, omitting `detectedSourceLanguage` from the response (which is parsed as `language.Und`).
*   In **5% of cases**, the API returns `detectedSourceLanguage` with the confirmed/original source language (e.g., `"fr"` or `"en"`), violating the omission spec.

This inconsistency (possibly due to regional backend replicas/models or load balancer routing differences) is the direct cause of the integration test flaking.

## 4. Changes Implemented
To make the integration test resilient against both behaviors (avoiding future CI flakes), we relaxed the hardcoded expectation in `translate/translate_test.go` to accept either `language.Und` or the expected `test.source`:

```go
// Provide source and format.
tr := translate(test.input, test.target, &Options{Source: test.source, Format: Text})
if got := tr.Source; got != language.Und && got != test.source {
    t.Errorf("source: got %q, wanted %q or %q", got, language.Und, test.source)
    continue
}
```

This ensures the test passes cleanly regardless of whether the backend replica populates or omits the source language in its response.