### PR TITLE
fix(bigquery): plumb query ID on polls

### DIFF
--- a/bigquery/integration_test.go
+++ b/bigquery/integration_test.go
@@ -137,7 +137,7 @@ func initIntegrationTest() func() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		connectionsClient, err = connection.NewClient(ctx, option.WithHTTPClient(hc))
+		connectionsClient, err = connection.NewClient(ctx)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/bigquery/job.go
+++ b/bigquery/job.go
@@ -37,6 +37,7 @@ type Job struct {
 	email      string
 	config     *bq.JobConfiguration
 	lastStatus *JobStatus
+	queryID    string
 }
 
 // JobFromID creates a Job which refers to an existing BigQuery job. The job
@@ -342,9 +343,12 @@ func (j *Job) read(ctx context.Context, waitForQuery func(context.Context, strin
 			projectID: j.projectID,
 			jobID:     j.jobID,
 			location:  j.location,
+			queryID:   j.queryID,
 		}
-		it = newRowIterator(ctx, &rowSource{j: itJob}, pf)
+		it = newRowIterator(ctx, &rowSource{j: itJob, queryID: j.queryID}, pf)
 		it.TotalRows = totalRows
+	} else {
+		it.src.queryID = j.queryID
 	}
 	it.Schema = schema
 	return it, nil

--- a/bigquery/query.go
+++ b/bigquery/query.go
@@ -425,6 +425,7 @@ func (q *Query) Read(ctx context.Context) (it *RowIterator, err error) {
 			jobID:     resp.JobReference.JobId,
 			location:  resp.JobReference.Location,
 			projectID: resp.JobReference.ProjectId,
+			queryID:   resp.QueryId,
 		}
 	}
 

--- a/bigquery/read_test.go
+++ b/bigquery/read_test.go
@@ -240,3 +240,31 @@ func TestReadQueryOptions(t *testing.T) {
 		t.Errorf("reading: got:\n%v\nwant:\n%v", pf.calls, want)
 	}
 }
+
+func TestReadQueryIDPropagation(t *testing.T) {
+	c := &Client{projectID: "project-id"}
+	pf := &pageFetcherReadStub{
+		values: [][][]Value{{{1, 2}}},
+	}
+	tr := &bq.TableReference{
+		ProjectId: "project-id",
+		DatasetId: "dataset-id",
+		TableId:   "table-id",
+	}
+	queryJob := &Job{
+		projectID: "project-id",
+		jobID:     "job-id",
+		c:         c,
+		config: &bq.JobConfiguration{
+			Query: &bq.JobConfigurationQuery{DestinationTable: tr},
+		},
+		queryID: "propagated-query-id-123",
+	}
+	it, err := queryJob.read(context.Background(), waitForQueryStub, pf.fetchPage)
+	if err != nil {
+		t.Fatalf("err calling Read: %v", err)
+	}
+	if got := it.QueryID(); got != "propagated-query-id-123" {
+		t.Errorf("it.QueryID() = %q, want %q", got, "propagated-query-id-123")
+	}
+}

--- a/bigquery/read_test.go
+++ b/bigquery/read_test.go
@@ -268,3 +268,35 @@ func TestReadQueryIDPropagation(t *testing.T) {
 		t.Errorf("it.QueryID() = %q, want %q", got, "propagated-query-id-123")
 	}
 }
+
+func TestReadQueryIDPropagationFromWaitForQuery(t *testing.T) {
+	c := &Client{projectID: "project-id"}
+	pf := &pageFetcherReadStub{
+		values: [][][]Value{{{1, 2}}},
+	}
+	tr := &bq.TableReference{
+		ProjectId: "project-id",
+		DatasetId: "dataset-id",
+		TableId:   "table-id",
+	}
+	queryJob := &Job{
+		projectID: "project-id",
+		jobID:     "job-id",
+		c:         c,
+		config: &bq.JobConfiguration{
+			Query: &bq.JobConfigurationQuery{DestinationTable: tr},
+		},
+		// queryID is initially empty!
+	}
+	waitForQueryWithID := func(ctx context.Context, projectID string) (Schema, uint64, error) {
+		queryJob.queryID = "mock-resolved-query-id-456"
+		return nil, 1, nil
+	}
+	it, err := queryJob.read(context.Background(), waitForQueryWithID, pf.fetchPage)
+	if err != nil {
+		t.Fatalf("err calling Read: %v", err)
+	}
+	if got := it.QueryID(); got != "mock-resolved-query-id-456" {
+		t.Errorf("it.QueryID() = %q, want %q", got, "mock-resolved-query-id-456")
+	}
+}


### PR DESCRIPTION
Seems like this is a legit bug in the client library where we did not plumb the query ID to the read acceleration path on queries that require polling to complete.

Here is Gemini's report:

# Bug Report: Empty QueryID Flake in TestIntegration_StorageReadQueryMorePages

## What Failed
The integration test `TestIntegration_StorageReadQueryMorePages` flakily failed with the following error:
```
storage_integration_test.go:429: expected non-empty QueryID for jobs.query storage read
```

## Root Cause Analysis
1. When `query.go:Read` submits a query, it attempts the fast path.
2. If the query completes within the fast path timeout (e.g. 10 seconds), `resp.JobComplete` is true. If the query is more than one page and Storage Read API is available, it returns a Storage Row Iterator and sets its `queryID` from `resp.QueryId`.
3. However, under heavier load or larger query execution times, the query does not finish within the initial fast path timeout, resulting in `resp.JobComplete` being false.
4. When `resp.JobComplete` is false, the fast path falls back to the job-polling mechanism via `minimalJob.Read(ctx)`.
5. `Job.Read` polls until complete and initializes the Storage Row Iterator, but it **never set/propagated the `queryID` field** (either on the standard iterator's `rowSource` or the Storage API's `it.src.queryID`). Thus, `it.QueryID()` returned `""`, causing the assertion to fail.

## Fix Implemented
1. Added an unexported `queryID string` field to the internal `Job` struct.
2. Updated the fast path fallback construction in `bigquery/query.go` to save `resp.QueryId` in `minimalJob.queryID`.
3. Modified `Job.read` in `bigquery/job.go` to propagate `j.queryID` to the returned iterator's `rowSource` or `it.src.queryID` depending on the selected execution path (standard or Storage API).
4. Fixed a replay test configuration incompatibility in `bigquery/integration_test.go` by removing the incorrect `option.WithHTTPClient` option from the gRPC-based `connectionsClient` instantiation, which previously prevented proper local/replay initializations.

Fixes #20435 